### PR TITLE
Fix: replace deprecated gpt-4o-mini default with supported gpt-5-mini

### DIFF
--- a/docs/maintainers/test-specs/e2e-byo-fabric.md
+++ b/docs/maintainers/test-specs/e2e-byo-fabric.md
@@ -44,7 +44,7 @@ bash scripts/e2e-test.sh \
 
 - Resource group: `rg-ext-liveks-byo-e2e`
 - Azure AI Search
-- Azure OpenAI account and `gpt-4o-mini` deployment
+- Azure OpenAI account and `gpt-5-mini` deployment
 - Storage account
 - Static Web App and managed Functions API
 - Search managed identity with Azure OpenAI access

--- a/docs/maintainers/test-specs/e2e-full-greenfield.md
+++ b/docs/maintainers/test-specs/e2e-full-greenfield.md
@@ -57,7 +57,7 @@ bash scripts/fabric-e2e-test.sh \
 
 - Resource group: `rg-ext-liveks-full-e2e`
 - Azure AI Search
-- Azure OpenAI account and `gpt-4o-mini` deployment
+- Azure OpenAI account and `gpt-5-mini` deployment
 - Storage account
 - Static Web App and managed Functions API
 - F2 Microsoft Fabric capacity when `FABRIC_CAPACITY_MODE=create`

--- a/docs/maintainers/test-specs/e2e-mcp-only.md
+++ b/docs/maintainers/test-specs/e2e-mcp-only.md
@@ -35,7 +35,7 @@ bash scripts/e2e-test.sh \
 
 - Resource group: `rg-ext-liveks-mcp-e2e`
 - Azure AI Search
-- Azure OpenAI account and `gpt-4o-mini` deployment
+- Azure OpenAI account and `gpt-5-mini` deployment
 - Storage account
 - Static Web App and managed Functions API
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -75,13 +75,13 @@ param fabricCapacitySku string = 'F2'
 param fabricCapacityAdmin string = ''
 
 @description('Azure OpenAI chat model deployment name.')
-param chatDeploymentName string = 'gpt-4o-mini'
+param chatDeploymentName string = 'gpt-5-mini'
 
 @description('Azure OpenAI chat model name.')
-param chatModelName string = 'gpt-4o-mini'
+param chatModelName string = 'gpt-5-mini'
 
 @description('Azure OpenAI chat model version.')
-param chatModelVersion string = '2024-07-18'
+param chatModelVersion string = '2025-08-07'
 
 @description('Azure OpenAI deployment capacity.')
 param chatDeploymentCapacity int = 10

--- a/scripts/postprovision.py
+++ b/scripts/postprovision.py
@@ -350,7 +350,7 @@ def main() -> None:
         "AZURE_OPENAI_ENDPOINT": get_setting("AZURE_OPENAI_ENDPOINT", azd_values),
         "AZURE_OPENAI_ACCOUNT_NAME": get_setting("AZURE_OPENAI_ACCOUNT_NAME", azd_values),
         "AZURE_OPENAI_DEPLOYMENT_ID": get_setting("AZURE_OPENAI_DEPLOYMENT_ID", azd_values),
-        "AZURE_OPENAI_MODEL_NAME": get_setting("AZURE_OPENAI_MODEL_NAME", azd_values, "gpt-4o-mini"),
+        "AZURE_OPENAI_MODEL_NAME": get_setting("AZURE_OPENAI_MODEL_NAME", azd_values, "gpt-5-mini"),
         "AZURE_OPENAI_API_KEY": get_setting("AZURE_OPENAI_API_KEY", azd_values),
         "AZURE_STORAGE_ACCOUNT_NAME": get_setting("AZURE_STORAGE_ACCOUNT_NAME", azd_values),
         "AZURE_HOSTING_MODE": get_setting("AZURE_HOSTING_MODE", azd_values, "staticwebapp"),


### PR DESCRIPTION
## Summary

The default Azure OpenAI chat model in `infra/main.bicep` was `gpt-4o-mini` version `2024-07-18`. Azure now rejects **new** deployments of that model version with `ServiceModelDeprecating`, so `azd up` fails at preflight validation before any resources are created. This blocks every deployment mode that provisions Azure OpenAI.

This change updates the default chat model to `gpt-5-mini` (`2025-08-07`):

- `infra/main.bicep`: `chatDeploymentName` / `chatModelName` → `gpt-5-mini`, `chatModelVersion` → `2025-08-07`.
- `scripts/postprovision.py`: fallback default model → `gpt-5-mini`.
- `docs/maintainers/test-specs/{e2e-full-greenfield,e2e-byo-fabric,e2e-mcp-only}.md`: prerequisite model name updated for consistency.

`gpt-5-mini` is on the Azure AI Search agentic-retrieval supported model list (gpt-4o / gpt-4o-mini / gpt-5 / gpt-5-mini / gpt-5-nano) and is available as GlobalStandard, so agentic query planning and answer synthesis continue to work.

## Change Type

- [x] Script or deployment automation
- [ ] Documentation
- [ ] REST sample / payload shape
- [ ] Notebook
- [ ] Demo app
- [ ] Test or validation evidence
- [ ] Other

## Deployment Mode Impact

- [x] `mcp-only`
- [x] `byo-fabric`
- [x] `full`
- [ ] No deployment-mode impact

(The Azure OpenAI chat deployment is provisioned by `azd up` in every live mode, so the deprecation blocked all of them.)

## Validation

- [x] `bash scripts/validate-local.sh`
- [x] `git diff --check`
- [ ] GitHub Actions `Validate` workflow passes
- [x] E2E report reviewed when deployment behavior changed
- [x] Generated reports remain local and ignored
- [ ] Not applicable; docs-only or metadata-only change

If E2E was run, summarize the ignored report path and result:

```text
deployments/<env>/deployment-summary.md   (gitignored)
Result: PASS — full-mode live re-run on gpt-5-mini: provisioning + postprovision
(MCP KS + Fabric Ontology KS + MCP-only KB + Combined KB + Airline Ops index) +
smoke test + live agentic retrieve (query planning + MCP + answer synthesis) all succeeded.
```

## Preview And Security Checklist

- [x] API version remains explicit where preview APIs are used.
- [x] No secrets, bearer tokens, API keys, tenant-specific IDs, customer data, or private endpoint details were added.
- [x] Generated files remain under ignored paths such as `.deployment/`, `deployments/`, or `scratch/`.
- [x] Fabric live claims are backed by live Fabric activity or clearly described as offline replay.
- [x] MCP examples use remote HTTPS MCP servers, not local stdio servers.
- [x] Public-facing claims follow `docs/13-public-preview-limitations.md`.

## Reviewer Notes

- Core change is two default values in `infra/main.bicep` plus the matching fallback in `scripts/postprovision.py`; doc edits are name-consistency only.
- Out of scope (separate concern, not addressed here): azd's built-in `staticwebapp` service deploy passes `--env default`, which the SWA content server now rejects; the repo's `scripts/deploy-static-webapp-api.sh` postdeploy hook already uses `--env production`.
