### PR TITLE
Update GitHub Actions runtimes to v7

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,14 +40,14 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip
           cache-dependency-path: requirements-docs.txt
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,12 +20,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Summary

- update `actions/setup-node` from v6 to v7 in Pages and validation workflows
- update `actions/setup-python` from v6 to v7 in Pages, Linux validation, and Windows validation
- preserve Node.js 22, Python 3.11, and the existing npm and pip cache settings

## Compatibility

- the removed `pip-install` input is not used by this repository
- both action upgrades already pass the repository's Pages, Linux, and Windows workflow paths

## Validation

- `bash scripts/validate-local.sh`
- `git diff --check`
