### PR TITLE
[codex] Add agent operability runbook and profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# Agent Runbook
+
+This repo is a public sample accelerator for Azure AI Search / Foundry IQ live Knowledge Sources. Use this file as the first stop when a coding agent is asked to inspect, run, validate, or modify the repo.
+
+## Default Path
+
+Use the safest path that matches the user's tenant state:
+
+```text
+offline -> mcp-only -> byo-fabric
+```
+
+- Start with offline replay unless the user explicitly asks for live Azure resources.
+- Use `mcp-only` for the fastest live validation without Fabric.
+- Use `byo-fabric` only when the user already has a Fabric workspace ID and ontology ID.
+- Treat `full` as a maintainer or greenfield demo path. It can create Fabric capacity and sample Fabric assets.
+
+## First Commands
+
+Inspect offline traces with no cloud resources:
+
+```bash
+python3 samples/python/inspect_retrieve_response.py samples/responses/mcp-retrieve.sample.json
+python3 samples/python/inspect_retrieve_response.py samples/responses/fabric-airline-ops-retrieve.sample.json
+python3 samples/python/inspect_retrieve_response.py samples/responses/combined-airline-ops-retrieve.sample.json
+```
+
+Run the local validation gate:
+
+```bash
+bash scripts/validate-local.sh
+```
+
+Run agent-readable preflight:
+
+```bash
+python3 tools/doctor.py --format json
+python3 tools/validate.py --profile offline --format json
+```
+
+## Profile Entry Points
+
+- `profiles/offline.yaml`: learn the retrieve contract without Azure, Fabric, or tenant access.
+- `profiles/mcp-only.yaml`: deploy and validate MCP Server Knowledge Source only.
+- `profiles/byo-fabric.yaml`: connect an existing Fabric ontology to Azure AI Search.
+- `profiles/semantic-join.yaml`: inspect combined MCP + Fabric trace behavior.
+
+Use mode-specific env examples under `env/` when creating ignored local env files. Keep `.env.sample` as the full variable catalog.
+
+## Public Sample Boundaries
+
+Do not add or publish:
+
+- internal Fabric ontology authoring steps,
+- private preview instructions,
+- tenant allowlisting processes,
+- internal endpoints,
+- real workspace IDs, ontology IDs, tenant IDs, tokens, API keys, customer data, raw live responses, or screenshots with sensitive values,
+- Fabric MCP through MCP Server KS as the recommended path.
+
+This repo can connect to an existing Fabric ontology. It should not teach private or internal Fabric ontology authoring flows.
+
+## Source Of Truth
+
+Azure AI Search Knowledge Source APIs are in public preview. Keep official Microsoft Learn docs as the source of truth for API behavior:
+
+- Create an MCP Server knowledge source
+- Create a Fabric Ontology knowledge source
+- Create a knowledge base
+- Query a knowledge base
+
+When behavior differs between offline replay and live retrieval, state that offline replay only demonstrates trace shape.
+
+## Safe Output Rules
+
+- Generated logs, reports, env files, screenshots, and deployment summaries stay in ignored paths.
+- Do not paste raw access tokens into issues, PRs, docs, screenshots, or final answers.
+- Do not print full live retrieve responses if they may contain tenant-specific values.
+- Prefer sanitized counts, status, and source names over raw payloads in public-facing summaries.
+
+## Validation Expectations
+
+Before proposing a public PR, run:
+
+```bash
+python3 tools/validate.py --profile offline --format json
+bash scripts/validate-local.sh
+```
+
+For live deployment claims, use the matching deployment or E2E flow and summarize only sanitized evidence.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ One Knowledge Base can route a query to live MCP tools and governed Fabric seman
 
 **🎬 See it in action** — a ~5 min walkthrough from `git clone` to a verified deployment (`clone → local mock → test → deploy → verify → cleanup`), with real footage of the demo app and an executed notebook (offline / dry-run — no secrets on screen).
 
-[![Watch the full walkthrough — KO & EN](https://img.shields.io/badge/%E2%96%B6_Watch_the_full_walkthrough-KO_%26_EN-d29922?style=for-the-badge)](../../releases/tag/walkthrough-v1)
+[![Watch the full walkthrough — KO & EN](https://img.shields.io/badge/%E2%96%B6_Watch_the_full_walkthrough-KO_%26_EN-d29922?style=for-the-badge)](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/releases/tag/walkthrough-v1)
 
-⬇ Download the full video: [English (5 min)](../../releases/download/walkthrough-v1/repo-quickstart-guide-en.mp4) · [한국어 (5분)](../../releases/download/walkthrough-v1/repo-quickstart-guide.mp4) &nbsp;·&nbsp; [chapters &amp; how to rebuild](video-guide/README.md)
+⬇ Download the full video: [English (5 min)](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/releases/download/walkthrough-v1/repo-quickstart-guide-en.mp4) · [한국어 (5분)](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/releases/download/walkthrough-v1/repo-quickstart-guide.mp4) &nbsp;·&nbsp; [chapters &amp; how to rebuild](video-guide/README.md)
 
 ## What This Is
 
@@ -126,6 +126,7 @@ Generated deployment logs and reports stay under ignored paths such as `.deploym
 | Run the one-command deployment | [One-Command Demo Deployment](docs/10-one-command-deployment.md) |
 | Connect existing Fabric assets | [Fabric Live BYO Validation](docs/11-fabric-live-byo-validation.md) |
 | Inspect offline traces | [Offline Replay](docs/09-offline-replay.md) |
+| Review repo and agent boundaries | [Repo Boundaries](docs/12-repo-boundaries.md) |
 | Troubleshoot setup and retrieve issues | [Troubleshooting](docs/07-troubleshooting.md) |
 | Check common questions | [FAQ](docs/19-faq.md) |
 | Review preview caveats | [Public Preview Limitations](docs/13-public-preview-limitations.md) |
@@ -163,6 +164,13 @@ bash scripts/validate-local.sh
 ```
 
 The gate checks shell syntax, Python compile, Python contract tests, notebook JSON, Markdown links, sample hygiene, payload generation, offline responses, no-secret scan, Static Web Apps build, and Bicep build when Azure CLI is available.
+
+For agent-readable preflight, run:
+
+```bash
+python3 tools/doctor.py --format json
+python3 tools/validate.py --profile offline --format json
+```
 
 ## Security Notes
 

--- a/docs/12-repo-boundaries.md
+++ b/docs/12-repo-boundaries.md
@@ -1,0 +1,43 @@
+# Repo Boundaries
+
+This repo is a public sample accelerator for Azure AI Search / Foundry IQ live Knowledge Sources. It is not a production reference architecture and it is not a Fabric ontology authoring guide.
+
+## In Scope
+
+- Synthetic Airline Operations sample data.
+- Offline retrieve responses that demonstrate the trace contract.
+- MCP Server Knowledge Source payloads and walkthroughs.
+- BYO Fabric Ontology Knowledge Source validation.
+- Combined Knowledge Base routing examples.
+- Deployment automation for Azure AI Search, Azure OpenAI, app hosting, and sample Knowledge Source assets.
+- Public-preview caveats and validation guidance.
+
+## Out Of Scope
+
+- Internal Fabric ontology authoring steps.
+- Private preview setup, allowlisting, or unpublished tenant instructions.
+- Customer data, real tenant IDs, real workspace IDs, real ontology IDs, API keys, bearer tokens, raw live responses, or screenshots with sensitive values.
+- Recommending Fabric MCP through MCP Server Knowledge Source as the primary path. Use native Fabric Ontology Knowledge Source for the Fabric path.
+- Production hardening claims that are not backed by explicit evidence.
+
+## Agent Rules
+
+- Start with offline replay unless the user asks for live resources.
+- Prefer `mcp-only` before Fabric paths.
+- Use `byo-fabric` only when existing Fabric workspace and ontology IDs are available.
+- Treat `full` as maintainer/demo-oriented because it can create Fabric capacity and sample Fabric assets.
+- Keep generated reports and logs in ignored paths.
+- Summarize live evidence with sanitized status and counts, not raw tenant payloads.
+
+## Evidence Standards
+
+Use the right evidence for the claim:
+
+- Repo shape: `bash scripts/validate-local.sh`
+- Offline trace shape: `samples/responses/*.sample.json`
+- Route expectations: `evals/expected_routes.yaml`
+- Live MCP path: `mcp-only` deployment or E2E evidence
+- Live Fabric path: `byo-fabric` deployment or E2E evidence with delegated source authorization
+- Greenfield demo path: `full` mode evidence plus cleanup evidence
+
+Offline replay is useful learning evidence. It is not proof of live Fabric retrieval.

--- a/env/byo-fabric.env.example
+++ b/env/byo-fabric.env.example
@@ -1,0 +1,27 @@
+# BYO Fabric profile
+# Copy to an ignored file such as .env.external.local before editing.
+
+DEPLOYMENT_MODE=byo-fabric
+
+# External tenant helper. Use zero GUID placeholders in committed examples only.
+EXTERNAL_TENANT_ID=00000000-0000-0000-0000-000000000000
+EXTERNAL_AZURE_CONFIG_DIR=~/.azure-foundry-iq-ext
+
+# Existing Fabric assets. Do not commit real values.
+FABRIC_WORKSPACE_ID=00000000-0000-0000-0000-000000000000
+FABRIC_ONTOLOGY_ID=00000000-0000-0000-0000-000000000001
+FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME=fabric-ontology-ks
+
+# Optional live retrieve token. Keep raw tokens only in ignored local files or transient UI input.
+FABRIC_USER_SEARCH_TOKEN=<optional-raw-delegated-token>
+
+# MCP Server Knowledge Source still participates in the combined KB.
+MCP_KNOWLEDGE_SOURCE_NAME=microsoft-learn-mcp-ks
+MCP_SERVER_URL=https://learn.microsoft.com/api/mcp
+MCP_TOOL_NAME=microsoft_docs_search
+
+SEARCH_API_VERSION=2026-05-01-preview
+KNOWLEDGE_BASE_NAME=live-knowledge-sources-kb
+MCP_ONLY_KNOWLEDGE_BASE_NAME=live-knowledge-sources-mcp-kb
+NEXT_TELEMETRY_DISABLED=1
+RUN_LIVE_CALLS=false

--- a/env/mcp-only.env.example
+++ b/env/mcp-only.env.example
@@ -1,0 +1,23 @@
+# MCP-only profile
+# Copy to an ignored file such as .env.mcp.local before editing.
+
+DEPLOYMENT_MODE=mcp-only
+
+# MCP Server Knowledge Source
+MCP_KNOWLEDGE_SOURCE_NAME=microsoft-learn-mcp-ks
+MCP_SERVER_URL=https://learn.microsoft.com/api/mcp
+MCP_TOOL_NAME=microsoft_docs_search
+
+# Knowledge base names
+MCP_ONLY_KNOWLEDGE_BASE_NAME=live-knowledge-sources-mcp-kb
+KNOWLEDGE_BASE_NAME=live-knowledge-sources-kb
+
+# Optional local REST testing values. Do not commit real keys.
+SEARCH_API_VERSION=2026-05-01-preview
+AZURE_OPENAI_ENDPOINT=https://<azure-openai-or-foundry-resource>.openai.azure.com
+AZURE_OPENAI_DEPLOYMENT_ID=<chat-completions-deployment-name>
+AZURE_OPENAI_MODEL_NAME=<model-name>
+AZURE_OPENAI_API_KEY=<optional-azure-openai-api-key-for-local-rest-testing>
+
+NEXT_TELEMETRY_DISABLED=1
+RUN_LIVE_CALLS=false

--- a/env/offline.env.example
+++ b/env/offline.env.example
@@ -1,0 +1,6 @@
+# Offline profile
+# Copy only if you need a local env file for notebooks or scripts.
+# Offline replay does not require Azure, Fabric, Search, or model credentials.
+
+RUN_LIVE_CALLS=false
+NEXT_TELEMETRY_DISABLED=1

--- a/evals/expected_routes.yaml
+++ b/evals/expected_routes.yaml
@@ -1,23 +1,42 @@
 - query: "Find Microsoft Learn guidance for Azure AI Search knowledge sources."
   expected_knowledge_source: "microsoft-learn-mcp-ks"
   expected_tool: "microsoft_docs_search"
+  expected_activity_source: "mcpServer"
+  expected_min_references: 1
+  expected_min_source_data_references: 1
 
 - query: "Use the governed ontology to summarize relevant business entities and relationships."
   expected_knowledge_source: "fabric-ontology-ks"
   expected_reference_source_data: true
+  expected_activity_source: "fabricOntology"
+  expected_min_references: 1
+  expected_min_source_data_references: 1
 
 - query: "Which airlines have the highest customer-care exposure this month?"
   expected_knowledge_source: "fabric-ontology-ks"
   expected_reference_source_data: true
   expected_answer_hint: "Alpine Air"
+  expected_activity_source: "fabricOntology"
+  expected_min_references: 1
+  expected_min_source_data_references: 1
+  expected_source_data_rows: 5
 
 - query: "Using the Airline Ops ontology, identify the airline with the highest customer-care exposure this month. Also cite Microsoft Learn guidance for how I should validate activity, references, and sourceData in the Knowledge Base retrieve response."
   expected_knowledge_sources:
     - "fabric-ontology-ks"
     - "microsoft-learn-mcp-ks"
   expected_reference_source_data: true
+  expected_activity_sources:
+    - "fabricOntology"
+    - "mcpServer"
+  expected_min_references: 2
+  expected_min_source_data_references: 2
+  expected_source_data_rows: 5
 
 - query: "Which passenger-care policies or regulation topics explain the risk for the highest-exposure airline?"
   expected_knowledge_source: "fabric-ontology-ks"
   expected_answer_hint: "delay category"
   expected_reference_source_data: true
+  expected_activity_source: "fabricOntology"
+  expected_min_references: 1
+  expected_min_source_data_references: 1

--- a/profiles/byo-fabric.yaml
+++ b/profiles/byo-fabric.yaml
@@ -1,0 +1,33 @@
+profile: byo-fabric
+purpose: Connect an existing Fabric ontology to Azure AI Search and validate live Fabric Ontology Knowledge Source behavior.
+default: false
+required_tools:
+  - bash
+  - python3
+  - azd
+  - az
+  - node
+  - npm
+required_env:
+  - FABRIC_WORKSPACE_ID
+  - FABRIC_ONTOLOGY_ID
+optional_env:
+  - DEPLOYMENT_MODE
+  - EXTERNAL_TENANT_ID
+  - EXTERNAL_AZURE_CONFIG_DIR
+  - FABRIC_USER_SEARCH_TOKEN
+  - MCP_KNOWLEDGE_SOURCE_NAME
+  - FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME
+commands:
+  - bash scripts/deploy.sh --mode byo-fabric --env-file .env.external.local --env-name liveks-byo --location eastus
+  - bash scripts/e2e-test.sh --mode byo-fabric --env-file .env.external.local --env-name liveks-byo-e2e --location eastus --cleanup
+success_criteria:
+  - Fabric Ontology Knowledge Source is created from provided workspace and ontology IDs.
+  - Combined Knowledge Base references MCP and Fabric sources.
+  - Live Fabric retrieve works only when delegated source authorization is provided.
+forbidden_outputs:
+  - Do not commit Fabric workspace IDs, ontology IDs, tenant IDs, or source authorization tokens.
+  - Do not document internal Fabric ontology authoring steps.
+  - Do not publish raw live retrieve responses from tenant runs.
+cleanup:
+  - bash scripts/destroy.sh --env-file .env.external.local --env-name liveks-byo --yes

--- a/profiles/mcp-only.yaml
+++ b/profiles/mcp-only.yaml
@@ -1,0 +1,31 @@
+profile: mcp-only
+purpose: Deploy the fastest live Azure AI Search MCP Server Knowledge Source validation path without Fabric dependencies.
+default: false
+required_tools:
+  - bash
+  - python3
+  - azd
+  - az
+  - node
+  - npm
+required_env: []
+optional_env:
+  - DEPLOYMENT_MODE
+  - MCP_KNOWLEDGE_SOURCE_NAME
+  - MCP_SERVER_URL
+  - MCP_TOOL_NAME
+  - AZURE_OPENAI_ENDPOINT
+  - AZURE_OPENAI_DEPLOYMENT_ID
+  - AZURE_OPENAI_MODEL_NAME
+commands:
+  - bash scripts/deploy.sh --mode mcp-only --env-name liveks-mcp --location eastus
+  - bash scripts/e2e-test.sh --mode mcp-only --env-name liveks-mcp-e2e --location eastus --cleanup
+success_criteria:
+  - MCP Server Knowledge Source is created.
+  - MCP-only Knowledge Base retrieve returns mcpServer activity or references.
+  - Demo app loads without exposing Search admin keys or Azure OpenAI keys in browser code.
+forbidden_outputs:
+  - Do not commit generated deployment summaries or logs.
+  - Do not publish Search endpoints or resource names from private runs unless sanitized.
+cleanup:
+  - bash scripts/destroy.sh --env-name liveks-mcp --yes

--- a/profiles/offline.yaml
+++ b/profiles/offline.yaml
@@ -1,0 +1,21 @@
+profile: offline
+purpose: Inspect checked-in retrieve responses without Azure resources, tenant access, or live MCP/Fabric calls.
+default: true
+required_tools:
+  - python3
+required_env: []
+optional_env:
+  - RUN_LIVE_CALLS
+commands:
+  - python3 samples/python/inspect_retrieve_response.py samples/responses/mcp-retrieve.sample.json
+  - python3 samples/python/inspect_retrieve_response.py samples/responses/fabric-airline-ops-retrieve.sample.json
+  - python3 samples/python/inspect_retrieve_response.py samples/responses/combined-airline-ops-retrieve.sample.json
+success_criteria:
+  - MCP sample shows mcpServer activity and sourceData.
+  - Fabric sample shows fabricOntology activity and sourceData.
+  - Combined sample shows both Fabric and MCP evidence.
+forbidden_outputs:
+  - Do not treat offline replay as proof of live Fabric retrieval.
+  - Do not replace synthetic samples with tenant or customer data.
+cleanup:
+  - No cleanup required.

--- a/profiles/semantic-join.yaml
+++ b/profiles/semantic-join.yaml
@@ -1,0 +1,22 @@
+profile: semantic-join
+purpose: Validate the walkthrough story where Fabric Ontology KS supplies governed operational data and MCP Server KS supplies implementation guidance.
+default: false
+required_tools:
+  - python3
+required_env: []
+optional_env:
+  - FABRIC_WORKSPACE_ID
+  - FABRIC_ONTOLOGY_ID
+  - FABRIC_USER_SEARCH_TOKEN
+commands:
+  - python3 samples/python/inspect_retrieve_response.py samples/responses/combined-airline-ops-retrieve.sample.json
+  - python3 tools/validate.py --profile semantic-join --format json
+success_criteria:
+  - Combined offline trace includes Fabric and MCP Knowledge Source names.
+  - Fabric sourceData includes Airline Ops customer-care exposure rows.
+  - MCP sourceData includes Microsoft Learn-style guidance evidence.
+forbidden_outputs:
+  - Do not claim deterministic live multi-source routing from offline replay alone.
+  - Do not make the whole repo look like an airline-only sample.
+cleanup:
+  - No cleanup required for offline semantic join inspection.

--- a/scripts/validate-local.sh
+++ b/scripts/validate-local.sh
@@ -151,6 +151,8 @@ run_required "Python compile" \
     scripts/check-sample-hygiene.py \
     scripts/maintainers/summarize-e2e-evidence.py \
     scripts/maintainers/extract-review-evidence.py \
+    tools/validate.py \
+    tools/doctor.py \
     samples/python/build_payloads.py \
     samples/python/inspect_retrieve_response.py
 

--- a/tests/test_expected_routes.py
+++ b/tests/test_expected_routes.py
@@ -29,6 +29,8 @@ def parse_scalar(value):
     value = value.strip()
     if value in {"true", "false"}:
         return value == "true"
+    if value.isdigit():
+        return int(value)
     if len(value) >= 2 and value[0] == value[-1] == '"':
         return value[1:-1]
     return value
@@ -93,6 +95,26 @@ def stringify_source_data(response):
     return "\n".join(parts)
 
 
+def count_source_data_references(response):
+    return sum(1 for reference in response.get("references", []) if "sourceData" in reference)
+
+
+def count_fabric_source_data_rows(response):
+    row_count = 0
+    for reference in response.get("references", []):
+        source_data = reference.get("sourceData")
+        if not isinstance(source_data, dict):
+            continue
+
+        raw_data = source_data.get("fabricRawData")
+        if isinstance(raw_data, str):
+            lines = [line for line in raw_data.splitlines() if line.strip()]
+            row_count += max(0, len(lines) - 1)
+        elif isinstance(raw_data, list):
+            row_count += len(raw_data)
+    return row_count
+
+
 class ExpectedRoutesContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -138,6 +160,29 @@ class ExpectedRoutesContractTests(unittest.TestCase):
 
                 if route.get("expected_reference_source_data"):
                     self.assertTrue(any("sourceData" in item for item in references))
+
+                expected_activity_source = route.get("expected_activity_source")
+                if expected_activity_source:
+                    activity_types = {item.get("type") for item in activity}
+                    self.assertIn(expected_activity_source, activity_types)
+
+                expected_activity_sources = route.get("expected_activity_sources")
+                if expected_activity_sources:
+                    activity_types = {item.get("type") for item in activity}
+                    for activity_source in expected_activity_sources:
+                        self.assertIn(activity_source, activity_types)
+
+                expected_min_references = route.get("expected_min_references")
+                if expected_min_references is not None:
+                    self.assertGreaterEqual(len(references), expected_min_references)
+
+                expected_min_source_data_references = route.get("expected_min_source_data_references")
+                if expected_min_source_data_references is not None:
+                    self.assertGreaterEqual(count_source_data_references(response), expected_min_source_data_references)
+
+                expected_source_data_rows = route.get("expected_source_data_rows")
+                if expected_source_data_rows is not None:
+                    self.assertEqual(count_fabric_source_data_rows(response), expected_source_data_rows)
 
                 expected_hint = route.get("expected_answer_hint")
                 if expected_hint:

--- a/tools/doctor.py
+++ b/tools/doctor.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Summarize which repo profiles are ready in the current environment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import validate as profile_validate
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Report runnable profiles for the current checkout.")
+    parser.add_argument("--env-file", type=Path)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args()
+
+    reports = [
+        profile_validate.check_profile(profile, args.env_file)
+        for profile in sorted(profile_validate.PROFILES)
+    ]
+    ready = [report["profile"] for report in reports if report["status"] == "pass"]
+    blocked = [report["profile"] for report in reports if report["status"] != "pass"]
+    output = {
+        "status": "pass" if ready else "fail",
+        "ready_profiles": ready,
+        "blocked_profiles": blocked,
+        "profiles": reports,
+    }
+
+    if args.format == "json":
+        print(json.dumps(output, indent=2, sort_keys=True))
+    else:
+        print("Ready profiles: " + (", ".join(ready) if ready else "none"))
+        print("Blocked profiles: " + (", ".join(blocked) if blocked else "none"))
+        for report in reports:
+            print()
+            print(profile_validate.render_text(report))
+
+    return 0 if ready else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Machine-readable profile validation for agents and maintainers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+PROFILES: dict[str, dict[str, Any]] = {
+    "offline": {
+        "required_tools": ["python3"],
+        "required_env": [],
+        "next_safe_step": "Run the offline response inspector against samples/responses/*.sample.json.",
+    },
+    "mcp-only": {
+        "required_tools": ["bash", "python3", "azd", "az", "node", "npm"],
+        "required_env": [],
+        "next_safe_step": "Run bash scripts/deploy.sh --mode mcp-only --env-name liveks-mcp --location eastus.",
+    },
+    "byo-fabric": {
+        "required_tools": ["bash", "python3", "azd", "az", "node", "npm"],
+        "required_env": ["FABRIC_WORKSPACE_ID", "FABRIC_ONTOLOGY_ID"],
+        "next_safe_step": "Fill an ignored env file from env/byo-fabric.env.example, then run the byo-fabric deploy wrapper.",
+    },
+    "semantic-join": {
+        "required_tools": ["python3"],
+        "required_env": [],
+        "next_safe_step": "Inspect samples/responses/combined-airline-ops-retrieve.sample.json.",
+    },
+}
+
+FORBIDDEN_TRACKED_PREFIXES = (
+    ".deployment/",
+    "deployments/",
+    "scratch/",
+    "_scratch/",
+    "spec/",
+    "specs/",
+    "_spec/",
+    "_specs/",
+    "planning/",
+    "_planning/",
+    "worklog/",
+    "worklogs/",
+    "_worklog/",
+    "_worklogs/",
+)
+
+FORBIDDEN_TRACKED_NAMES = {
+    ".env",
+    ".env.external.local",
+    "deployment-summary.md",
+}
+
+ZERO_GUID_RE = re.compile(r"^0{8}-0{4}-0{4}-0{4}-0{11}[0-9a-fA-F]$")
+
+
+def repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def parse_env_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def effective_env(env_file: Path | None) -> dict[str, str]:
+    values = dict(os.environ)
+    if env_file:
+        values.update(parse_env_file(env_file))
+    return values
+
+
+def is_placeholder(value: str) -> bool:
+    if not value:
+        return True
+    if value.startswith("<") and value.endswith(">"):
+        return True
+    if ZERO_GUID_RE.fullmatch(value):
+        return True
+    return False
+
+
+def git_ls_files(root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def forbidden_tracked_files(root: Path) -> list[str]:
+    failures: list[str] = []
+    for file_path in git_ls_files(root):
+        path = Path(file_path)
+        if file_path in FORBIDDEN_TRACKED_NAMES or path.name in FORBIDDEN_TRACKED_NAMES:
+            failures.append(file_path)
+        elif any(file_path.startswith(prefix) for prefix in FORBIDDEN_TRACKED_PREFIXES):
+            failures.append(file_path)
+    return sorted(set(failures))
+
+
+def check_profile(profile: str, env_file: Path | None = None) -> dict[str, Any]:
+    root = repo_root()
+    config = PROFILES[profile]
+    env = effective_env(env_file)
+
+    missing_tools = [tool for tool in config["required_tools"] if shutil.which(tool) is None]
+    missing_env = [
+        key
+        for key in config["required_env"]
+        if is_placeholder(env.get(key, ""))
+    ]
+    forbidden_files = forbidden_tracked_files(root)
+
+    checks = [
+        {
+            "name": "required_tools",
+            "status": "pass" if not missing_tools else "fail",
+            "missing": missing_tools,
+        },
+        {
+            "name": "required_env",
+            "status": "pass" if not missing_env else "fail",
+            "missing": missing_env,
+        },
+        {
+            "name": "forbidden_tracked_outputs",
+            "status": "pass" if not forbidden_files else "fail",
+            "files": forbidden_files,
+        },
+    ]
+
+    status = "pass" if all(check["status"] == "pass" for check in checks) else "fail"
+    return {
+        "profile": profile,
+        "status": status,
+        "env_file": str(env_file) if env_file else None,
+        "checks": checks,
+        "next_safe_step": config["next_safe_step"],
+    }
+
+
+def run_local_gate(root: Path) -> dict[str, Any]:
+    result = subprocess.run(
+        ["bash", "scripts/validate-local.sh", "--no-color"],
+        cwd=root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return {
+        "name": "validate_local",
+        "status": "pass" if result.returncode == 0 else "fail",
+        "exit_code": result.returncode,
+        "output_tail": result.stdout.splitlines()[-30:],
+    }
+
+
+def render_text(report: dict[str, Any]) -> str:
+    lines = [f"Profile: {report['profile']}", f"Status: {report['status']}"]
+    for check in report["checks"]:
+        lines.append(f"- {check['name']}: {check['status']}")
+        missing = check.get("missing") or check.get("files") or []
+        if missing:
+            lines.append("  " + ", ".join(missing))
+    lines.append(f"Next safe step: {report['next_safe_step']}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate repo agent-operability profile readiness.")
+    parser.add_argument("--profile", choices=sorted(PROFILES), default="offline")
+    parser.add_argument("--env-file", type=Path)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    parser.add_argument("--run-local-gate", action="store_true", help="Also run scripts/validate-local.sh.")
+    args = parser.parse_args()
+
+    if args.env_file and not args.env_file.exists():
+        print(f"Missing env file: {args.env_file}", file=sys.stderr)
+        return 2
+
+    report = check_profile(args.profile, args.env_file)
+    if args.run_local_gate:
+        gate = run_local_gate(repo_root())
+        report["checks"].append(gate)
+        if gate["status"] != "pass":
+            report["status"] = "fail"
+
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/video-guide/README.md
+++ b/video-guide/README.md
@@ -12,17 +12,17 @@ offline / dry-run mode — no secrets on screen).
 The video ships in two languages with identical scene order and timing
 (9085 frames / 303 s each); only the captions, callouts, and labels differ. The
 rendered MP4s are **hosted on GitHub Releases** (tag
-[`walkthrough-v1`](../../releases/tag/walkthrough-v1)) to keep the repository
+[`walkthrough-v1`](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/releases/tag/walkthrough-v1)) to keep the repository
 lean — this folder holds only the source that rebuilds them.
 
 | Language | Final video (release asset) | Per-chapter source |
 | --- | --- | --- |
-| 🇰🇷 Korean  | [`repo-quickstart-guide.mp4`](../../releases/download/walkthrough-v1/repo-quickstart-guide.mp4) | rebuilt from `build_guide_video.py` |
-| 🇬🇧 English | [`repo-quickstart-guide-en.mp4`](../../releases/download/walkthrough-v1/repo-quickstart-guide-en.mp4) | rebuilt from `build_guide_video.py --lang en` |
+| 🇰🇷 Korean  | [`repo-quickstart-guide.mp4`](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/releases/download/walkthrough-v1/repo-quickstart-guide.mp4) | rebuilt from `build_guide_video.py` |
+| 🇬🇧 English | [`repo-quickstart-guide-en.mp4`](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/releases/download/walkthrough-v1/repo-quickstart-guide-en.mp4) | rebuilt from `build_guide_video.py --lang en` |
 
 ## Play it
 
-Download a final video from the [`walkthrough-v1` release](../../releases/tag/walkthrough-v1),
+Download a final video from the [`walkthrough-v1` release](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/releases/tag/walkthrough-v1),
 or rebuild locally (see **Rebuild it** below) and open the result:
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a root `AGENTS.md` runbook so coding agents have a safe first-read execution contract.
- Add machine-readable profiles and mode-specific env examples for offline, MCP-only, BYO Fabric, and semantic-join paths.
- Add JSON-friendly validate/doctor tools and expand expected route checks with activity/reference/sourceData expectations.
- Add public repo boundary guidance and fix release links so local Markdown validation treats them as external URLs.

## Why

This makes the sample easier for a person or coding agent to clone, inspect, run, and validate without guessing which path is safe for the current tenant state.

## Validation

- `python3 -m unittest discover -s tests`
- `bash scripts/no-secret-scan.sh`
- `python3 tools/doctor.py --format json`
- `python3 tools/validate.py --profile offline --format json --run-local-gate`
- `bash scripts/validate-local.sh --no-color` via the JSON validator wrapper
- `git diff --cached --check`

## Notes

- Private planning notes remain under ignored `specs/` and are not included.
- Opened as draft for org review readiness.
