### PR TITLE
Add post-deployment demo validation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ See [Configuration](docs/21-configuration.md) for precedence, fields, external-t
 ./liveks down --env liveks-mcp
 ```
 
+Before cleanup, open the deployed App URL and run the packaged MCP, Fabric, and Combined queries that apply to the profile. Follow the [Guided Live Demo](docs/16-demo-walkthrough.md) for the exact controls and presenter sequence, and use [Post-Deployment Tests](docs/08-test-queries.md) for expected answers and trace-level pass/fail criteria.
+
 For a complete create, call, verify, and delete rehearsal:
 
 ```bash
@@ -156,6 +158,8 @@ The default app is Azure Static Web Apps with a managed Node.js API. Browser cod
 | Learn the CLI lifecycle | [LiveKS CLI](docs/20-liveks-cli.md) |
 | Author the YAML ledger | [Configuration](docs/21-configuration.md) |
 | Deploy and clean up | [One-Command Deployment](docs/10-one-command-deployment.md) |
+| Test a deployed Knowledge Source | [Post-Deployment Tests](docs/08-test-queries.md) |
+| Present the app click by click | [Guided Live Demo](docs/16-demo-walkthrough.md) |
 | Connect existing Fabric assets | [BYO Fabric Validation](docs/11-fabric-live-byo-validation.md) |
 | Inspect the evidence contract | [Offline Replay](docs/09-offline-replay.md) |
 | Troubleshoot a run | [Troubleshooting](docs/07-troubleshooting.md) |

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -54,12 +54,12 @@ Use this map when you are reviewing the repo or deciding what to read next.
 | Understand combined routing | [Combined Knowledge Base Routing](05-combined-kb-routing.md) |
 | Review security posture | [Security and Governance](06-security-governance.md) |
 | Debug a run | [Troubleshooting](07-troubleshooting.md) |
-| Pick test questions | [Test Queries And Expected Traces](08-test-queries.md) |
+| Test a live deployment | [Post-Deployment Tests And Expected Traces](08-test-queries.md) |
 | Inspect traces without live resources | [Offline Replay](09-offline-replay.md) |
 | Deploy the app and resources | [One-Command Demo Deployment](10-one-command-deployment.md) |
 | Connect existing Fabric assets | [Fabric Live BYO Validation](11-fabric-live-byo-validation.md) |
 | Avoid unsafe preview claims | [Public Preview Limitations and Caveats](13-public-preview-limitations.md) |
-| Run a short demo | [Demo Walkthrough](16-demo-walkthrough.md) |
+| Run a short demo | [Guided Live Demo Walkthrough](16-demo-walkthrough.md) |
 | Answer common setup questions | [FAQ](19-faq.md) |
 
 ## Validation Loop

--- a/docs/08-test-queries.md
+++ b/docs/08-test-queries.md
@@ -1,32 +1,81 @@
-# Test Queries And Expected Traces
+# Post-Deployment Tests And Expected Traces
 
-This guide makes the validation loop explicit:
+Use this guide after `./liveks up` to prove that the deployed app can retrieve from the expected Knowledge Source. A successful deployment is not enough by itself: the answer, response mode, source activity, references, and source data must agree.
+
+## Choose A Test Surface
+
+| Surface | Use it for | What it proves |
+| --- | --- | --- |
+| Deployed demo app | First manual acceptance test and live presentation | A person can run the packaged query and inspect the same evidence shown to an audience. |
+| `./liveks verify` | Repeatable deployment verification | The app and single-source retrieve paths return recognized live evidence. |
+| REST samples | Request and response troubleshooting | The exact Knowledge Base retrieve payload and headers. |
+| Notebooks | Guided experimentation | Payload construction, query changes, and deeper trace inspection. |
+
+Start with the deployed app, then run `./liveks verify`. Use REST or notebooks only when you need to inspect or change the underlying request.
+
+## Live Versus Replay
+
+The app can show canonical offline responses when a live source is unavailable. Those responses are useful for learning the trace shape, but they do not prove that the deployed source was called.
+
+| Screen signal | Meaning | Can it prove a live call? |
+| --- | --- | --- |
+| Answer badge is `live` | The managed API returned an Azure AI Search retrieve response. | Yes, when the expected source also appears in the trace. |
+| Answer badge is `offline` or `offline-replay` | The app used a checked-in response fixture. | No. |
+| Notice says `Canonical sample response` | GitHub Pages or API fallback supplied replay data. | No. |
+| Source badge names a KS but response mode is offline | The fixture demonstrates the expected trace shape. | No. |
+
+!!! warning "Do not validate by answer text alone"
+    Offline replay intentionally returns a useful, realistic answer. Require a `live` badge and expected `activity` or `references` before claiming that a live Knowledge Source worked.
+
+## Open The Deployed App
+
+After deployment, read the generated local summary:
 
 ```text
-Question
-  -> expected Knowledge Source
-  -> expected activity record
-  -> expected references and sourceData
+deployments/<environment>/deployment-summary.md
 ```
 
-Use these queries after creating the Knowledge Source and Knowledge Base resources in `samples/rest/`.
+1. Open the **App URL** from the summary.
+2. Confirm that the top-right status pill says `<deployment-mode> live`.
+3. Select **Deployment**.
+4. Select **Re-check**.
+5. In **Runtime Status**, confirm `reachabilityStatus` is `live`, `reachable` is `true`, and `deploymentMode` matches the profile you deployed.
 
-## MCP Server KS
+The status check proves that the app can reach Azure AI Search. It does not by itself prove MCP or Fabric retrieval, so continue with the source tests below.
 
-Run `samples/rest/03-retrieve-mcp.http` after:
+## Test 1: MCP Server KS
+
+This test applies to all three live profiles.
+
+### Run It In The App
+
+1. Select **MCP Live** in the top navigation.
+2. Select **Run retrieve**.
+3. Wait for the button to change from **Running...** back to **Run retrieve**.
+4. In **Answer**, require the `live` badge.
+5. Require the **MCP Server KS** source badge.
+6. Scroll to **Source Trace** and confirm the activity and reference counts are greater than zero.
+7. Scroll to **Activity** and find `type: "mcpServer"` and `toolName: "microsoft_docs_search"`.
+8. Scroll to **References** and **Source Data** and confirm Microsoft Learn evidence is present.
+
+The app submits this query:
 
 ```text
-samples/rest/01-create-mcp-server-ks.http
-samples/rest/02-create-mcp-only-kb.http
+What must be configured to create an Azure AI Search MCP Server knowledge source?
 ```
+
+Expected answer content includes relevant setup guidance, such as a remote HTTPS MCP endpoint, allowed tools, output parsing, and Knowledge Base attachment. Wording can vary; the trace is the routing proof.
+
+### Additional MCP Questions
+
+Use the REST sample or notebook when you want to replace the packaged app query.
 
 | Test query | Expected source | What to check |
 | --- | --- | --- |
-| What must be configured to create an Azure AI Search MCP Server knowledge source? | `microsoft-learn-mcp-ks` | `activity[*].type == "mcpServer"` and `activity[*].mcpServerArguments.toolName == "microsoft_docs_search"` |
-| How do I inspect activity, references, and sourceData from an Azure AI Search knowledge base retrieve response? | `microsoft-learn-mcp-ks` | `references[*].type == "mcpServer"` and `references[*].sourceData` is present |
-| How can I pass per-request credentials to an MCP Server knowledge source? | `microsoft-learn-mcp-ks` | Answer mentions query-time paired control headers, not storing per-user tokens |
+| How do I inspect activity, references, and sourceData from an Azure AI Search knowledge base retrieve response? | `microsoft-learn-mcp-ks` | `references[*].type == "mcpServer"` and source data is present. |
+| How can I pass per-request credentials to an MCP Server knowledge source? | `microsoft-learn-mcp-ks` | The answer describes paired query-time control headers rather than storing per-user tokens. |
 
-Good MCP trace:
+Good MCP activity contains this shape:
 
 ```json
 {
@@ -38,43 +87,60 @@ Good MCP trace:
 }
 ```
 
-## Fabric Ontology KS
+Automated equivalent:
 
-Run `samples/rest/06-retrieve-fabric-ontology.http` after:
-
-```text
-samples/rest/04-create-fabric-ontology-ks.http
-samples/rest/05-create-combined-kb.http
+```bash
+./liveks verify --env <environment>
 ```
 
-For this repo, map the Airline Ops sample contract first:
+REST equivalent: `samples/rest/03-retrieve-mcp.http`.
 
-```text
-samples/data/airline-ops/
-samples/ontology/airline-ops/ontology-contract.yaml
-docs/fabric-ontology-prerequisites.md
+## Test 2: Fabric Ontology KS
+
+This test applies to `byo-fabric` and `full`. In `mcp-only`, an offline response explaining that Fabric was not created is expected and is not a live Fabric pass.
+
+The packaged app question targets the repo's Airline Ops ontology contract. `full` creates that sample. For `byo-fabric`, the Alpine Air answer is expected only when the connected ontology maps the same sample data and relationships. With another ontology, require live Fabric trace evidence and validate the answer against that ontology's known facts; use the REST sample or Fabric notebook to submit a domain-specific question.
+
+### Acquire Delegated Source Authorization
+
+Live Fabric retrieve needs a raw end-user token scoped to Azure AI Search:
+
+```bash
+az account get-access-token \
+  --resource https://search.azure.com \
+  --query accessToken \
+  --output tsv
 ```
 
-| Test query | Expected source | What to check |
+Run the command in a private terminal and copy only the token value. Do not add a `Bearer` prefix. The app keeps the value only in the current password field, includes it in Fabric and Combined requests, and does not persist it. Refreshing or closing the page clears the value.
+
+### Run It In The App
+
+1. Select **Fabric** in the top navigation.
+2. Paste the raw token into **Fabric Source Authorization**.
+3. Select **Run retrieve** under **Fabric Ontology**.
+4. Wait for the button to return from **Running...** to **Run retrieve**.
+5. In **Answer**, require the `live` badge. An `offline` answer does not pass this test even if it names Alpine Air.
+6. Require the **Fabric Ontology KS** source badge.
+7. For `full` or an Airline Ops BYO ontology, confirm the answer ranks Alpine Air first. For another BYO ontology, validate the answer against its own known facts.
+8. In **Activity**, find `type: "fabricOntology"`.
+9. In **References** or **Source Data**, find `fabricAnswer` and `fabricRawData`.
+
+The app submits this query:
+
+```text
+Which airlines have the highest customer-care exposure this month?
+```
+
+### Additional Fabric Questions
+
+| Test query | Expected result | What it validates |
 | --- | --- | --- |
-| Which airlines have the highest customer-care exposure this month? | `fabric-ontology-ks` | `activity[*].type == "fabricOntology"` and Alpine Air appears first |
-| Which routes have the most delayed flights over 15 minutes? | `fabric-ontology-ks` | The answer joins Route and Flight, and delayed flights over 15 minutes total 10 |
-| Which delay categories are controllable and driving customer-care exposure? | `fabric-ontology-ks` | `references[*].sourceData.fabricAnswer` and `references[*].sourceData.fabricRawData` are present |
-| Which passenger-care policies or regulation topics explain the risk for the highest-exposure airline? | `fabric-ontology-ks` | The answer joins through delay category and trigger condition rather than airline-name matching |
+| Which routes have the most delayed flights over 15 minutes? | Delayed flights over 15 minutes total 10. | Route and Flight relationships are traversable. |
+| Which delay categories are controllable and driving customer-care exposure? | Controllable categories and exposure evidence are returned. | DelayEvent category and exposure semantics are mapped. |
+| Which passenger-care policies or regulation topics explain the risk for the highest-exposure airline? | Policy evidence is joined through category, trigger, and scope. | The answer uses ontology relationships rather than airline-name matching. |
 
-Good Fabric trace:
-
-```json
-{
-  "type": "fabricOntology",
-  "knowledgeSourceName": "fabric-ontology-ks",
-  "fabricOntologyArguments": {
-    "search": "<natural-language ontology query>"
-  }
-}
-```
-
-Good Fabric reference:
+Good Fabric evidence contains this shape:
 
 ```json
 {
@@ -86,42 +152,71 @@ Good Fabric reference:
 }
 ```
 
-## Combined KB Routing
-
-Run `samples/rest/05-create-combined-kb.http` after both Knowledge Sources exist.
-
-| Test query | Expected source behavior | What to check |
-| --- | --- | --- |
-| What must be configured to connect a remote MCP server as a Knowledge Source? | MCP should provide the answer | `activity` contains an `mcpServer` call with `count > 0`; other sources can appear with `count == 0` |
-| Which airlines have the highest customer-care exposure this month? | Fabric should provide the answer | `activity` contains `fabricOntology`; use a Fabric-only KB if you need deterministic source isolation |
-| Using the Airline Ops ontology, identify the airline with the highest customer-care exposure this month. Also cite Microsoft Learn guidance for how I should validate activity, references, and sourceData in the Knowledge Base retrieve response. | Mixed or source-selected | Confirm whether one or both sources were selected; do not assume both will always be called |
-
-When routing does not match your expectation, improve:
-
-- Knowledge Source descriptions
-- `retrievalInstructions`
-- the query wording
-- separate single-source Knowledge Bases for controlled tests
-
-`knowledgeSourceParams` configures runtime options for a source, but it isn't a strict allow-list in combined Knowledge Bases. During live validation, MCP Server KS rejected `alwaysQuerySource`, so use a single-source KB when you need deterministic MCP-only or Fabric-only behavior.
-
-## Offline Replay
-
-Use the checked-in responses to validate trace inspection without live keys:
+Automated equivalent:
 
 ```bash
-./liveks try --sample mcp --details
-./liveks try --sample fabric --details
-./liveks try --sample combined --details
+./liveks verify --env <environment>
 ```
+
+REST equivalent: `samples/rest/06-retrieve-fabric-ontology.http`.
+
+## Test 3: Combined Knowledge Base
+
+Run the MCP and Fabric single-source tests first. They prove each source independently; the combined Knowledge Base planner can select one or both sources for an individual question.
+
+The packaged combined question also assumes Airline Ops semantics. For a non-Airline Ops BYO ontology, use the REST sample or notebook to replace the business half of the question before evaluating answer quality.
+
+### Run It In The App
+
+1. Complete the Fabric test and leave the token in the **Fabric Source Authorization** field.
+2. Select **Combined Trace** in the top navigation.
+3. Select **Run retrieve**.
+4. Wait for the button to return from **Running...** to **Run retrieve**.
+5. In **Answer**, require the `live` badge.
+6. Read the answer and identify the business conclusion and any implementation guidance it returned.
+7. Inspect the source badges and **Activity** to see whether the planner selected Fabric, MCP, or both.
+8. Match each claim to its corresponding **References** and **Source Data** entry.
+
+The app submits this query:
+
+```text
+Using the Airline Ops ontology, identify the airline with the highest customer-care exposure this month. Also cite Microsoft Learn guidance for how I should validate activity, references, and sourceData in the Knowledge Base retrieve response.
+```
+
+Expected interpretation:
+
+- Fabric Ontology KS can provide the airline ranking and exposure evidence.
+- MCP Server KS can provide Azure AI Search implementation guidance.
+- One or both sources can appear because planner routing is dynamic.
+- A two-source offline replay demonstrates the ideal trace shape, not a live two-source call.
+
+Do not use source badges alone to claim that both live sources ran. Require `mode: "live"` and inspect the corresponding activity and references.
+
+REST equivalent: `samples/rest/08-retrieve-combined-airline-ops.http`.
+
+## What Each Result Lets You Claim
+
+| Observed evidence | Supported claim |
+| --- | --- |
+| MCP test is live and identifies `microsoft_docs_search` | Azure AI Search called the Microsoft Learn MCP tool during retrieve. |
+| Fabric test is live and returns Fabric source data | Azure AI Search grounded retrieval in the configured Fabric ontology with delegated source authorization. |
+| Both single-source tests pass | Both live Knowledge Source paths are independently operational. |
+| Combined test is live and its trace contains both source types | This retrieve call used both grounding paths. |
+| Combined test is live and contains one source type | Planner routing worked, but this call does not prove that both sources ran. |
+| Any result is offline or offline-replay | Only the packaged response shape and inspection experience are demonstrated. |
 
 ## Pass/Fail Checklist
 
-Treat a test as passing only when all are true:
+Treat a live acceptance test as passing only when all applicable checks are true:
 
-- The answer is useful.
-- The expected source appears in `activity`.
-- References are returned when `includeReferences` is true.
-- Source data is returned when `includeReferenceSourceData` is true.
-- Authentication behavior is understood and repeatable.
-- No customer, tenant, or secret values are saved into tracked sample responses.
+- [ ] The app status is live and the deployment mode is correct.
+- [ ] The Answer badge is `live`, not `offline` or `offline-replay`.
+- [ ] The answer is useful for the submitted question.
+- [ ] The expected source appears in `activity` or `references`.
+- [ ] References are returned.
+- [ ] Source data is returned for the evidence being discussed.
+- [ ] Fabric tests use delegated source authorization.
+- [ ] Combined routing is described from the observed trace rather than assumed.
+- [ ] No token, tenant value, endpoint, or raw live response is copied into tracked files.
+
+For the complete presenter sequence, use [Guided Live Demo Walkthrough](16-demo-walkthrough.md). For payload-level experimentation, use the [notebooks](samples/notebooks.md).

--- a/docs/10-one-command-deployment.md
+++ b/docs/10-one-command-deployment.md
@@ -111,6 +111,20 @@ The single-source KB checks prove the MCP and Fabric paths independently. The co
 
 Reports under `deployments/<environment>/` are ignored and must remain private unless sanitized.
 
+### Verify Through The Demo App
+
+`up` and `verify` provide automated evidence. Also test the interface that a workshop participant will use:
+
+1. Open the **App URL** in `deployments/<environment>/deployment-summary.md`.
+2. Select **Deployment** and then **Re-check** to confirm live Search reachability.
+3. Select **MCP Live** and then **Run retrieve**. Require a `live` badge and MCP activity or references.
+4. For a Fabric profile, select **Fabric**, enter a raw delegated Search token, and run retrieve. Require a `live` badge and Fabric evidence.
+5. Select **Combined Trace** only after the single-source paths pass, then describe the planner selection visible in activity and references.
+
+The answer text is not the acceptance criterion. An offline fixture can return the same useful answer, so require a `live` response mode plus the expected source trace.
+
+Continue with [Guided Live Demo Walkthrough](16-demo-walkthrough.md) for every click and presenter cue, or [Post-Deployment Tests](08-test-queries.md) for additional queries and expected trace fields.
+
 ## Demo App
 
 The build has two hosting contexts:

--- a/docs/13-public-preview-limitations.md
+++ b/docs/13-public-preview-limitations.md
@@ -138,4 +138,4 @@ Before sharing outside the working team:
 [ ] Learn manual links and preview API version are current
 ```
 
-For setup and test guidance, see [One-Command Demo Deployment](10-one-command-deployment.md), [Test Queries](08-test-queries.md), and [Troubleshooting](07-troubleshooting.md).
+For setup and test guidance, see [One-Command Demo Deployment](10-one-command-deployment.md), [Post-Deployment Tests](08-test-queries.md), and [Troubleshooting](07-troubleshooting.md).

--- a/docs/16-demo-walkthrough.md
+++ b/docs/16-demo-walkthrough.md
@@ -1,216 +1,349 @@
-# Demo Walkthrough
+# Guided Live Demo Walkthrough
 
-Use this walkthrough when you need to show the repo in a workshop or short live demo.
+This is the click-by-click presenter guide for the deployed demo app. It explains what to open, what to select, what question the app sends, what should appear, and what the result proves.
+
+Use [Post-Deployment Tests And Expected Traces](08-test-queries.md) when you need the complete acceptance criteria or additional test questions.
 
 ![Current demo flow](assets/current-demo-flow.svg)
 
-The goal is to explain the sample through one simple loop:
+## Choose The Demo You Can Prove
 
-```text
-Choose a deployment mode
-  -> Run a retrieve query
-    -> Inspect activity and references
-      -> Decide whether the evidence proves MCP, Fabric, or combined grounding
-```
+| Available environment | Recommended demo | Time | Valid claim |
+| --- | --- | --- | --- |
+| No Azure or Fabric access | GitHub Pages replay | 2 minutes | The packaged response and trace inspection experience. |
+| `mcp-only` deployed | Status plus MCP Live | 3 minutes | A live Microsoft Learn MCP tool call through Knowledge Base retrieve. |
+| `byo-fabric` deployed | MCP, Fabric, then Combined | 7 minutes | Both source paths work independently and the combined planner can route between them. |
+| `full` deployed | Deployment, MCP, Fabric, Combined, cleanup | 10 minutes | Greenfield Fabric assets and the complete Azure/Fabric lifecycle work together. |
 
-## Before You Start
+!!! warning "Match the claim to the badge"
+    A realistic answer with an `offline` or `offline-replay` badge is replay evidence. Only a `live` answer with matching activity or references proves a live source call.
 
-Run the local validation gate:
+## Presenter Preparation
 
-```bash
-bash scripts/validate-local.sh
-```
+### 1. Deploy And Verify
 
-For a live deployment, initialize and plan one profile before running `up`:
+Use the profile that matches the demo:
 
 ```bash
 ./liveks init --profile mcp-only --env liveks-mcp
 ./liveks plan --env liveks-mcp
 ./liveks up --env liveks-mcp
+./liveks verify --env liveks-mcp
 ```
+
+For existing Fabric assets:
 
 ```bash
 ./liveks init --profile byo-fabric --env liveks-byo
 # Add the existing Fabric IDs to .liveks/liveks-byo.yaml.
 ./liveks plan --env liveks-byo
 ./liveks up --env liveks-byo
+./liveks verify --env liveks-byo
 ```
+
+For greenfield Fabric assets:
 
 ```bash
 ./liveks init --profile full --env liveks-full
 ./liveks plan --env liveks-full
 ./liveks up --env liveks-full --accept-fabric-capacity
+./liveks verify --env liveks-full
 ```
 
-Do not use private tenant values, generated deployment reports, or local screenshots in public docs unless they have been sanitized.
+Do not begin a live presentation with a failed `verify` result.
 
-## Three-Minute Demo
+### 2. Find The Correct App
 
-### 1. Start With The Mode Selector
+Open the generated, ignored summary for the environment you just verified:
 
-Open [Live Knowledge Sources Manual](index.md) and show the three paths:
+```text
+deployments/<environment>/deployment-summary.md
+```
 
-| Mode | Message |
+Copy the **App URL** into a private browser window. Do not present the Search endpoint, tenant IDs, resource names, or the summary itself.
+
+The public [interactive trace demo](https://microsoft.github.io/azure-ai-search-foundry-iq-live-knowledge-sources/demo/?demo=combined) is GitHub Pages replay. Use it when you want to explain the UI without a live environment, and call it replay explicitly.
+
+### 3. Prepare Fabric Authorization
+
+Skip this step for `mcp-only`. For `byo-fabric` or `full`, acquire a fresh raw token just before the demo:
+
+```bash
+az account get-access-token \
+  --resource https://search.azure.com \
+  --query accessToken \
+  --output tsv
+```
+
+Keep the value off the shared screen. Do not prepend `Bearer`. The browser sends the token for the request but does not persist it; refreshing or closing the page clears the entered value.
+
+The app uses a fixed Airline Ops question for a repeatable demo. `full` creates the matching sample. Before a `byo-fabric` presentation, confirm that the connected ontology maps the Airline Ops contract; otherwise plan to validate the live Fabric trace in the app and use the Fabric notebook or REST sample for a business question that matches the existing ontology.
+
+### 4. Rehearse The Exact Path
+
+Run the same tabs once before the audience joins. Confirm:
+
+- the top status pill shows the expected deployment mode and `live`,
+- MCP returns a `live` answer,
+- Fabric and Combined return `live` after the delegated token is entered,
+- expected source badges and trace entries appear,
+- no private endpoint or token is visible in the browser viewport.
+
+## Know What Each Control Does
+
+| Control | Behavior |
 | --- | --- |
-| `mcp-only` | Fastest first run. Validates Microsoft Learn MCP Server KS without Fabric. |
-| `byo-fabric` | Primary Fabric live path. Connects an existing Fabric workspace and ontology. |
-| `full` | Greenfield platform story. Creates Fabric sample assets, then connects Azure AI Search. |
+| **Overview**, **MCP Live**, **Fabric**, **Combined Trace**, **Deployment** tabs | Change the visible section but do not run a query. |
+| **Run MCP**, **Check Fabric**, or **View trace** on an Overview mode card | Opens the matching tab and immediately runs its packaged query. |
+| Top-right **Run combined retrieve** | Opens Combined Trace and immediately runs the combined query. |
+| **Run retrieve** inside a source tab | Runs that tab's packaged query when you choose. |
+| **Re-check** in Deployment | Refreshes Search reachability and runtime status. |
+| Answer mode badge | Distinguishes `live` from `offline` or `offline-replay`. |
+| Source badges | Summarize source types found in response activity. |
+| Activity, References, Source Data | Provide the detailed routing and grounding evidence. |
 
-Talk track:
+For a controlled presentation, use the top navigation tabs and then select **Run retrieve**. The Overview shortcuts start the request immediately and are better for a quick self-guided demo.
 
-```text
-This repo packages two public preview live Knowledge Sources into three reusable demo paths.
-MCP-only is the quickest validation path.
-BYO Fabric is for customers with existing semantic assets.
-Full mode is the zero-to-demo platform path when quota and tenant settings are ready.
-```
+## Step 1: Establish Runtime Status
 
-### 2. Show The App Overview
+1. Open the deployed App URL.
+2. Stay on **Overview**.
+3. Point to the top-right status pill.
+4. Require `<deployment-mode> live`, such as `mcp-only live` or `byo-fabric live`.
+5. In **Deployment Readiness**, confirm the current mode, Search endpoint readiness, Search key readiness, and MCP KS name.
+6. Select **Deployment** in the top navigation.
+7. Select **Re-check**.
+8. Wait for the button to change from **Checking...** back to **Re-check**.
+9. In **Runtime Status**, confirm:
 
-Open the deployed app URL from:
+   ```text
+   "reachabilityStatus": "live"
+   "reachable": true
+   "deploymentMode": "<the profile you deployed>"
+   "hostingMode": "staticwebapp"
+   ```
 
-```text
-deployments/<env>/deployment-summary.md
-```
+10. Return to **Overview**.
 
-In the app, start with **Current Demo Flow** and **Deployment Readiness**.
+What this proves: the managed API is running and can reach the configured Azure AI Search service.
 
-What to point out:
+What this does not prove: a Knowledge Source has answered a retrieve request. Continue to the source tabs.
 
-- deployment mode,
-- app runtime status,
-- MCP live path,
-- Fabric live or offline replay status,
-- source trace sections.
+## Step 2: Demonstrate MCP Live
 
-Do not show secrets, app settings, raw tokens, or private service URLs in screenshots.
+This path is available in every live profile and is the best first live query.
 
-### 3. Run MCP Live
+### Click Sequence
 
-Use the MCP panel or `/api/retrieve/mcp`.
+1. Select **MCP Live** in the top navigation.
+2. Point out that this tab calls the public Microsoft Learn MCP server through Azure AI Search.
+3. Select **Run retrieve**.
+4. Wait while the button reads **Running...**.
+5. When the result appears, start with the **Answer** panel.
+6. Require the `live` badge at the top-right of the Answer panel.
+7. Require the **MCP Server KS** badge below the answer.
+8. Scroll to **Source Trace**.
+9. Point out the activity count, reference count, and `live` response mode.
+10. Scroll to **Query** and show the exact question sent by the app.
+11. In **Activity**, find `type: "mcpServer"`.
+12. In the same activity entry, find `toolName: "microsoft_docs_search"`.
+13. In **References** and **Source Data**, show that Microsoft Learn evidence accompanied the answer.
 
-Suggested query:
+### Packaged Query
 
 ```text
 What must be configured to create an Azure AI Search MCP Server knowledge source?
 ```
 
-Expected evidence:
+### Expected Result
 
-- MCP Server Knowledge Source is `microsoft-learn-mcp-ks`.
-- Activity or references show Microsoft Learn MCP evidence.
-- The answer is useful, but the proof is the trace: `activity`, `references`, and source data.
+- The answer gives relevant MCP Server KS setup guidance.
+- The Answer badge is `live`.
+- **MCP Server KS** appears as a source badge.
+- Activity identifies `mcpServer` and `microsoft_docs_search`.
+- References or source data contain Microsoft Learn grounding.
 
-Claim you can make:
-
-```text
-Azure AI Search can call a remote HTTPS MCP server at retrieve time and return traceable evidence.
-```
-
-### 4. Show Fabric Ontology
-
-Use the Fabric panel or `/api/retrieve/fabric`.
-
-Suggested query:
+### Presenter Talk Track
 
 ```text
-Which carriers have the highest customer-care exposure this month?
+This is not an indexed copy of Microsoft Learn. The Knowledge Base selected the MCP Server Knowledge Source at retrieve time, called the allowed microsoft_docs_search tool, and returned the answer together with inspectable activity and references.
 ```
 
-Expected evidence in live mode:
+### Do Not Claim A Pass When
 
-- Fabric Ontology Knowledge Source exists.
-- The combined or Fabric KB includes the Fabric source.
-- Live retrieve uses delegated source authorization.
-- Activity or source data shows Fabric Ontology evidence.
+- the badge says `offline` or `offline-replay`,
+- the notice says a canonical sample response was used,
+- no MCP activity or reference is present,
+- only the answer text looks correct.
 
-Expected behavior without live Fabric auth:
+## Step 3: Demonstrate Fabric Ontology
 
-- The app shows offline replay.
-- The response explains that Fabric live mode needs Fabric IDs and delegated source authorization.
+Use this path only for `byo-fabric` or `full`.
 
-Claim you can make only with live evidence:
+### Click Sequence
+
+1. Select **Fabric** in the top navigation.
+2. In **Fabric Source Authorization**, paste the raw token prepared earlier.
+3. Confirm visually that the field is populated, but do not reveal the token.
+4. Select **Run retrieve** under **Fabric Ontology**.
+5. Wait while the button reads **Running...**.
+6. In **Answer**, require the `live` badge.
+7. Require the **Fabric Ontology KS** source badge.
+8. For `full` or an Airline Ops BYO ontology, confirm the answer identifies Alpine Air as the highest customer-care exposure airline. For another BYO ontology, validate the result against its own known facts.
+9. Scroll to **Source Trace** and require `live` response mode.
+10. In **Query**, show the business question sent by the app.
+11. In **Activity**, find `type: "fabricOntology"` and the Fabric ontology search argument.
+12. In **References** or **Source Data**, find `fabricAnswer` and `fabricRawData`.
+
+### Packaged Query
 
 ```text
-Fabric Ontology KS can ground retrieval on governed Fabric semantics with user source authorization.
+Which airlines have the highest customer-care exposure this month?
 ```
 
-Safe fallback claim:
+### Expected Result
+
+- The Answer badge is `live`.
+- **Fabric Ontology KS** appears as a source badge.
+- Alpine Air ranks first when the deployed ontology uses the checked-in Airline Ops sample.
+- Activity identifies `fabricOntology`.
+- Source data contains both a Fabric answer and raw grounding data.
+
+### Presenter Talk Track
 
 ```text
-Offline replay shows the expected Fabric trace shape while live Fabric auth is being configured.
+The question is expressed in business language. Fabric Ontology resolves the governed entities and relationships behind customer-care exposure, and the retrieve response returns both a synthesized answer and source-specific grounding data.
 ```
 
-### 5. Show Combined Trace
+### Important Failure Distinction
 
-Use the combined panel or `/api/retrieve/combined`.
+An offline replay also names Alpine Air. That is intentional, so the airline name alone is not proof. If the badge is offline, explain the replay or refresh the delegated token; do not present it as live Fabric retrieval.
 
-Suggested query:
+In `mcp-only`, the Fabric tab returns replay with a reason that Fabric Ontology KS was not created. This is expected profile behavior, not a Fabric pass.
+
+## Step 4: Demonstrate Combined Routing
+
+Run this step after the separate MCP and Fabric tests. The token entered on the Fabric tab remains available while the page stays open.
+
+For a non-Airline Ops BYO ontology, the packaged combined answer is not a domain acceptance test. Use it only to inspect routing, or replace the business question through the REST sample or notebook before the presentation.
+
+### Click Sequence
+
+1. Select **Combined Trace** in the top navigation.
+2. Select **Run retrieve**.
+3. Wait while the button reads **Running...**.
+4. In **Answer**, require the `live` badge.
+5. Read the answer and separate its business conclusion from its implementation guidance.
+6. Inspect the source badges. They show which source types appear in this response.
+7. Scroll to **Source Trace** and state the activity and reference counts that actually appear.
+8. In **Activity**, identify whether the planner selected Fabric, MCP, or both.
+9. In **References**, match the business claim to Fabric evidence and any implementation claim to MCP evidence.
+10. In **Source Data**, show the source-specific evidence returned for the selected path or paths.
+
+### Packaged Query
 
 ```text
-Identify the top customer-care exposure carrier and cite implementation guidance.
+Using the Airline Ops ontology, identify the airline with the highest customer-care exposure this month. Also cite Microsoft Learn guidance for how I should validate activity, references, and sourceData in the Knowledge Base retrieve response.
 ```
 
-What to inspect:
+### Expected Interpretation
 
-- source badges or trace sections,
-- activity entries,
-- references,
-- source-specific data,
-- whether the answer used MCP, Fabric, or offline replay.
+- Fabric can supply the Airline Ops ranking and exposure grounding.
+- MCP can supply Azure AI Search implementation guidance.
+- The planner can select one or both sources for a retrieve call.
+- The two preceding single-source tests prove that both paths work independently.
+- Only a live combined trace containing both source types proves that this particular call used both.
 
-Claim you can make:
+### Presenter Talk Track
 
 ```text
-The same Knowledge Base pattern can route across live tools and semantic business data, then expose trace evidence for review.
+One Knowledge Base can compose multiple live Knowledge Sources. The planner decides which source to call for this question, and the response exposes that decision through activity, references, and sourceData instead of asking us to infer routing from the prose answer.
 ```
 
-## Ten-Minute Workshop Path
+Do not say that every combined query always calls both sources. Describe the trace that is visible in the current response.
 
-Use this order when the audience needs to reproduce the sample:
+## Step 5: Close With Automated Evidence
 
-1. Run `./liveks try`, then `bash scripts/validate-local.sh`.
-2. Read [Choose a Pattern](02-choose-a-pattern.md).
-3. Initialize, plan, and deploy `mcp-only`.
-4. Open the app and run the MCP query.
-5. Open `notebooks/01-mcp-server-ks-quickstart.ipynb`.
-6. Inspect `samples/rest/01-create-mcp-server-ks.http` through `samples/rest/03-retrieve-mcp.http`.
-7. Move to `byo-fabric` when Fabric workspace and ontology IDs are ready.
-8. Open `notebooks/02-fabric-ontology-ks-airline-ops.ipynb`.
-9. Run the combined route and inspect source evidence.
+Return to the terminal after the visual walkthrough and run:
 
-## Demo Safety Checks
+```bash
+./liveks verify --env <environment>
+```
+
+Explain that the visual demo answers "what can a user do?" while `verify` provides a repeatable check of the app, MCP path, and applicable Fabric paths. Sanitized reports are written under the ignored `deployments/<environment>/` directory.
+
+For a complete create, retrieve, verify, and delete rehearsal:
+
+```bash
+./liveks e2e --env <environment> --cleanup --yes
+```
+
+Use `--accept-fabric-capacity` for `full`.
+
+## Ready-Made Demo Sequences
+
+### Three-Minute MCP Demo
+
+1. **Overview**: show `mcp-only live` and the Question -> Knowledge Base -> Live Sources -> Trace pipeline.
+2. **Deployment**: select **Re-check** and show Search reachability.
+3. **MCP Live**: select **Run retrieve**.
+4. **Answer**: show the `live` and **MCP Server KS** badges.
+5. **Activity**: show `microsoft_docs_search`.
+6. Close with `./liveks verify --env liveks-mcp`.
+
+### Seven-Minute Fabric Demo
+
+1. **Overview**: show `byo-fabric live` or `full live`.
+2. **MCP Live**: run and prove MCP independently.
+3. **Fabric**: enter the delegated token, run, and show `fabricOntology` plus Fabric source data.
+4. **Combined Trace**: run and describe the source selection actually shown.
+5. **Deployment**: show current mode and resource names without exposing private IDs.
+6. Close with the automated verify result.
+
+### Two-Minute Offline Explanation
+
+1. Open the public interactive trace demo.
+2. Select **Combined Trace**, then **Run retrieve**.
+3. Point out the `offline-replay` badge before discussing the answer.
+4. Show the two source badges, activity, references, and source data as the expected contract shape.
+5. State clearly that no live tenant or source call is being demonstrated.
+
+## Troubleshooting During A Demo
+
+| What you see | Meaning | Presenter action |
+| --- | --- | --- |
+| Top pill says `offline replay ready` | The managed API is unavailable, or this is GitHub Pages. | Use replay only and label it as replay. |
+| Top pill says `<mode> unreachable` | App settings exist but Search did not answer the status check. | Open Deployment, select Re-check, then use the last verified replay if necessary. |
+| MCP answer is offline | Search configuration or the live MCP retrieve failed. | Show the error/notice, then use replay and the last `verify` result. |
+| Fabric answer is offline and asks for authorization | The delegated token is missing or expired. | Acquire a fresh raw Search token, paste it in Fabric, and rerun. |
+| Combined shows only one live source | Planner selected one source for this question. | Describe the observed routing; use the single-source tests to prove each path. |
+| Button stays on **Running...** | The retrieve call is still within its runtime window or the source is slow. | Wait for completion; do not click repeatedly. |
+| App is unavailable | Hosting or deployment is incomplete. | Use notebooks, REST samples, or public replay without making a live claim. |
+
+## Demo Safety Checklist
 
 Before showing the demo outside the working team:
 
-```text
-[ ] Local validation passes
-[ ] The app URL is from a current deployment summary
-[ ] Screenshots do not expose tenant IDs, tokens, keys, or private endpoints
-[ ] Fabric live claims are backed by Fabric activity or source data
-[ ] Offline replay is clearly described as offline replay
-[ ] Cleanup evidence exists when deployment behavior is being claimed
-[ ] Preview caveats match docs/13-public-preview-limitations.md
-```
-
-## Failure Fallbacks
-
-| Failure | Use this fallback |
-| --- | --- |
-| MCP live call fails | Show `samples/responses/mcp-retrieve.sample.json` and the local validation result. |
-| Fabric token expires | Show Fabric offline replay and explain delegated source authorization. |
-| Full deployment is too slow | Show the generated E2E report summary and deployment mode diagram. |
-| App is unavailable | Use the notebooks and REST files to show the same retrieve sequence. |
-| Public preview behavior changes | Stop at the Learn manual boundary and update the sample before making claims. |
+- [ ] Local validation and `liveks verify` pass.
+- [ ] The App URL comes from the current environment's deployment summary.
+- [ ] The response mode matches every live claim.
+- [ ] Fabric authorization is entered off-screen and no token is visible.
+- [ ] Source selection claims match visible activity and references.
+- [ ] Offline replay is explicitly labeled as replay.
+- [ ] Screenshots contain no tenant IDs, keys, tokens, private endpoints, or customer data.
+- [ ] `full` demo ownership and cleanup responsibilities are understood.
+- [ ] Preview caveats match [Public Preview Limitations](13-public-preview-limitations.md).
 
 ## What Not To Claim
 
-Avoid these during demos:
+Avoid these statements:
 
 - offline replay proves live Fabric retrieval,
-- screenshots alone prove source selection,
+- a useful answer alone proves source selection,
+- source badges from an offline fixture prove a live call,
+- every combined query always calls both sources,
 - `azd up` alone proves retrieve behavior,
-- full mode will work in every tenant and region,
+- full mode works in every tenant and region,
 - local stdio MCP servers can be attached directly to Azure AI Search.
 
-Use [Public Preview Limitations and Caveats](13-public-preview-limitations.md) for safe wording.
+Use [Post-Deployment Tests And Expected Traces](08-test-queries.md) for additional questions and exact pass/fail evidence.

--- a/docs/19-faq.md
+++ b/docs/19-faq.md
@@ -146,5 +146,5 @@ Not through the supported `byo-fabric` path. BYO ownership is marked `reuse`, an
 | Pick a mode | [Choose a Pattern](02-choose-a-pattern.md) |
 | Understand architecture | [Architecture](01-architecture.md) |
 | Deploy the sample | [One-Command Deployment](10-one-command-deployment.md) |
-| Prepare a short demo | [Demo Walkthrough](16-demo-walkthrough.md) |
+| Prepare a short demo | [Guided Live Demo](16-demo-walkthrough.md) |
 | Check preview caveats | [Public Preview Limitations](13-public-preview-limitations.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,21 @@ The YAML ledger is written to ignored `.liveks/liveks-mcp.yaml`. `plan` performs
 
 The safe default progression is `offline -> mcp-only -> byo-fabric`. Use `full` only after checking Fabric quota, cost, tenant settings, and cleanup expectations.
 
+## After Deployment: Prove It Live
+
+`liveks up` provisions and verifies the environment, but the first user-facing success moment happens in the deployed app:
+
+1. Open the App URL from `deployments/<environment>/deployment-summary.md`.
+2. Confirm the deployment status is live.
+3. Select **MCP Live**, **Fabric**, or **Combined Trace**.
+4. Select **Run retrieve**.
+5. Require a `live` answer and inspect `activity`, `references`, and `sourceData` for the expected source.
+
+[Follow the click-by-click live demo](16-demo-walkthrough.md){ .md-button .md-button--primary }
+[Choose test queries and pass criteria](08-test-queries.md){ .md-button }
+
+An `offline` or `offline-replay` result is useful for learning the response contract, but it does not prove that a live Knowledge Source ran.
+
 ## Composition Model
 
 ![Live Knowledge Sources Architecture](assets/live-knowledge-sources-architecture.svg)
@@ -59,6 +74,8 @@ The app and CLI replay use the same canonical response fixtures as the serverles
 | Understand commands and exit codes | [LiveKS CLI](20-liveks-cli.md) |
 | Manage YAML and secrets | [Configuration](21-configuration.md) |
 | Deploy and clean up | [One-Command Deployment](10-one-command-deployment.md) |
+| Test the deployed sources | [Post-Deployment Tests](08-test-queries.md) |
+| Present the demo click by click | [Guided Live Demo](16-demo-walkthrough.md) |
 | Connect existing Fabric | [BYO Fabric Validation](11-fabric-live-byo-validation.md) |
 | Diagnose failures | [Troubleshooting](07-troubleshooting.md) |
 | Review safety boundaries | [Security and Governance](06-security-governance.md) |

--- a/docs/maintainers/private-review-workflow.md
+++ b/docs/maintainers/private-review-workflow.md
@@ -191,7 +191,7 @@ Use role-specific asks so reviewers can answer quickly.
 | --- | --- | --- |
 | Azure AI Search / Knowledge Source | KS/KB REST shape, API version, retrieve trace wording, `activity` / `references` interpretation, MCP Server KS examples | `samples/rest/`, [MCP Server KS](../03-mcp-server-ks.md), [Reviewer Evidence Guide](reviewer-evidence.md) |
 | Fabric / Ontology | Fabric workspace and ontology prerequisites, Fabric Ontology KS wording, delegated source authorization caveats, full-mode Fabric setup language | [Fabric Ontology KS](../04-fabric-ontology-ks.md), [Fabric Prerequisites](../fabric-ontology-prerequisites.md), [BYO Fabric Validation](../11-fabric-live-byo-validation.md) |
-| Field / workshop owner | First-five-minutes flow, deployment-mode clarity, notebook usability, offline replay usefulness, failure fallback story | [Choose a Pattern](../02-choose-a-pattern.md), `notebooks/`, [Demo Walkthrough](../16-demo-walkthrough.md) |
+| Field / workshop owner | First-five-minutes flow, deployment-mode clarity, notebook usability, offline replay usefulness, failure fallback story | [Choose a Pattern](../02-choose-a-pattern.md), `notebooks/`, [Guided Live Demo](../16-demo-walkthrough.md) |
 | Security / release hygiene | Ignored generated outputs, env handling, no-secret scan posture, synthetic data boundary, preview limitation language | [Security Governance](../06-security-governance.md), [Release Readiness](release-readiness-checklist.md), [Public Preview Limitations](../13-public-preview-limitations.md) |
 | Blog / presentation reviewer | Claims vs evidence, screenshots, architecture wording, customer-safe phrasing, call-to-action | [Storyline And Safe Claims](storyline-and-safe-claims.md), sanitized screenshots under ignored `scratch/` |
 

--- a/docs/maintainers/storyline-and-safe-claims.md
+++ b/docs/maintainers/storyline-and-safe-claims.md
@@ -130,7 +130,7 @@ Use this when you have three to five minutes:
 5. Show combined trace.
 6. Close with evidence and caveats: validation gate, E2E reports, preview limitations.
 
-For the longer app sequence, use [Demo Walkthrough](../16-demo-walkthrough.md).
+For the longer app sequence, use [Guided Live Demo Walkthrough](../16-demo-walkthrough.md).
 
 ## Reviewer Ask
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -97,11 +97,31 @@ Expected evidence:
 | `byo-fabric` | MCP evidence plus live Fabric and combined evidence using delegated Search authorization. |
 | `full` | Generated Fabric GraphModel is ready, separate checks prove both sources, and all Azure assets pass. |
 
+### Run The Manual Acceptance Test
+
+Do not stop at a successful deployment message. Open the **App URL** from:
+
+```text
+deployments/<environment>/deployment-summary.md
+```
+
+Then run this minimum screen check:
+
+1. On **Overview**, confirm the top status pill says `<deployment-mode> live`.
+2. Open **Deployment**, select **Re-check**, and confirm `reachabilityStatus: live` and `reachable: true`.
+3. Open **MCP Live**, select **Run retrieve**, and require a `live` answer with **MCP Server KS** activity or references.
+4. For `byo-fabric` or `full`, open **Fabric**, enter a raw delegated Search token without a `Bearer` prefix, select **Run retrieve**, and require a `live` answer with **Fabric Ontology KS** evidence.
+5. After both single-source checks pass, open **Combined Trace**, select **Run retrieve**, and describe the source selection shown in activity. Do not assume every combined query calls both sources.
+
+Use [Guided Live Demo Walkthrough](16-demo-walkthrough.md) for the exact click sequence, packaged questions, expected answers, presenter notes, and failure handling. Use [Post-Deployment Tests](08-test-queries.md) for trace-level pass/fail criteria and additional queries.
+
 Run verification again without redeploying:
 
 ```bash
 ./liveks verify --env liveks-mcp
 ```
+
+The manual app test proves the user-facing experience. `verify` independently repeats the applicable source checks and records sanitized evidence under the ignored `deployments/<environment>/` directory.
 
 Sanitized reports are written under ignored `deployments/<environment>/`.
 

--- a/docs/samples/rest.md
+++ b/docs/samples/rest.md
@@ -17,4 +17,4 @@ samples/rest/07-delete-resources.http
 
 Use the REST path when you want exact request shapes without the deployment wrapper. Keep live endpoints, API keys, and query-time authorization headers in local tooling only.
 
-Next: use [Test Queries](../08-test-queries.md) to pick validation prompts and expected trace signals.
+Next: use [Post-Deployment Tests](../08-test-queries.md) to pick validation prompts and expected trace signals.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,8 +69,8 @@ nav:
       - One-Command Deployment: 10-one-command-deployment.md
       - BYO Fabric Validation: 11-fabric-live-byo-validation.md
   - Operate:
-      - Test Queries: 08-test-queries.md
-      - Demo Walkthrough: 16-demo-walkthrough.md
+      - Post-Deployment Tests: 08-test-queries.md
+      - Guided Live Demo: 16-demo-walkthrough.md
       - Troubleshooting: 07-troubleshooting.md
       - Security and Governance: 06-security-governance.md
       - External Tenant Login: external-tenant-login.md

--- a/samples/responses/README.md
+++ b/samples/responses/README.md
@@ -32,4 +32,4 @@ Offline replay is not proof of live retrieval.
 
 Use offline replay to understand trace shape and user experience. Use E2E reports and live retrieve activity when you need to prove a live MCP or Fabric path.
 
-For query and trace guidance, see [Test Queries And Expected Traces](../../docs/08-test-queries.md).
+For query and trace guidance, see [Post-Deployment Tests And Expected Traces](../../docs/08-test-queries.md).

--- a/samples/rest/README.md
+++ b/samples/rest/README.md
@@ -80,4 +80,4 @@ Then inspect:
 - `sourceData.fabricAnswer`
 - `sourceData.fabricRawData`
 
-For query and trace guidance, see [Test Queries And Expected Traces](../../docs/08-test-queries.md).
+For query and trace guidance, see [Post-Deployment Tests And Expected Traces](../../docs/08-test-queries.md).

--- a/src/liveks/cli.py
+++ b/src/liveks/cli.py
@@ -418,6 +418,10 @@ def _response_has_evidence(payload: Any, source_type: str | None = None) -> bool
     return any(item.get("type") == source_type for item in evidence if isinstance(item, dict))
 
 
+def _response_has_live_evidence(payload: Any, source_type: str) -> bool:
+    return isinstance(payload, dict) and payload.get("mode") == "live" and _response_has_evidence(payload, source_type)
+
+
 def _evidence_types(payload: Any) -> list[str]:
     if not isinstance(payload, dict):
         return []
@@ -448,8 +452,8 @@ def verify_report(config: ResolvedConfig, *, quiet: bool = False) -> dict[str, A
             status_code, status_payload = http_json(f"{app_url}/api/status", attempts=18, delay_seconds=10, timeout=20)
             checks.append(_check("app-status", "pass" if status_code == 200 else "fail", f"HTTP {status_code}"))
             mcp_code, mcp_payload = http_json(f"{app_url}/api/retrieve/mcp", method="POST", body={"query": "What must be configured for an Azure AI Search MCP Server knowledge source?"}, attempts=3, delay_seconds=5, timeout=120)
-            mcp_ok = mcp_code == 200 and _response_has_evidence(mcp_payload, "mcpServer")
-            checks.append(_check("mcp-retrieve", "pass" if mcp_ok else "fail", "MCP activity/reference evidence returned" if mcp_ok else f"HTTP {mcp_code} without MCP evidence"))
+            mcp_ok = mcp_code == 200 and _response_has_live_evidence(mcp_payload, "mcpServer")
+            checks.append(_check("mcp-retrieve", "pass" if mcp_ok else "fail", "Live MCP activity/reference evidence returned" if mcp_ok else f"HTTP {mcp_code}; live MCP evidence missing"))
             if config.profile in {"byo-fabric", "full"}:
                 token_result = runner.run(["az", "account", "get-access-token", "--resource", "https://search.azure.com", "--query", "accessToken", "-o", "tsv"])
                 token = token_result.stdout.strip()
@@ -458,7 +462,7 @@ def verify_report(config: ResolvedConfig, *, quiet: bool = False) -> dict[str, A
                 else:
                     fabric_body = {"query": "Which airlines have the highest customer-care exposure this month?", "fabricUserSearchToken": token}
                     fabric_code, fabric_payload = http_json(f"{app_url}/api/retrieve/fabric", method="POST", body=fabric_body, attempts=3, delay_seconds=5, timeout=120)
-                    fabric_ok = fabric_code == 200 and _response_has_evidence(fabric_payload, "fabricOntology") and fabric_payload.get("mode") == "live"
+                    fabric_ok = fabric_code == 200 and _response_has_live_evidence(fabric_payload, "fabricOntology")
                     checks.append(_check("fabric-retrieve", "pass" if fabric_ok else "fail", "Live Fabric ontology evidence returned" if fabric_ok else f"HTTP {fabric_code}; live Fabric evidence missing"))
                     combined_body = {
                         "query": (

--- a/tests/test_liveks_config.py
+++ b/tests/test_liveks_config.py
@@ -113,6 +113,12 @@ class LiveKsConfigTests(unittest.TestCase):
         self.assertEqual(cli._evidence_types(fabric_only), ["fabricOntology"])
         self.assertEqual(cli._evidence_types(both), ["fabricOntology", "mcpServer"])
 
+    def test_live_evidence_rejects_offline_fixture_activity(self):
+        offline = {"mode": "offline", "activity": [{"type": "mcpServer"}], "references": []}
+        live = {"mode": "live", "activity": [{"type": "mcpServer"}], "references": []}
+        self.assertFalse(cli._response_has_live_evidence(offline, "mcpServer"))
+        self.assertTrue(cli._response_has_live_evidence(live, "mcpServer"))
+
     def test_e2e_reports_preserve_machine_and_maintainer_formats(self):
         config = resolve_config(profile="mcp-only", environment="unit-report")
         report = {


### PR DESCRIPTION
## Summary

- add click-by-click post-deployment tests for MCP, Fabric, and Combined retrieval
- expand the guided demo with exact controls, expected evidence, presenter cues, and failure handling
- connect the README, manual home, runbook, and deployment guide to the new validation flow
- require live MCP evidence in `liveks verify` so offline fixtures cannot satisfy a live check

## Validation

- `bash scripts/validate-local.sh`
- `python3 -m mkdocs build --strict --site-dir /tmp/liveks-manual-test`
- desktop and mobile manual rendering
- MCP, Fabric, Combined, and Deployment tab interaction checks
