### PR TITLE
Add managed-organization execution manual

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,6 +22,7 @@ AIRLINE_OPS_INDEX_NAME=airline-ops-regulatory-docs
 MCP_KNOWLEDGE_SOURCE_NAME=microsoft-learn-mcp-ks
 FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME=fabric-ontology-ks
 MCP_ONLY_KNOWLEDGE_BASE_NAME=live-knowledge-sources-mcp-kb
+FABRIC_ONLY_KNOWLEDGE_BASE_NAME=live-knowledge-sources-fabric-kb
 KNOWLEDGE_BASE_NAME=live-knowledge-sources-kb
 MCP_SERVER_URL=https://learn.microsoft.com/api/mcp
 MCP_TOOL_NAME=microsoft_docs_search

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,7 +54,7 @@ jobs:
           cache-dependency-path: static-app/package-lock.json
 
       - name: Configure GitHub Pages
-        if: github.event_name != 'pull_request' && github.repository_owner == 'microsoft'
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v6
         with:
           enablement: true
@@ -73,14 +73,14 @@ jobs:
           cp -R static-app/dist/. _site/demo/
 
       - name: Upload Pages artifact
-        if: github.event_name != 'pull_request' && github.repository_owner == 'microsoft'
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
   deploy:
     name: Deploy manual
-    if: github.event_name != 'pull_request' && github.repository_owner == 'microsoft'
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,7 +54,7 @@ jobs:
           cache-dependency-path: static-app/package-lock.json
 
       - name: Configure GitHub Pages
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event.repository.private == false
         uses: actions/configure-pages@v6
         with:
           enablement: true
@@ -73,14 +73,14 @@ jobs:
           cp -R static-app/dist/. _site/demo/
 
       - name: Upload Pages artifact
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event.repository.private == false
         uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
   deploy:
     name: Deploy manual
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event.repository.private == false
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -61,4 +61,4 @@ jobs:
           .\liveks.ps1 bootstrap
           .\liveks.ps1 profiles --format json
           .\liveks.ps1 doctor --profile offline --format json
-          .\.liveks\venv\Scripts\python.exe -m unittest tests.test_liveks_config
+          .\.liveks\venv\Scripts\python.exe -m unittest tests.test_liveks_config tests.test_mcp_invocation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Unknown YAML fields fail closed. Secret fields must use `{env: VARIABLE_NAME}` a
 ./liveks plan --env liveks-mcp
 ./liveks up --env liveks-mcp
 ./liveks verify --env liveks-mcp
+./liveks mcp --env liveks-mcp
 ./liveks down --env liveks-mcp
 ```
 
@@ -81,6 +82,8 @@ Use the evidence that matches the claim:
 | MCP path is live | MCP activity or references from `liveks verify` |
 | Fabric path is live | `fabricOntology` evidence in live mode with delegated authorization |
 | Combined routing worked | Recognized live evidence from the source or sources selected by the combined KB planner |
+| Knowledge Base MCP is callable | `liveks mcp` passes `tools/list` and `tools/call` |
+| Knowledge Base MCP returned expected grounding | `liveks mcp --expect-term <known-fact>` passes `grounding-content`; pair it with source-specific `verify` evidence before naming the source that ran |
 | Full rehearsal is complete | Create and retrieve checks pass; deployment RG, generated capacity RG, and generated capacity absence checks pass |
 
 Final answer text alone is not routing evidence. Inspect `activity`, `references`, and `sourceData`, and use the single-source KB checks to prove MCP and Fabric independently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this accelerator are documented here.
 
 ### Added
 
+- Managed-organization GitHub Pages manual that leads operators from profile configuration through one Live Knowledge Source, Foundry IQ grounding evidence, native Knowledge Base MCP invocation, and known limitations, with official Microsoft Learn references.
+- Native `liveks mcp` client for JSON and SSE transports, tool discovery and calls, delegated Fabric source authorization, known-fact assertions, redacted reports, and reproducible expected-failure evidence.
+- Dedicated Fabric-only Knowledge Base configuration through `FABRIC_ONLY_KNOWLEDGE_BASE_NAME` so Fabric Ontology grounding can be verified independently of combined planner routing.
+- Traceable Langflow benchmark adaptation record that separates observable README and workflow patterns from out-of-scope implementation details and documents independent implementation and license handling.
 - Cross-platform `liveks` and `liveks.ps1` lifecycle entry points with dependency-free offline replay.
 - Canonical v2 YAML schema and executable `offline`, `mcp-only`, `byo-fabric`, and `full` profiles.
 - Plan-first `init`, `doctor`, `plan`, `up`, `verify`, `down`, and `e2e` commands with JSON output.
@@ -17,6 +21,9 @@ All notable changes to this accelerator are documented here.
 
 ### Changed
 
+- README and manual onboarding now start with the repository's user, input, and result contract; profile-specific required settings; one representative first-success path; sanitized evidence; and only then advanced deployment and protocol paths.
+- Live verification now distinguishes MCP protocol success from grounding-content proof. BYO Fabric operators must provide a known, non-sensitive ontology fact instead of treating a fluent response as source evidence.
+- GitHub Pages CI always builds the manual, but uploads and deploys only for non-PR events in public repositories so private mirrors validate cleanly without attempting unsupported Pages publication.
 - YAML is now the human-managed deployment ledger; `azd env` is a generated deployment projection.
 - Legacy shell and Python entry points delegate to LiveKS while retaining compatibility arguments.
 - Azure Developer CLI hooks are cross-platform Python scripts.
@@ -29,6 +36,8 @@ All notable changes to this accelerator are documented here.
 
 ### Compatibility
 
+- The Knowledge Base MCP tool accepts its documented `queries` input only; retrieve-only source-forcing parameters are not sent through MCP, so independent source proof uses the corresponding single-source Knowledge Base.
+- The checked-in Airline Ops terms are synthetic sample evidence and are not assumed to exist in an arbitrary BYO Fabric ontology; live assertions must match the connected ontology's own sanitized facts.
 - Azure AI Search Knowledge Source API remains pinned to `2026-05-01-preview`.
 - Python 3.11+, Azure Developer CLI 1.27.0+, and Node.js 22+ are required for live profiles.
 - Legacy dotenv input remains supported through `--env-file` and one-time `init --from-env` migration.

--- a/README.md
+++ b/README.md
@@ -1,89 +1,47 @@
 # Foundry IQ Live Knowledge Sources Accelerator
 
-> Deploy and inspect Azure AI Search MCP Server and Fabric Ontology Knowledge Sources through one Foundry IQ Knowledge Base, with source-level evidence for every answer.
+> Platform teams connect a governed Fabric Ontology or remote HTTPS MCP tool, submit a natural-language question to a Foundry IQ Knowledge Base, and receive a grounded result with source evidence that can also be consumed through MCP.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Azure AI Search](https://img.shields.io/badge/Azure%20AI%20Search-2026--05--01--preview-orange)
 ![Python](https://img.shields.io/badge/Python-3.11%2B-blue)
 ![Node.js](https://img.shields.io/badge/Node.js-22%2B-green)
 
-[Open the interactive trace demo](https://microsoft.github.io/azure-ai-search-foundry-iq-live-knowledge-sources/demo/?demo=combined) | [Read the execution manual](https://microsoft.github.io/azure-ai-search-foundry-iq-live-knowledge-sources/) | [Watch the KO/EN walkthrough](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/releases/tag/walkthrough-v1)
+[Read the execution manual](https://microsoft.github.io/azure-ai-search-foundry-iq-live-knowledge-sources/) | [Open the trace demo](https://microsoft.github.io/azure-ai-search-foundry-iq-live-knowledge-sources/demo/?demo=combined) | [Watch the KO/EN walkthrough](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/releases/tag/walkthrough-v1)
 
-## Try It Before Installing
+This public accelerator is designed for managed-organization evaluation, field demos, and implementation review. It is not a production reference architecture.
 
-No Azure subscription, tenant access, Fabric workspace, or keys are required:
+## Components At A Glance
+
+| Component | What it does | Proof to inspect |
+| --- | --- | --- |
+| **MCP Server Knowledge Source** | Calls an allowed tool on a remote HTTPS MCP server during Knowledge Base retrieval. | `mcpServer` activity or references and the invoked tool name. |
+| **Fabric Ontology Knowledge Source** | Grounds a business question in governed Fabric entities and relationships. | `fabricOntology` activity or references plus Fabric source data. |
+| **Foundry IQ Knowledge Base** | Plans retrieval across attached sources and produces one grounded result. | Answer content, `activity`, `references`, and `sourceData`. |
+| **Native Knowledge Base MCP endpoint** | Exposes `knowledge_base_retrieve` to MCP-compatible clients. | `tools/list`, `tools/call`, and a known-fact match when source grounding is claimed. |
+| **LiveKS CLI** | Validates, plans, deploys, verifies, invokes MCP, and cleans up. | Stable status envelopes and nonzero failures. |
+
+There are two distinct MCP directions:
+
+```text
+Northbound: MCP client -> Knowledge Base MCP endpoint -> Foundry IQ -> Knowledge Source
+Southbound: Foundry IQ -> MCP Server Knowledge Source -> remote HTTPS MCP tool
+```
+
+The representative managed-organization scenario uses the northbound client path with a native Fabric Ontology Knowledge Source. Fabric is not routed through the external MCP Server KS.
+
+## Run One Live Knowledge Source
+
+Use `byo-fabric` when the organization already owns a Fabric workspace and ontology:
 
 ```bash
 git clone --depth 1 https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources.git
 cd azure-ai-search-foundry-iq-live-knowledge-sources
-./liveks try
-```
-
-The answer is printed first, followed by MCP Server KS and Fabric Ontology KS evidence from the checked-in combined response. Add `--details` to inspect `activity`, `references`, and `sourceData`.
-
-On Windows PowerShell, run `./liveks.ps1 try`.
-
-![Retrieve trace contract](assets/trace-contract.gif)
-
-## What This Accelerator Does
-
-- **MCP Server Knowledge Source** calls an allowed tool on a remote HTTPS MCP server during Knowledge Base retrieval. The sample uses Microsoft Learn MCP.
-- **Fabric Ontology Knowledge Source** grounds the same question in governed Fabric entities and relationships. The sample uses a synthetic Airline Operations domain.
-- **Foundry IQ composition** can route one question across either or both sources and returns one answer with inspectable `activity`, `references`, and `sourceData`.
-- **Plan-first automation** validates tools, configuration, Bicep, payloads, and the demo app before it creates cloud resources.
-- **Ownership-aware cleanup** deletes generated Azure and Fabric assets while preserving BYO Fabric workspaces and ontologies.
-
-This is a reusable public-preview accelerator, not a production reference architecture. The Azure AI Search API version is pinned to `2026-05-01-preview`; use the [official Microsoft manuals](#official-manuals) as the source of truth while preview behavior evolves.
-
-## Go Live
-
-Bootstrap the local CLI once:
-
-```bash
 ./liveks bootstrap
-./liveks profiles
-```
-
-Create an ignored YAML configuration, inspect the non-mutating plan, then deploy:
-
-```bash
-./liveks init --profile mcp-only --env liveks-mcp
-./liveks doctor --env liveks-mcp
-./liveks plan --env liveks-mcp
-./liveks up --env liveks-mcp
-```
-
-`up` shows an Azure preview and cost context, then requires `create liveks-mcp` before provisioning. Use `--yes` only in controlled automation.
-
-| Profile | Use when | Required configuration |
-| --- | --- | --- |
-| `offline` | You want to learn the retrieve contract without cloud resources. | None |
-| `mcp-only` | You want the fastest live validation without Fabric. | Azure sign-in; defaults are otherwise runnable |
-| `byo-fabric` | You already have a Fabric workspace and ontology. | `fabric.workspace_id` and `fabric.ontology_id` |
-| `full` | You want a greenfield Fabric and Azure deployment. | Fabric quota and explicit `--accept-fabric-capacity` |
-
-For BYO Fabric:
-
-```bash
 ./liveks init --profile byo-fabric --env liveks-byo
-# Edit .liveks/liveks-byo.yaml with the existing workspace and ontology GUIDs.
-./liveks plan --env liveks-byo
-./liveks up --env liveks-byo
 ```
 
-For a greenfield run:
-
-```bash
-./liveks init --profile full --env liveks-full
-./liveks plan --env liveks-full
-./liveks up --env liveks-full --accept-fabric-capacity
-```
-
-The `full` profile creates a billable Fabric F2 capacity. It never accepts BYO workspace or ontology IDs. Review the plan and run cleanup when the demo is complete.
-
-## One YAML Ledger
-
-Deployment settings live in ignored `.liveks/<environment>.yaml` files:
+Edit the ignored `.liveks/liveks-byo.yaml` ledger and add the existing identifiers:
 
 ```yaml
 version: 2
@@ -94,90 +52,157 @@ azure:
 fabric:
   workspace_id: 11111111-1111-1111-1111-111111111111
   ontology_id: 22222222-2222-2222-2222-222222222222
-  user_search_token:
-    env: FABRIC_USER_SEARCH_TOKEN
 ```
 
-Secret values are environment references, never YAML literals. LiveKS validates the file, derives names, projects the resolved values into the selected `azd` environment, and writes a redacted lock under `.liveks/`. Legacy dotenv inputs remain available through `--env-file`, but YAML is the canonical v2 path.
+Then inspect before provisioning and deploy only after reviewing the resource and cost list:
 
-See [Configuration](docs/21-configuration.md) for precedence, fields, external-tenant settings, and secret handling.
+```bash
+az login --tenant <tenant-guid>
+azd auth login
+./liveks doctor --env liveks-byo
+./liveks plan --env liveks-byo
+./liveks up --env liveks-byo
+```
+
+`plan` is non-provisioning. `up` displays the Azure preview and requires `create liveks-byo`. Postprovision creates a Fabric-only Knowledge Base for isolated source validation and a combined Knowledge Base for planner-routing tests. Cleanup later deletes generated Azure resources and preserves the existing Fabric workspace and ontology.
+
+No existing ontology? Use `mcp-only` for the fastest live path. Use `full` only with explicit approval because it creates a billable Fabric F2 capacity.
+
+## Confirm Foundry IQ Grounding
+
+Do not treat a successful deployment message or final answer as routing proof:
+
+```bash
+./liveks verify --env liveks-byo --format json
+```
+
+For the checked-in synthetic Airline Ops contract, the verifier asks:
+
+```text
+Which airlines have the highest customer-care exposure this month?
+```
+
+Require a live `fabric-retrieve` pass backed by `fabricOntology` activity or references. The sample ontology should rank Alpine Air first and return Fabric answer and raw grounding fields; another BYO ontology must use a question and expected fact from its own domain.
+
+The verifier writes sanitized status and evidence summaries under ignored `deployments/<environment>/`. Raw responses, tokens, endpoints, and tenant-specific identifiers must stay out of git.
+
+Follow [Post-Deployment Tests](docs/08-test-queries.md) for the exact trace-level pass/fail contract.
+
+## Call It Through MCP
+
+After REST evidence proves the Knowledge Source independently, invoke the same Fabric-only Knowledge Base as an MCP server:
+
+```bash
+./liveks mcp \
+  --env liveks-byo \
+  --query "Which airlines have the highest customer-care exposure this month?" \
+  --expect-term "Alpine Air"
+```
+
+Expected sanitized output:
+
+```text
+LiveKS mcp: PASS
+[PASS] tools-list: Knowledge Base publishes knowledge_base_retrieve.
+[PASS] tools-call: knowledge_base_retrieve returned 1 text block(s).
+[PASS] grounding-content: MCP content matched 1/1 expected term(s).
+```
+
+Use `Alpine Air` only when the connected ontology implements the checked-in synthetic contract. For another BYO ontology, use a non-sensitive fact that a known-answer question must return. Omitting `--expect-term` proves the MCP protocol surface only and produces a grounding warning.
+
+The default sample path reads a Search admin key transiently through Azure CLI and never prints or persists it. Organization-managed identities with **Search Index Data Reader** can use `--auth bearer`.
+
+For a controlled Fabric authorization failure:
+
+```bash
+./liveks mcp --env liveks-byo --omit-source-authorization --expect-failure
+```
+
+The command normalizes external failure text and stores no raw MCP content. The current MCP result returns `result.content[]`, not the retrieve API's separate `activity` and `references`; the acceptance proof is therefore the pair of source-specific `verify` evidence and an `mcp` known-fact match.
+
+Read [Call the Knowledge Base Through MCP](docs/22-knowledge-base-mcp.md) for authentication, evidence, and failure handling.
+
+## Configuration And Known Limitations
+
+| Profile | Use when | Required configuration |
+| --- | --- | --- |
+| `offline` | Learn the response and evidence contract without cloud resources. | None |
+| `mcp-only` | Validate one live MCP Server KS without Fabric. | Azure sign-in; profile defaults are otherwise runnable. |
+| `byo-fabric` | Connect an existing Fabric workspace and ontology. | `fabric.workspace_id` and `fabric.ontology_id`. |
+| `full` | Rehearse a greenfield Fabric and Azure deployment. | Fabric quota and `--accept-fabric-capacity`. |
+
+`.liveks/<environment>.yaml` is the canonical human-authored ledger. `azd env` is generated deployment state, and dotenv files are compatibility inputs for REST and notebook users. Secret fields use `{env: VARIABLE_NAME}` references; raw values never belong in YAML.
+
+The Azure AI Search API is pinned to `2026-05-01-preview`. Preview behavior has no production SLA and can change. Microsoft Learn is the source of truth for the current API, authentication, MCP response, and Fabric requirements.
+
+Important boundaries:
+
+- Fabric live retrieve requires a raw end-user Search token in `x-ms-query-source-authorization`, without a `Bearer` prefix.
+- MCP Server KS requires a reachable remote HTTPS endpoint; local stdio servers cannot be attached directly.
+- The native MCP result alone does not identify source activity in separate arrays; use retrieve evidence first and a known-fact match before claiming grounded MCP content.
+- The current `knowledge_base_retrieve` MCP tool accepts one `queries` array and cannot carry retrieve-only `knowledgeSourceParams`, including `alwaysQuerySource`.
+- Browser code never receives Search admin keys or Azure OpenAI keys.
+- Do not commit customer data, tenant IDs, workspace or ontology IDs, keys, tokens, raw live responses, or private screenshots.
+
+See [Configuration](docs/21-configuration.md), [Security and Governance](docs/06-security-governance.md), [Troubleshooting](docs/07-troubleshooting.md), and [Public Preview Limitations](docs/13-public-preview-limitations.md).
+
+## Try Before Going Live
+
+No Azure subscription, tenant, Fabric workspace, or key is needed to inspect the checked-in response contract:
+
+```bash
+./liveks try
+./liveks try --details
+```
+
+The answer is printed first, followed by MCP Server KS and Fabric Ontology KS evidence. This is offline replay only; it does not prove that a live source ran.
+
+![Retrieve trace contract](assets/trace-contract.gif)
 
 ## Verify And Clean Up
 
+Before cleanup, open the App URL in `deployments/<environment>/deployment-summary.md` and complete the [Guided Live Demo](docs/16-demo-walkthrough.md).
+
 ```bash
-./liveks verify --env liveks-mcp
-./liveks down --env liveks-mcp
+./liveks down --env liveks-byo
 ```
 
-Before cleanup, open the deployed App URL and run the packaged MCP, Fabric, and Combined queries that apply to the profile. Follow the [Guided Live Demo](docs/16-demo-walkthrough.md) for the exact controls and presenter sequence, and use [Post-Deployment Tests](docs/08-test-queries.md) for expected answers and trace-level pass/fail criteria.
+Require `resource-group-absent`. A `full` run that generated Fabric capacity must also report `fabric-capacity-resource-group-absent` and `fabric-capacity-absent`.
 
-For a complete create, call, verify, and delete rehearsal:
+For a controlled end-to-end rehearsal:
 
 ```bash
 ./liveks e2e --env liveks-mcp --cleanup --yes
 ```
 
-`byo-fabric` cleanup deletes only generated Azure resources. `full` cleanup deletes the generated Fabric stack first and then Azure resources; disagreement between the YAML and deployment lock fails closed for Fabric deletion. Successful output includes `resource-group-absent`; when `full` created the capacity, it also includes `fabric-capacity-resource-group-absent` and `fabric-capacity-absent`.
+Use exactly one of `--cleanup` or `--keep-resources`. Prefer cleanup and record the owner whenever resources are retained.
 
 ## Architecture
 
 ![Architecture](assets/live-knowledge-sources-architecture.svg)
-
-One Knowledge Base composes the live sources. Query-time source options influence routing, while the response itself provides the evidence contract.
 
 ```text
 Question
   -> Foundry IQ Knowledge Base
     -> MCP Server KS: implementation guidance
     -> Fabric Ontology KS: governed business semantics
-  -> one answer + activity + references + sourceData
+  -> grounded result + activity + references + sourceData
+  -> native knowledge_base_retrieve MCP tool
 ```
 
-The Airline Ops ontology is supporting sample data, not the main product surface. Its entities, relationships, SVG map, and PNG rendering are documented in the [Airline Ops Ontology Contract](samples/ontology/airline-ops/README.md).
-
-## What Gets Created
-
-| Profile | Knowledge Sources | Other assets |
-| --- | --- | --- |
-| `mcp-only` | Microsoft Learn MCP Server KS | Azure AI Search, Azure OpenAI, MCP-only KB, Search index, demo app |
-| `byo-fabric` | MCP Server KS + Fabric Ontology KS | The same Azure assets plus a combined KB connected to existing Fabric assets |
-| `full` | MCP Server KS + generated Fabric Ontology KS | Fabric capacity, workspace, Lakehouse, ontology, GraphModel, Azure assets, combined KB, demo app |
-
-The default app is Azure Static Web Apps with a managed Node.js API. Browser code never receives Search admin keys or Azure OpenAI keys.
-
-<p align="center">
-  <img src="assets/demo-overview.png" alt="Foundry IQ combined retrieve answer and source trace" width="900">
-</p>
-
-## Manual
-
-| Need | Start here |
-| --- | --- |
-| Follow the shortest end-to-end sequence | [Execution Runbook](docs/runbook.md) |
-| Choose a profile | [Choose a Pattern](docs/02-choose-a-pattern.md) |
-| Learn the CLI lifecycle | [LiveKS CLI](docs/20-liveks-cli.md) |
-| Author the YAML ledger | [Configuration](docs/21-configuration.md) |
-| Deploy and clean up | [One-Command Deployment](docs/10-one-command-deployment.md) |
-| Test a deployed Knowledge Source | [Post-Deployment Tests](docs/08-test-queries.md) |
-| Present the app click by click | [Guided Live Demo](docs/16-demo-walkthrough.md) |
-| Connect existing Fabric assets | [BYO Fabric Validation](docs/11-fabric-live-byo-validation.md) |
-| Inspect the evidence contract | [Offline Replay](docs/09-offline-replay.md) |
-| Troubleshoot a run | [Troubleshooting](docs/07-troubleshooting.md) |
-| Review safety boundaries | [Security and Governance](docs/06-security-governance.md) |
-| Check common questions | [FAQ](docs/19-faq.md) |
+The Airline Ops data is synthetic supporting material, not the main product surface. See the [Airline Ops Ontology Contract](samples/ontology/airline-ops/README.md).
 
 ## Repository Map
 
 ```text
 liveks, liveks.ps1     Cross-platform lifecycle entry points
 config/, profiles/    Canonical schema and executable profile defaults
-src/liveks/            Configuration, planning, deploy, verify, and cleanup CLI
+src/liveks/            Configuration, planning, deploy, verify, MCP, and cleanup CLI
 infra/                 Bicep for Azure AI Search, Azure OpenAI, Storage, and hosting
-scripts/               Hooks, compatibility wrappers, Fabric automation, validation
 static-app/            Pages replay UI and Azure Static Web Apps managed API
 samples/               REST, Python, responses, synthetic data, and ontology contract
 notebooks/             Guided MCP and Fabric walkthroughs
-docs/                  Concept, deployment, troubleshooting, and operations manual
+docs/                  Execution manual, concepts, troubleshooting, and operations
 ```
 
 Generated configuration, locks, deployment evidence, app builds, and logs stay under ignored `.liveks/`, `.deployment/`, `deployments/`, and build directories.
@@ -189,27 +214,16 @@ bash scripts/validate-local.sh
 git diff --check
 ```
 
-The gate checks CLI profiles and generated examples, Python contracts, notebooks, links, sample and repository hygiene, secrets, the Pages demo build, and Bicep.
+The gate checks configuration and CLI contracts, notebooks, links, sample and repository hygiene, secrets, the Pages demo build, Windows launcher behavior, and Bicep.
 
-Agent-readable commands support JSON output:
+## Official Microsoft Manuals
 
-```bash
-./liveks doctor --profile offline --format json
-./liveks plan --env liveks-mcp --format json
-```
-
-## Security Notes
-
-- Do not commit tenant IDs, service URLs, API keys, bearer tokens, raw live responses, generated reports, or private screenshots.
-- MCP Server KS requires a remote HTTPS MCP server. Local stdio MCP servers cannot be attached directly.
-- Fabric live retrieve requires a raw end-user Search token in `x-ms-query-source-authorization`; do not prefix it with `Bearer`.
-- Offline replay demonstrates response shape. It is not evidence of live Fabric retrieval.
-
-## Official Manuals
-
-- [Create an MCP Server knowledge source](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-mcp-server)
-- [Create a Fabric Ontology knowledge source](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-fabric-ontology)
-- [Create a knowledge base](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-create-knowledge-base)
-- [Query a knowledge base](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-retrieve)
+- [Agentic retrieval overview](https://learn.microsoft.com/en-us/azure/search/search-agentic-retrieval-concept)
+- [What is a Knowledge Source?](https://learn.microsoft.com/en-us/azure/search/agentic-knowledge-source-overview)
+- [Create an MCP Server knowledge source](https://learn.microsoft.com/en-us/azure/search/agentic-knowledge-source-how-to-mcp-server)
+- [Create a Fabric Ontology knowledge source](https://learn.microsoft.com/en-us/azure/search/agentic-knowledge-source-how-to-fabric-ontology)
+- [Create a Knowledge Base](https://learn.microsoft.com/en-us/azure/search/agentic-retrieval-how-to-create-knowledge-base)
+- [Query a Knowledge Base using retrieve or MCP](https://learn.microsoft.com/en-us/azure/search/agentic-retrieval-how-to-retrieve)
+- [Microsoft Fabric Ontology overview](https://learn.microsoft.com/en-us/fabric/iq/ontology/overview)
 
 Issues and PRs are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md), [SECURITY.md](SECURITY.md), and [SUPPORT.md](SUPPORT.md). This project is licensed under the [MIT License](LICENSE).

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -63,6 +63,9 @@ fields:
   search.mcp_knowledge_base_name:
     type: string
     azd: MCP_ONLY_KNOWLEDGE_BASE_NAME
+  search.fabric_knowledge_base_name:
+    type: string
+    azd: FABRIC_ONLY_KNOWLEDGE_BASE_NAME
   search.combined_knowledge_base_name:
     type: string
     azd: KNOWLEDGE_BASE_NAME
@@ -155,6 +158,7 @@ legacy_env:
   MCP_KNOWLEDGE_SOURCE_NAME: search.mcp_knowledge_source_name
   FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME: search.fabric_knowledge_source_name
   MCP_ONLY_KNOWLEDGE_BASE_NAME: search.mcp_knowledge_base_name
+  FABRIC_ONLY_KNOWLEDGE_BASE_NAME: search.fabric_knowledge_base_name
   KNOWLEDGE_BASE_NAME: search.combined_knowledge_base_name
   MCP_SERVER_URL: mcp.server_url
   MCP_TOOL_NAME: mcp.tool_name

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -28,6 +28,7 @@ The repo is designed for field demos, customer workshops, private product review
 | MCP Server KS | Calls explicitly allowed tools on a remote HTTPS MCP server at retrieve time. | [MCP Server Knowledge Source](03-mcp-server-ks.md) |
 | Fabric Ontology KS | Grounds retrieval in Fabric ontology entities, relationships, and governed semantic definitions. | [Fabric Ontology Knowledge Source](04-fabric-ontology-ks.md) |
 | Combined KB | Shows how one Knowledge Base can route across both live source types. | [Combined Knowledge Base Routing](05-combined-kb-routing.md) |
+| Knowledge Base MCP | Lets MCP-compatible clients invoke `knowledge_base_retrieve` on the deployed Knowledge Base. | [Call the Knowledge Base Through MCP](22-knowledge-base-mcp.md) |
 
 ## Deployment Modes
 

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -32,4 +32,16 @@ Southbound MCP Server KS:
   A Knowledge Base calls an external MCP server as a Knowledge Source.
 ```
 
-This repository focuses on the southbound MCP Server Knowledge Source pattern.
+The deployment demonstrates the southbound MCP Server Knowledge Source pattern. The execution manual also validates the northbound endpoint with `./liveks mcp`, so operators can prove the complete client-to-Knowledge-Source path without confusing the two MCP roles.
+
+For the representative managed-organization scenario:
+
+```text
+MCP client
+  -> Knowledge Base MCP endpoint
+    -> Foundry IQ planning and grounding
+      -> Fabric Ontology Knowledge Source
+  -> MCP text content
+```
+
+Use the retrieve API evidence from `./liveks verify` to prove that `fabricOntology` ran. The current native MCP result provides `result.content[]`, but not the retrieve API's separate `activity` and `references` arrays. Pair that trace with `./liveks mcp --expect-term <known-fact>` because a text block by itself proves only protocol execution.

--- a/docs/02-choose-a-pattern.md
+++ b/docs/02-choose-a-pattern.md
@@ -48,4 +48,4 @@ Use `mcp-only` unless the answer to one of these is yes:
 | Fabric Ontology KS | `samples/rest/04-create-fabric-ontology-ks.http` |
 | Combined Knowledge Base | `samples/rest/05-create-combined-kb.http` |
 
-Validate single-source Knowledge Bases first when deterministic source evidence matters. In a combined Knowledge Base, query-time `knowledgeSourceParams` provide source options and arguments; the returned `activity` and `references` are the evidence of what actually ran.
+Validate the MCP-only and Fabric-only Knowledge Bases first when deterministic source evidence matters. In a combined Knowledge Base, query-time `knowledgeSourceParams` provide source options and arguments; the returned `activity` and `references` are the evidence of what actually ran.

--- a/docs/06-security-governance.md
+++ b/docs/06-security-governance.md
@@ -25,6 +25,14 @@ flowchart LR
 - Monitor tool latency, failures, and output size.
 - Keep human oversight for actions that can affect real systems.
 
+## Knowledge Base MCP Client
+
+- The default `./liveks mcp --auth admin-key` path is a sample-development convenience. It reads the key transiently through Azure CLI, never prints it, and never persists raw MCP content.
+- Prefer `--auth bearer` for organization-managed clients after assigning **Search Index Data Reader** to the client identity.
+- Fabric calls need a separate raw user token in `x-ms-query-source-authorization`; the `Authorization` bearer token and source-authorization token have different roles even when acquired for the same user.
+- Keep the generated count-only report under ignored `deployments/`. Do not publish prompts, raw tool content, endpoints, or external error bodies.
+- Review the [Microsoft Learn MCP security guidance](https://learn.microsoft.com/en-us/azure/search/agentic-retrieval-how-to-retrieve#call-the-mcp-endpoint) before connecting an agent runtime.
+
 ## Fabric Ontology KS
 
 - Validate Fabric workspace and ontology permissions.

--- a/docs/07-troubleshooting.md
+++ b/docs/07-troubleshooting.md
@@ -49,6 +49,15 @@ Start with machine-readable diagnostics:
 - Increase `maxRuntimeInSeconds` if the tool is slow.
 - Use query-time header passthrough for per-user credentials.
 
+## Knowledge Base MCP Client Fails
+
+- Run `./liveks verify --env <environment>` first. The MCP client is not a substitute for source readiness checks.
+- HTTP `401` or `403`: for `--auth bearer`, assign **Search Index Data Reader** and reacquire the token; for the sample admin-key path, confirm Azure CLI can read the Search service keys.
+- HTTP `404`: confirm the selected `azd` environment contains the current Search endpoint, Knowledge Base name, and API version.
+- A normalized tool error on a Fabric profile usually means delegated source authorization is missing, expired, or not permitted to query the ontology.
+- An expected-term mismatch means content returned but the known fact was absent. Check the question and connected ontology rather than treating the transport as failed.
+- The count-only report is `deployments/<environment>/mcp-call-report.json`. Raw MCP responses are intentionally not stored.
+
 ## Fabric Ontology KS Fails
 
 - Confirm the Fabric workspace ID and ontology ID.

--- a/docs/08-test-queries.md
+++ b/docs/08-test-queries.md
@@ -97,7 +97,7 @@ REST equivalent: `samples/rest/03-retrieve-mcp.http`.
 
 ## Test 2: Fabric Ontology KS
 
-This test applies to `byo-fabric` and `full`. In `mcp-only`, an offline response explaining that Fabric was not created is expected and is not a live Fabric pass.
+This test applies to `byo-fabric` and `full`. Those profiles create a Fabric-only Knowledge Base so source execution is deterministic before combined routing. In `mcp-only`, an offline response explaining that Fabric was not created is expected and is not a live Fabric pass.
 
 The packaged app question targets the repo's Airline Ops ontology contract. `full` creates that sample. For `byo-fabric`, the Alpine Air answer is expected only when the connected ontology maps the same sample data and relationships. With another ontology, require live Fabric trace evidence and validate the answer against that ontology's known facts; use the REST sample or Fabric notebook to submit a domain-specific question.
 
@@ -194,6 +194,25 @@ Do not use source badges alone to claim that both live sources ran. Require `mod
 
 REST equivalent: `samples/rest/08-retrieve-combined-airline-ops.http`.
 
+## Test 4: Native Knowledge Base MCP
+
+Run this only after the applicable single-source test has passed. The retrieve trace proves which Knowledge Source ran; the native MCP call proves that an MCP-compatible client can consume the same Knowledge Base.
+
+For the synthetic Airline Ops contract:
+
+```bash
+./liveks mcp \
+  --env <environment> \
+  --query "Which airlines have the highest customer-care exposure this month?" \
+  --expect-term "Alpine Air"
+```
+
+Require `tools-list=pass`, `tools-call=pass`, and `grounding-content=pass`. For a non-Airline Ops BYO ontology, replace both the question and expected term with a non-sensitive known fact from that ontology. A protocol pass with `grounding-content=warn` is not source-content acceptance.
+
+The current MCP result does not return separate `activity` and `references` arrays. Do not use this test by itself to claim that Fabric or MCP Server KS ran. Pair it with the matching source-specific retrieve test above.
+
+See [Call the Knowledge Base Through MCP](22-knowledge-base-mcp.md) for authentication and normalized failure tests.
+
 ## What Each Result Lets You Claim
 
 | Observed evidence | Supported claim |
@@ -203,6 +222,7 @@ REST equivalent: `samples/rest/08-retrieve-combined-airline-ops.http`.
 | Both single-source tests pass | Both live Knowledge Source paths are independently operational. |
 | Combined test is live and its trace contains both source types | This retrieve call used both grounding paths. |
 | Combined test is live and contains one source type | Planner routing worked, but this call does not prove that both sources ran. |
+| Native MCP call matches a known fact after a source-specific retrieve pass | An MCP client consumed expected grounding content from the same operational Knowledge Base. |
 | Any result is offline or offline-replay | Only the packaged response shape and inspection experience are demonstrated. |
 
 ## Pass/Fail Checklist

--- a/docs/10-one-command-deployment.md
+++ b/docs/10-one-command-deployment.md
@@ -69,14 +69,14 @@ Automation can use `--yes`. Full mode still requires the separate cost acknowled
 | Profile | Azure resources | Fabric behavior |
 | --- | --- | --- |
 | `mcp-only` | Search, OpenAI, Storage, app, MCP KS, MCP-only KB, sample index | Skipped |
-| `byo-fabric` | Same Azure assets plus Fabric KS and combined KB | Existing workspace/ontology reused |
-| `full` | Same Azure assets plus generated Fabric KS and combined KB | F2 capacity, workspace, Lakehouse, ontology, and GraphModel created |
+| `byo-fabric` | Same Azure assets plus Fabric KS, Fabric-only KB, and combined KB | Existing workspace/ontology reused |
+| `full` | Same Azure assets plus generated Fabric KS, Fabric-only KB, and combined KB | F2 capacity, workspace, Lakehouse, ontology, and GraphModel created |
 
 The Search managed identity receives Azure OpenAI access for answer synthesis. The default frontend is Azure Static Web Apps with a managed Node.js API, which keeps Search and OpenAI credentials out of browser code.
 
 ## Fabric Full Details
 
-Full mode creates the Fabric stack before `azd up` so long Lakehouse and GraphModel readiness work does not run inside the Azure postprovision timeout. Generated IDs are projected into the selected `azd` environment, then postprovision creates the Fabric Ontology KS and combined KB.
+Full mode creates the Fabric stack before `azd up` so long Lakehouse and GraphModel readiness work does not run inside the Azure postprovision timeout. Generated IDs are projected into the selected `azd` environment, then postprovision creates the Fabric Ontology KS, Fabric-only KB, and combined KB.
 
 Each fresh run clears stale generated IDs, resolves the assets created for the environment by name, and waits through the initial OneLake metadata propagation window. During Azure deployment, Bicep consumes the preprovisioned capacity as an existing asset; the YAML ledger remains `fabric.mode: create` so cleanup ownership stays explicit.
 

--- a/docs/11-fabric-live-byo-validation.md
+++ b/docs/11-fabric-live-byo-validation.md
@@ -41,7 +41,7 @@ Do not add a `Bearer` prefix.
 
 The BYO doctor check uses a transient Fabric API token to read the configured workspace and ontology. A missing asset or tenant permission therefore fails before `azd up`; no token is written to YAML, the lock, or `azd env`.
 
-The generated deployment summary should identify the Fabric KS and combined KB without exposing workspace or ontology IDs publicly.
+The generated deployment summary should identify the Fabric KS, Fabric-only KB, and combined KB without exposing workspace or ontology IDs publicly.
 
 ## Verify
 

--- a/docs/13-public-preview-limitations.md
+++ b/docs/13-public-preview-limitations.md
@@ -38,6 +38,20 @@ MCP Server KS is the lowest-friction first path in this repo, but it still has i
 
 This repo uses Microsoft Learn MCP as the default remote MCP server because it is public, official, and does not require tenant-specific setup for a first run.
 
+## Knowledge Base MCP Endpoint Caveats
+
+The northbound Knowledge Base MCP endpoint has a different evidence shape from the retrieve API:
+
+- `tools/list` exposes `knowledge_base_retrieve`.
+- `tools/call` returns MCP `result.content[]` text blocks.
+- The current MCP result does not return separate `activity` and `references` arrays.
+- The current tool input schema accepts one `queries` array and rejects additional properties. Retrieve-only `knowledgeSourceParams`, including `alwaysQuerySource`, cannot be passed through the MCP tool call.
+- A successful text result proves protocol execution, not source execution. Source-specific REST activity and a known-fact MCP match are required for a grounded-source claim.
+- Admin-key authentication is supported for this sample but grants broad Search access. Prefer bearer authentication and **Search Index Data Reader** for managed clients.
+- Fabric-backed calls still require delegated source authorization in addition to Search service authentication.
+
+Use `./liveks mcp --expect-term <known-non-sensitive-fact>` for count-only content evidence and normalized failures; do not publish raw MCP content. A run without `--expect-term` intentionally reports grounding as unverified.
+
 ## Fabric Ontology KS Caveats
 
 Fabric Ontology KS is the strongest semantic-grounding path, but it has more setup requirements:

--- a/docs/19-faq.md
+++ b/docs/19-faq.md
@@ -4,11 +4,11 @@ Use this page when you need quick answers before choosing a deployment mode, run
 
 ## Which mode should I run first?
 
-Run `mcp-only` first.
+Run `mcp-only` first when you are learning the repository or do not already have Fabric semantic assets.
 
 It validates Azure AI Search MCP Server Knowledge Source behavior with Microsoft Learn MCP and does not require Fabric workspace or ontology setup.
 
-Move to `byo-fabric` when you already have Fabric workspace and ontology IDs. Use `full` when you want the greenfield platform story and have checked Fabric quota, region, tenant settings, and source authorization requirements.
+For a managed organization that already has a Fabric workspace and ontology, the representative live acceptance path is `byo-fabric`: prove one Fabric source, then call the Knowledge Base through MCP. Use `full` when you want the greenfield platform story and have checked Fabric quota, region, tenant settings, and source authorization requirements.
 
 ## Why does the repo have three modes?
 
@@ -66,6 +66,15 @@ Not directly.
 
 Azure AI Search MCP Server KS needs a remote MCP-compatible HTTPS endpoint that Azure AI Search can reach. Local stdio MCP servers are useful for local agent workflows, but they are not directly attachable as Azure AI Search MCP Server Knowledge Sources.
 
+## Is the Knowledge Base MCP endpoint the same as MCP Server KS?
+
+No. They point in opposite directions.
+
+- The native Knowledge Base MCP endpoint lets an MCP client call `knowledge_base_retrieve`.
+- MCP Server KS lets the Knowledge Base call an external HTTPS MCP tool during retrieval.
+
+Use `./liveks verify` to prove which Knowledge Source ran, then `./liveks mcp` to prove that an MCP client can consume the Knowledge Base. The current MCP tool result does not expose the retrieve API's separate activity and references arrays.
+
 ## Why use Microsoft Learn MCP for the first sample?
 
 Microsoft Learn MCP is public, official, and does not require tenant-specific setup for the first run.
@@ -79,7 +88,7 @@ Treat `knowledgeSourceParams` as source-specific runtime options, not as a stric
 For deterministic validation, use a single-source Knowledge Base:
 
 - MCP-only KB for MCP Server KS validation.
-- Fabric or combined KB for Fabric and multi-source validation.
+- Fabric-only KB for deterministic Fabric validation, then the combined KB for multi-source routing.
 
 When presenting combined routing, inspect `activity`, `references`, and source-specific data instead of assuming source selection from the final answer text.
 

--- a/docs/20-liveks-cli.md
+++ b/docs/20-liveks-cli.md
@@ -30,6 +30,7 @@ PowerShell equivalents replace `./liveks` with `./liveks.ps1`.
 | `plan` | None | Run doctor, build Bicep, dry-run payloads, build the app, and write a redacted lock. |
 | `up` | Yes, after confirmation | Sync the selected `azd` environment, preview ARM changes, provision, deploy, and verify. |
 | `verify` | Read/call only | Check the resource group, app API, and source evidence. |
+| `mcp` | Read/call only | Discover and call `knowledge_base_retrieve` on the deployed Knowledge Base MCP endpoint. |
 | `down` | Yes, after confirmation | Delete only assets owned by the environment. |
 | `e2e` | Yes | Run `up` and either clean up or explicitly retain resources. |
 
@@ -43,6 +44,7 @@ PowerShell equivalents replace `./liveks` with `./liveks.ps1`.
 ./liveks plan --env liveks-mcp
 ./liveks up --env liveks-mcp
 ./liveks verify --env liveks-mcp
+./liveks mcp --env liveks-mcp
 ./liveks down --env liveks-mcp
 ```
 
@@ -55,6 +57,8 @@ Use JSON output when cleanup evidence will be reviewed:
 ```
 
 Every live profile must report `resource-group-absent=pass`. A `full` run that created capacity must additionally report `fabric-capacity-resource-group-absent=pass` and `fabric-capacity-absent=pass`. These checks are omitted for reused capacity so preservation is not misreported as failed deletion.
+
+For `byo-fabric` and `full`, `mcp` attaches delegated source authorization by default. It records text-block and expected-term counts but never persists the endpoint, query, response content, key, or token. A call without `--expect-term` can pass protocol checks but reports `grounding-content=warn`; use a known non-sensitive fact for source-content acceptance. See [Call the Knowledge Base Through MCP](22-knowledge-base-mcp.md).
 
 ## Confirmation Rules
 

--- a/docs/21-configuration.md
+++ b/docs/21-configuration.md
@@ -126,6 +126,20 @@ The parser accepts dotenv-style assignments but does not execute command substit
 
 Generated `.env.sample` and `env/*.env.example` files remain for REST, notebook, and v1 compatibility. They are produced from the YAML schema and profiles by `scripts/generate_env_examples.py`; they are not the v2 configuration authority.
 
+## Native MCP Client Inputs
+
+`./liveks mcp --env <environment>` derives the Search endpoint, API version, Knowledge Base name, resource group, and service name from the selected deployment. Do not duplicate them in a dotenv file.
+
+Authentication is acquired at call time:
+
+- `--auth admin-key` reads the sample deployment's Search key through Azure CLI and keeps it in memory only.
+- `--auth bearer` acquires an Azure AI Search bearer token for an identity with **Search Index Data Reader**.
+- Fabric profiles acquire a separate user token and send its raw value in `x-ms-query-source-authorization`.
+
+The generated MCP report contains counts and normalized statuses only. It does not contain the endpoint, query, expected terms, response content, key, or token.
+
+`--query` and repeatable `--expect-term` values are runtime acceptance inputs, not deployment configuration. Supply a known non-sensitive fact when validating Fabric-backed MCP content. Without an expected term, the command validates protocol execution and reports grounding as unverified.
+
 ## Safe Review
 
 ```bash

--- a/docs/22-knowledge-base-mcp.md
+++ b/docs/22-knowledge-base-mcp.md
@@ -1,0 +1,159 @@
+# Call The Knowledge Base Through MCP
+
+This page covers the northbound MCP path: an MCP client calls the Knowledge Base, and Foundry IQ retrieves from the Knowledge Sources attached to that Knowledge Base.
+
+It is different from the southbound MCP Server Knowledge Source, where Foundry IQ calls a remote HTTPS MCP server.
+
+## Client Contract
+
+Every Azure AI Search Knowledge Base exposes this endpoint:
+
+```text
+https://<search-service>.search.windows.net/knowledgebases/<knowledge-base>/mcp?api-version=2026-05-01-preview
+```
+
+The endpoint publishes one tool named `knowledge_base_retrieve`. The repository client sends stateless JSON-RPC 2.0 requests over HTTP and accepts either JSON or server-sent event responses.
+
+The implementation follows the current [Microsoft Learn retrieve and MCP contract](https://learn.microsoft.com/en-us/azure/search/agentic-retrieval-how-to-retrieve). Preview behavior can change; that article remains authoritative.
+
+## Run A Live Call
+
+Prerequisites:
+
+- A passing `./liveks verify --env <environment>` run.
+- Azure CLI access to the deployed Search service.
+- For `byo-fabric` or `full`, delegated access to the Fabric ontology.
+
+Call the profile's deterministic single-source Knowledge Base. `mcp-only` selects the MCP-only KB; `byo-fabric` and `full` select the Fabric-only KB:
+
+```bash
+./liveks mcp --env liveks-byo
+```
+
+This no-expectation form proves endpoint discovery and tool execution only. Because the MCP response has no separate source trace, the command reports `grounding-content=warn` until a known fact is supplied.
+
+For the synthetic Airline Ops scenario, make the expected result executable:
+
+```bash
+./liveks mcp \
+  --env liveks-byo \
+  --query "Which airlines have the highest customer-care exposure this month?" \
+  --expect-term "Alpine Air"
+```
+
+Repeat `--expect-term` when several non-sensitive facts must be present. The command checks terms in memory, then stores counts only. It never writes the query, matched text, response content, service endpoint, key, or token to the report.
+
+The ignored report is written to:
+
+```text
+deployments/<environment>/mcp-call-report.json
+```
+
+## Authentication Modes
+
+### Sample Deployment Default
+
+```bash
+./liveks mcp --env liveks-byo --auth admin-key
+```
+
+The command reads the primary Search admin key through Azure CLI and keeps it in process memory only. This matches the sample app's local-auth deployment contract, but an admin key has full Search data-plane privileges and is not the preferred production client credential.
+
+### Organization-Managed Identity
+
+```bash
+./liveks mcp --env liveks-byo --auth bearer
+```
+
+The active Azure CLI identity must have **Search Index Data Reader** on the Search service. The client acquires a token scoped to `https://search.azure.com/.default` and sends it in the `Authorization` header.
+
+For `byo-fabric` and `full`, the client separately acquires a user Search token and sends the raw value in `x-ms-query-source-authorization`. It does not add a `Bearer` prefix to that source-authorization header.
+
+## Evidence Contract
+
+`./liveks mcp` performs two protocol calls and one optional content check:
+
+1. `tools/list` must publish `knowledge_base_retrieve`.
+2. `tools/call` must return at least one text content block without a JSON-RPC or tool error.
+3. When `--expect-term` is supplied, every expected term must occur in the returned content.
+
+The report is intentionally narrow:
+
+```json
+{
+  "command": "mcp",
+  "status": "pass",
+  "checks": [
+    {
+      "name": "tools-list",
+      "status": "pass",
+      "message": "Knowledge Base publishes knowledge_base_retrieve."
+    },
+    {
+      "name": "tools-call",
+      "status": "pass",
+      "contentBlocks": 1
+    },
+    {
+      "name": "grounding-content",
+      "status": "pass",
+      "expectedTermCount": 1,
+      "matchedExpectedTermCount": 1
+    }
+  ]
+}
+```
+
+The native MCP response currently differs from the retrieve API response: it returns `result.content[]` and does not provide separate `activity` or `references` arrays. The published tool schema accepts exactly one `queries` array and rejects additional properties, so a client cannot add retrieve-only `knowledgeSourceParams` such as `alwaysQuerySource`. Use `./liveks verify` first to prove `fabricOntology` or `mcpServer` source execution, then require a known-fact match from `./liveks mcp` before claiming grounded MCP content. See the official [retrieve and MCP contract](https://learn.microsoft.com/en-us/azure/search/agentic-retrieval-how-to-retrieve).
+
+## Reproduce A Failure
+
+For a Fabric profile, omit delegated source authorization deliberately:
+
+```bash
+./liveks mcp \
+  --env liveks-byo \
+  --omit-source-authorization \
+  --expect-failure
+```
+
+The command succeeds only if the MCP call fails. It normalizes the external error instead of printing the raw response:
+
+```text
+[PASS] tools-call: Expected failure reproduced: knowledge_base_retrieve returned a tool error; check source authorization and source readiness.
+```
+
+Other normalized failures include:
+
+| Message | Check |
+| --- | --- |
+| `Azure AI Search rejected MCP authentication (HTTP 401/403).` | Client credential, role assignment, and token audience. |
+| `The Knowledge Base MCP endpoint was not found (HTTP 404).` | Search endpoint, Knowledge Base name, and API version. |
+| `The Knowledge Base or one of its sources failed (HTTP 5xx).` | Source readiness, delegated authorization, throttling, and dependency availability. |
+| `MCP content matched N/M expected term(s).` with `grounding-content=fail` | Query suitability, source selection, source readiness, and expected facts for the connected ontology. |
+
+Do not use `--expect-failure` as a health check. It exists to demonstrate a known boundary in a controlled environment.
+
+## Acceptance Sequence
+
+```bash
+./liveks verify --env liveks-byo --format json
+./liveks mcp \
+  --env liveks-byo \
+  --query "Which airlines have the highest customer-care exposure this month?" \
+  --expect-term "Alpine Air"
+./liveks mcp \
+  --env liveks-byo \
+  --omit-source-authorization \
+  --expect-failure
+```
+
+Accept the scenario only when:
+
+- `verify` reports live `fabricOntology` evidence,
+- the MCP tool is discoverable,
+- the MCP result contains the known synthetic fact,
+- the missing-authorization run produces a normalized failure,
+- no raw response or secret appears in tracked files.
+
+For an arbitrary BYO ontology, replace both the question and `--expect-term` with a known, non-sensitive domain fact. A fluent no-data answer, a text block without an expectation, or `grounding-content=warn` is not an accepted Fabric-through-MCP result.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,97 +1,187 @@
 # Foundry IQ Live Knowledge Sources
 
-Deploy and inspect MCP Server and Fabric Ontology Knowledge Sources through one Foundry IQ Knowledge Base, with evidence showing which source answered.
+Platform teams connect a governed Fabric Ontology or remote HTTPS MCP tool, submit a natural-language question to a Foundry IQ Knowledge Base, and receive a grounded result that can be inspected through REST and consumed through MCP.
 
-[Open the combined trace demo](https://microsoft.github.io/azure-ai-search-foundry-iq-live-knowledge-sources/demo/?demo=combined){ .md-button .md-button--primary }
-[Start the runbook](runbook.md){ .md-button }
+[Run the managed-organization path](runbook.md){ .md-button .md-button--primary }
+[Inspect the offline trace](09-offline-replay.md){ .md-button }
 
-## First Run
+The representative path below reuses an existing Fabric workspace and ontology. It proves one source first, then calls the same Knowledge Base through its native MCP endpoint. It does not publish Fabric identifiers, tokens, endpoints, or raw live responses.
 
-No Azure subscription, tenant, Fabric workspace, or key is required:
+## Components At A Glance
+
+| Component | Role in the representative path | Immediate evidence |
+| --- | --- | --- |
+| Domain input | `Which airlines have the highest customer-care exposure this month?` | One stable question is reused for REST and MCP. |
+| Fabric Ontology Knowledge Source | Resolves governed Airline Ops entities and relationships at query time. | REST activity or references include `type: fabricOntology`. |
+| Foundry IQ Knowledge Base | Plans retrieval and synthesizes the grounded result. | A live response contains answer content plus inspectable source evidence. |
+| Retrieve API | Provides the auditable envelope used to prove source execution. | `activity`, `references`, and `sourceData` can be checked independently. |
+| Knowledge Base MCP endpoint | Exposes `knowledge_base_retrieve` to MCP-compatible clients. | `tools/list` publishes the tool, `tools/call` returns text, and a known-fact check proves useful grounding content. |
+| LiveKS CLI | Validates, plans, deploys, verifies, calls MCP, and cleans up. | Every command returns a status and nonzero failures. |
+
+Two MCP directions are involved. The Fabric path does not route through the external MCP Server Knowledge Source:
+
+```text
+Northbound: MCP client -> Knowledge Base MCP endpoint -> Foundry IQ -> Fabric Ontology KS
+Southbound: Foundry IQ Knowledge Base -> MCP Server KS -> remote HTTPS MCP tool
+```
+
+## Run One Live Knowledge Source
+
+Use `byo-fabric` when the organization already owns the Fabric workspace and ontology. The generated Azure resources can be deleted later; the existing Fabric assets are preserved.
 
 ```bash
 git clone --depth 1 https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources.git
 cd azure-ai-search-foundry-iq-live-knowledge-sources
-./liveks try
+./liveks bootstrap
+./liveks init --profile byo-fabric --env liveks-byo
 ```
 
-The command prints the combined answer first and then identifies the MCP and Fabric evidence. Use `./liveks try --details` for the full `activity`, `references`, and `sourceData` trace.
+Edit the ignored `.liveks/liveks-byo.yaml` ledger:
 
-## From Replay To Live
+```yaml
+version: 2
+profile: byo-fabric
+environment: liveks-byo
+azure:
+  location: eastus
+fabric:
+  workspace_id: 11111111-1111-1111-1111-111111111111
+  ontology_id: 22222222-2222-2222-2222-222222222222
+```
+
+The GUIDs are resource identifiers, not secrets, but this repository still keeps tenant-specific values in ignored local files. A delegated source token is acquired transiently during verification; do not paste it into YAML.
 
 ```bash
-./liveks bootstrap
-./liveks init --profile mcp-only --env liveks-mcp
-./liveks doctor --env liveks-mcp
-./liveks plan --env liveks-mcp
-./liveks up --env liveks-mcp
+az login --tenant <tenant-guid>
+azd auth login
+./liveks doctor --env liveks-byo
+./liveks plan --env liveks-byo
+./liveks up --env liveks-byo
 ```
 
-The YAML ledger is written to ignored `.liveks/liveks-mcp.yaml`. `plan` performs local and read-only cloud checks; `up` previews changes and asks for explicit confirmation before provisioning.
+`plan` is non-provisioning. `up` displays the Azure preview and cost context, then requires `create liveks-byo` before it creates resources. Postprovision attaches the Fabric source to a Fabric-only Knowledge Base for isolated validation and to the combined Knowledge Base for routing tests. The first live pass is not the deployment message; it is `fabricOntology` evidence from a retrieve call.
 
-| Profile | Reader state | First success signal |
-| --- | --- | --- |
-| `offline` | I want to understand the evidence contract now. | Answer plus MCP and Fabric source badges. |
-| `mcp-only` | I want the fastest live Knowledge Source validation. | Retrieve evidence names `microsoft_docs_search`. |
-| `byo-fabric` | I have a Fabric workspace and ontology. | Separate checks prove Fabric and MCP; the combined KB returns planner-selected evidence. |
-| `full` | I need a greenfield platform demo. | Generated Fabric GraphModel, both KS paths, app, and cleanup pass. |
+No existing Fabric ontology? Start with `mcp-only` and the [MCP Server KS path](03-mcp-server-ks.md). Use `full` only for an explicitly approved greenfield run because it creates a billable Fabric F2 capacity.
 
-The safe default progression is `offline -> mcp-only -> byo-fabric`. Use `full` only after checking Fabric quota, cost, tenant settings, and cleanup expectations.
+## Confirm Foundry IQ Grounding
 
-## After Deployment: Prove It Live
+Run the source-level verifier before testing combined routing:
 
-`liveks up` provisions and verifies the environment, but the first user-facing success moment happens in the deployed app:
+```bash
+./liveks verify --env liveks-byo --format json
+```
 
-1. Open the App URL from `deployments/<environment>/deployment-summary.md`.
-2. Confirm the deployment status is live.
-3. Select **MCP Live**, **Fabric**, or **Combined Trace**.
-4. Select **Run retrieve**.
-5. Require a `live` answer and inspect `activity`, `references`, and `sourceData` for the expected source.
+For the checked-in Airline Ops ontology contract, the verifier submits:
 
-[Follow the click-by-click live demo](16-demo-walkthrough.md){ .md-button .md-button--primary }
-[Choose test queries and pass criteria](08-test-queries.md){ .md-button }
+```text
+Which airlines have the highest customer-care exposure this month?
+```
 
-An `offline` or `offline-replay` result is useful for learning the response contract, but it does not prove that a live Knowledge Source ran.
+A sanitized pass contains these checks:
 
-## Composition Model
+```json
+{
+  "checks": [
+    {
+      "name": "fabric-retrieve",
+      "status": "pass",
+      "message": "Live Fabric ontology evidence returned"
+    },
+    {
+      "name": "knowledge-base-mcp",
+      "status": "warn",
+      "message": "MCP protocol content returned, but source grounding was not content-verified; repeat with --expect-term using a known non-sensitive fact."
+    }
+  ],
+  "status": "pass"
+}
+```
 
-![Live Knowledge Sources Architecture](assets/live-knowledge-sources-architecture.svg)
+The auditable REST evidence must include `fabricOntology` in `activity` or `references`. For the sample ontology, `sourceData` also contains `fabricAnswer` and `fabricRawData`. A useful answer without that source evidence does not prove live Fabric grounding.
 
-One question is routed through a Foundry IQ Knowledge Base to several live Knowledge Sources. The final answer is accompanied by:
+If a BYO ontology uses another domain, replace the question and expected fact with a known ontology fact. Do not force the Airline Ops expectation onto unrelated organizational data.
 
-- `activity`: which source and tool ran,
-- `references`: what evidence was returned,
-- `sourceData`: source-specific evidence for audit and citation handling.
+[Use the full source-level acceptance checklist](08-test-queries.md){ .md-button .md-button--primary }
 
-The app and CLI replay use the same canonical response fixtures as the serverless API. Pages runs in clearly labeled offline replay mode; an Azure deployment switches the same interface to live retrieval.
+## Call It Through MCP
 
-## Manual Map
+Each Knowledge Base is also a native MCP server. After the REST evidence proves the Fabric source independently, call the same Fabric-only Knowledge Base and business question through `knowledge_base_retrieve`:
 
-| Task | Page |
+```bash
+./liveks mcp \
+  --env liveks-byo \
+  --query "Which airlines have the highest customer-care exposure this month?" \
+  --expect-term "Alpine Air"
+```
+
+The command performs `tools/list`, invokes `tools/call`, and records only sanitized counts under the ignored `deployments/liveks-byo/` directory:
+
+```text
+LiveKS mcp: PASS
+[PASS] tools-list: Knowledge Base publishes knowledge_base_retrieve.
+[PASS] tools-call: knowledge_base_retrieve returned 1 text block(s).
+[PASS] grounding-content: MCP content matched 1/1 expected term(s).
+```
+
+Use this sample expectation only for an Airline Ops ontology. A different BYO ontology needs its own known-answer question and non-sensitive expected fact. Running without `--expect-term` validates transport and tool execution but deliberately leaves grounding at `WARN`.
+
+The sample deployment uses a transient Search admin key by default because it already uses local Search authentication. The key is never printed or persisted. For an organization-managed client identity with the **Search Index Data Reader** role, use the recommended bearer path:
+
+```bash
+./liveks mcp --env liveks-byo --auth bearer
+```
+
+Reproduce the delegated-authorization boundary without exposing the service response:
+
+```bash
+./liveks mcp \
+  --env liveks-byo \
+  --omit-source-authorization \
+  --expect-failure
+```
+
+Expected normalized output:
+
+```text
+[PASS] tools-call: Expected failure reproduced: knowledge_base_retrieve returned a tool error; check source authorization and source readiness.
+```
+
+The current MCP result contains `result.content[]`, not the retrieve API's separate `activity` and `references` arrays. Its tool schema accepts only a single `queries` array, so retrieve-only `knowledgeSourceParams` cannot be forced from this client call. Therefore, the acceptance proof is the pair: source-specific REST evidence first, then an MCP known-fact match for the same Knowledge Base and question.
+
+[Read the native MCP client contract](22-knowledge-base-mcp.md){ .md-button }
+
+## Configuration And Known Limitations
+
+| Concern | Supported contract |
 | --- | --- |
-| Run the complete lifecycle | [Execution Runbook](runbook.md) |
-| Choose a profile | [Choose a Pattern](02-choose-a-pattern.md) |
-| Understand commands and exit codes | [LiveKS CLI](20-liveks-cli.md) |
-| Manage YAML and secrets | [Configuration](21-configuration.md) |
-| Deploy and clean up | [One-Command Deployment](10-one-command-deployment.md) |
-| Test the deployed sources | [Post-Deployment Tests](08-test-queries.md) |
-| Present the demo click by click | [Guided Live Demo](16-demo-walkthrough.md) |
-| Connect existing Fabric | [BYO Fabric Validation](11-fabric-live-byo-validation.md) |
-| Diagnose failures | [Troubleshooting](07-troubleshooting.md) |
-| Review safety boundaries | [Security and Governance](06-security-governance.md) |
+| Authoring source | `.liveks/<environment>.yaml`; profile defaults fill omitted values. |
+| Secrets | Use `{env: VARIABLE_NAME}` references. Raw values never belong in YAML, git, or reports. |
+| Fastest live path | `mcp-only`; Azure sign-in is required and profile defaults are runnable. |
+| Managed organization path | `byo-fabric`; `fabric.workspace_id` and `fabric.ontology_id` are required. |
+| Greenfield path | `full`; Fabric quota and `--accept-fabric-capacity` are required. |
+| API contract | Pinned to `2026-05-01-preview`; Microsoft Learn is authoritative when behavior changes. |
+| MCP evidence | Text content proves protocol execution; a known-fact match plus REST activity is required to claim source grounding. |
+| Fabric authorization | A raw end-user Search token is sent in `x-ms-query-source-authorization`, without a `Bearer` prefix. |
+| BYO ownership | Cleanup deletes generated Azure resources and preserves the existing Fabric workspace and ontology. |
 
-!!! note "Public preview"
-    Azure AI Search Knowledge Source APIs are pinned to `2026-05-01-preview`. Use Microsoft Learn as the source of truth when preview behavior changes. This accelerator packages runnable configuration, deployment, samples, notebooks, and evidence around those APIs.
+Continue with [Configuration](21-configuration.md), [Security and Governance](06-security-governance.md), [Troubleshooting](07-troubleshooting.md), and [Public Preview Limitations](13-public-preview-limitations.md). When the rehearsal is complete:
+
+```bash
+./liveks down --env liveks-byo
+```
+
+Require `resource-group-absent` before closing the run.
 
 ## Official Microsoft Manuals
 
 | Need | Manual |
 | --- | --- |
-| Agentic retrieval | [Agentic Retrieval Overview](https://learn.microsoft.com/en-us/azure/search/agentic-retrieval-overview) |
-| Knowledge Sources | [Knowledge Source Overview](https://learn.microsoft.com/en-us/azure/search/agentic-knowledge-source-overview) |
-| MCP Server KS | [Create an MCP Server knowledge source](https://learn.microsoft.com/en-us/azure/search/agentic-knowledge-source-how-to-mcp-server) |
+| Agentic retrieval and Foundry IQ | [Agentic retrieval overview](https://learn.microsoft.com/en-us/azure/search/search-agentic-retrieval-concept) |
+| Knowledge Sources | [What is a Knowledge Source?](https://learn.microsoft.com/en-us/azure/search/agentic-knowledge-source-overview) |
 | Fabric Ontology KS | [Create a Fabric Ontology knowledge source](https://learn.microsoft.com/en-us/azure/search/agentic-knowledge-source-how-to-fabric-ontology) |
+| MCP Server KS | [Create an MCP Server knowledge source](https://learn.microsoft.com/en-us/azure/search/agentic-knowledge-source-how-to-mcp-server) |
 | Knowledge Base | [Create a Knowledge Base](https://learn.microsoft.com/en-us/azure/search/agentic-retrieval-how-to-create-knowledge-base) |
-| Retrieve | [Query a Knowledge Base](https://learn.microsoft.com/en-us/azure/search/agentic-retrieval-how-to-retrieve) |
+| REST and native MCP calls | [Query a Knowledge Base using retrieve or MCP](https://learn.microsoft.com/en-us/azure/search/agentic-retrieval-how-to-retrieve) |
+| Fabric Ontology | [Microsoft Fabric Ontology overview](https://learn.microsoft.com/en-us/fabric/iq/ontology/overview) |
 
-Do not publish tenant IDs, keys, tokens, raw live responses, generated reports, or private screenshots. Share sanitized source names, counts, statuses, and cleanup evidence.
+Do not publish tenant IDs, keys, tokens, raw live responses, generated reports, or private screenshots. Public evidence is limited to sanitized status, source type, expected-term counts, and cleanup outcome.

--- a/docs/maintainers/langflow-benchmark-adaptation.md
+++ b/docs/maintainers/langflow-benchmark-adaptation.md
@@ -1,0 +1,113 @@
+# Langflow Benchmark Adaptation Record
+
+This maintainer record documents why and how an external repository journey was adapted. It is not included in the GitHub Pages navigation and is not a claim that the external repository caused this project's adoption or quality.
+
+## Selection Rationale
+
+Benchmark cutoff: `2026-08-06`.
+
+In the supplied candidate-ranking snapshot, `langflow-ai/langflow` had the highest `hot_score` at `757.4`, with `152,865` stars, a push age of `0` days at collection time, and `fit_score` `101`. These values indicate current attention and activity in that supplied snapshot. They do not establish that README structure, CI, or any other observed repository feature caused the popularity.
+
+The ranking data was supplied for this task. It was not independently recomputed by this repository.
+
+## Verifiable Scope
+
+Research is limited to the supplied snapshots of:
+
+- `langflow-ai/langflow/README.md`,
+- the repository file listing,
+- `.github/workflows/*`.
+
+Studied observations:
+
+- the README value proposition and section order,
+- the Quickstart installation, execution, and success-check contract,
+- API, JSON, and MCP as post-success extension surfaces,
+- workflow separation used to guard installation, accessibility, and security regressions.
+
+Explicitly not studied:
+
+- visual builder internal state management,
+- the agent-orchestration engine,
+- concrete API server implementation,
+- concrete MCP server implementation,
+- Desktop packaging code.
+
+Those core-code snapshots were not supplied. No conclusion about their architecture or quality is supported by this benchmark.
+
+## Adaptation Rule
+
+The adaptation unit is an abstract journey pattern:
+
+```text
+user problem -> first success -> evidence -> extension -> quality gate
+```
+
+External wording, badge collections, screen composition, source code, and assets are not copied. The pattern is reimplemented around this repository's own Azure AI Search, Foundry IQ, Fabric Ontology, LiveKS, REST, and MCP contracts.
+
+## Discovery-To-First-Success Card
+
+Repository: `microsoft/azure-ai-search-foundry-iq-live-knowledge-sources`.
+
+| Journey element | Internal contract |
+| --- | --- |
+| 10-second understanding | Platform teams connect a governed Fabric Ontology or remote HTTPS MCP tool, submit a natural-language question to a Foundry IQ Knowledge Base, and receive a grounded result with source evidence that can also be consumed through MCP. |
+| One first success | The representative managed-organization path is `byo-fabric`; it runs one Fabric Ontology KS question before combined routing. |
+| Immediate execution evidence | `./liveks verify` must return live `fabricOntology` activity or references. A final answer alone is insufficient. |
+| Extension path | After source proof: native Knowledge Base MCP, `mcp-only`, combined routing, offline replay, REST, notebooks, and `full`. |
+| Trust path | Configuration, security, preview limitations, troubleshooting, ownership-aware cleanup, and official Microsoft Learn links are separate evidence-backed sections. |
+| Optional interest signal | Repository/demo links remain after the product sentence; no star CTA appears before the first result contract. |
+
+Acceptance for the card:
+
+- the opening sentence contains the user, input, and result,
+- one representative live path is named,
+- live success is tied to a source trace,
+- compatibility and security statements link to tests, generated artifacts, workflow gates, or official manuals,
+- no performance claim is made without a benchmark artifact.
+
+## Traceability Matrix
+
+| Change proposal | External observation path or heading | Why it applies here | Independent implementation scope | Verification | License handling |
+| --- | --- | --- | --- | --- | --- |
+| Make user, input, and result legible in one sentence. | Supplied `README.md` opening value proposition. | Managed-organization reviewers need to identify the operator, business question, and grounded output immediately. | New project-specific sentence in `README.md` and `docs/index.md`. | Maintainer review against the journey-card acceptance bullets. | Abstract pattern only; no external wording copied. |
+| Order the manual by components, one live run, evidence, MCP extension, then limits. | Supplied `README.md` progression from value proposition and highlight features into the easiest entry point, Quickstart, advanced setup, Security, Deployment, and Contribute. | The repository previously exposed all modes before establishing one auditable live scenario. | Reorganized internal content around BYO Fabric and existing LiveKS commands. | `mkdocs build --strict`; link check; manual sequence review. | Information architecture only; no copied layout, badges, or assets. |
+| Keep exactly one representative first live path. | Supplied `README.md` easiest-entry and Quickstart sequence. | `byo-fabric` best matches an organization that already governs Fabric assets. | Existing profile and YAML contract; no external implementation. | `doctor`, `plan`, `up`, and source-specific `verify`. | No external code or text used. |
+| Put evidence immediately after execution. | Supplied Quickstart install/run/success-check contract. | A deployment message or fluent answer cannot prove Knowledge Source routing. | Existing REST trace plus explicit `fabricOntology` pass criteria. | `./liveks verify --env <env> --format json`; `tests/test_liveks_config.py`. | No external artifact included. |
+| Add MCP as a post-proof client surface. | Supplied README API/JSON/MCP extension references. | Managed agent clients need the Knowledge Base's northbound MCP surface after source execution is proven. | New `./liveks mcp` command using Azure AI Search's documented JSON-RPC endpoint. | `tests/test_mcp_invocation.py`; live `tools/list`, `tools/call`, and known-fact check; ignored sanitized report. | Independently implemented from the Microsoft protocol contract; no Langflow code used. |
+| Make success and failure reproducible without raw data. | Supplied Quickstart success contract and workflow-oriented regression posture. | Public evidence must not expose organizational content, endpoints, IDs, keys, or tokens. | Count-only MCP report and normalized failure categories. | Unit tests inject secret-like strings and assert they are absent from persisted reports; no-secret scan. | No external text or fixture copied. |
+| Keep trust and limitations separate from feature claims. | Supplied `README.md` Security, Deployment, and Contribute sections. | Preview status, delegated authorization, admin-key tradeoffs, and cleanup ownership need explicit boundaries. | Links to repository security, configuration, preview, troubleshooting, and Microsoft Learn pages. | Markdown link check; repository security scan; maintainer review. | Section-role pattern only. |
+| Preserve installation and platform regression gates. | Supplied `.github/workflows/*` snapshot. | The CLI and manual must remain runnable on the supported Python, Node, Linux, and Windows baselines. | Existing Ubuntu local gate, Windows launcher job, Pages build, and secret/size checks; MCP tests join the Python suite. | `.github/workflows/validate.yml`; `bash scripts/validate-local.sh`; Pages workflow. | Workflow concepts only; no external YAML copied. |
+| Keep optional calls to action after result evidence. | Supplied `README.md` `Stay up-to-date` placement. | Interest signals must not displace the functional contract. | Documentation and demo links remain secondary; no leading star request. | Visual review of README and Pages first viewport. | Placement principle only. |
+
+## Internal Change Set
+
+| Internal file | Responsibility |
+| --- | --- |
+| `README.md` | Repository discovery journey and concise live acceptance path. |
+| `docs/index.md` | Manual landing sequence in the proposed order. |
+| `docs/runbook.md` | Configuration-first operational lifecycle. |
+| `docs/22-knowledge-base-mcp.md` | Native MCP client, sanitized evidence, and failure reproduction. |
+| `src/liveks/cli.py` | Read-only `mcp` command and verification integration. |
+| `src/liveks/runtime.py` | JSON/SSE MCP transport parsing. |
+| `tests/test_mcp_invocation.py` | Protocol parsing, count-only evidence, and raw-error redaction checks. |
+| `.github/workflows/validate.yml` | Existing Linux and Windows quality gates that execute the test suite. |
+
+## Completion Checks
+
+```bash
+python3 tools/validate.py --profile offline --format json
+bash scripts/validate-local.sh
+mkdocs build --strict --site-dir _site
+git diff --check
+```
+
+Live acceptance uses an ignored `byo-fabric` environment:
+
+```bash
+./liveks verify --env <environment> --format json
+./liveks mcp --env <environment> --query <domain-question> --expect-term <known-synthetic-fact>
+./liveks mcp --env <environment> --omit-source-authorization --expect-failure
+```
+
+The live result is shareable only after reducing it to source type, pass/fail state, expected-term counts, and cleanup outcome.

--- a/docs/maintainers/release-readiness-checklist.md
+++ b/docs/maintainers/release-readiness-checklist.md
@@ -33,6 +33,7 @@ The GitHub Actions `Validate` workflow runs the same local validation gate on pu
 [ ] docs/10-one-command-deployment.md matches script behavior
 [ ] docs/maintainers/reviewer-evidence.md matches E2E report behavior
 [ ] docs/13-public-preview-limitations.md captures current caveats
+[ ] docs/22-knowledge-base-mcp.md separates native Knowledge Base MCP from MCP Server KS and distinguishes protocol success from known-fact grounding evidence
 [ ] docs/maintainers/storyline-and-safe-claims.md matches the README and demo walkthrough
 [ ] docs/maintainers/private-review-workflow.md matches the promotion and reviewer evidence flow
 [ ] docs/19-faq.md answers first-run mode choice, offline replay, Fabric source authorization, MCP endpoint requirements, and evidence collection
@@ -53,6 +54,7 @@ The GitHub Actions `Validate` workflow runs the same local validation gate on pu
 [ ] offline response samples are synthetic and safe to commit
 [ ] Fictional Airline Ops data is used for semantic examples
 [ ] MCP examples use remote HTTPS MCP servers
+[ ] Native Knowledge Base MCP acceptance pairs a known-fact `liveks mcp` check with source-specific `liveks verify` evidence
 [ ] Fabric examples use Fabric Ontology KS, not Fabric MCP through generic MCP Server KS
 [ ] Generated deployment reports, logs, local screenshots, and scratch notes are ignored
 ```
@@ -70,7 +72,7 @@ Expected evidence:
 | Mode | Evidence expected |
 | --- | --- |
 | `mcp-only` | MCP KS, MCP-only KB, retrieve activity or references, app load, cleanup. |
-| `byo-fabric` | MCP KS, Fabric KS, combined KB, Fabric live retrieve when delegated token exists or clear offline fallback when absent, app load, cleanup. |
+| `byo-fabric` | MCP KS, Fabric KS, Fabric-only and combined KBs, Fabric live retrieve when delegated token exists or clear offline fallback when absent, native MCP call, app load, cleanup. |
 | `full` | Fabric capacity/workspace/lakehouse/ontology/GraphModel preparation, Azure deploy, KS/KB creation, app load, cleanup. |
 
 Do not commit the report itself. Summarize only sanitized evidence in PRs or review notes.

--- a/docs/maintainers/reviewer-evidence.md
+++ b/docs/maintainers/reviewer-evidence.md
@@ -107,7 +107,7 @@ It copies only safe fields and checklist status/check names. It does not copy ch
 | Mode | Required evidence | Expected result |
 | --- | --- | --- |
 | `mcp-only` | MCP KS exists, MCP-only KB exists, MCP retrieve returns activity or references, app loads, cleanup completes | PASS without Fabric IDs. |
-| `byo-fabric` | MCP KS exists, Fabric KS exists, combined KB exists, Fabric retrieve is live when a delegated token is provided or clearly offline when absent, app loads, cleanup completes | PASS when Fabric IDs are present. |
+| `byo-fabric` | MCP KS exists, Fabric KS exists, Fabric-only and combined KBs exist, Fabric retrieve is live when a delegated token is provided or clearly offline when absent, app loads, cleanup completes | PASS when Fabric IDs are present. |
 | `full` | Fabric capacity/workspace/lakehouse/ontology setup completes, Azure resources deploy, Fabric KS connects, MCP/Fabric/combined app routes respond, cleanup completes | PASS when region quota and delegated auth expectations are met. |
 
 ## What Good Looks Like
@@ -216,7 +216,7 @@ Use these proof points to decide whether a run supports a claim.
 | Claim | Minimum evidence |
 | --- | --- |
 | MCP Server KS works | `microsoft-learn-mcp-ks` exists, MCP-only KB exists, retrieve returns MCP activity or Microsoft Learn references. |
-| Fabric Ontology KS works | Fabric KS exists, combined KB includes it, live retrieve with delegated source authorization returns Fabric activity or Fabric source data. |
+| Fabric Ontology KS works | Fabric KS and Fabric-only KB exist, live retrieve with delegated source authorization returns Fabric activity or Fabric source data. |
 | Combined routing works | Combined KB includes both source names and retrieve output contains recognized live evidence from the source or sources selected for the query. Separate checks prove MCP and Fabric independently. |
 | Demo app works | App root returns HTTP 200, `/api/status` exposes no secrets, and retrieve routes return live evidence or clearly marked offline replay. |
 | Full greenfield path works | Fabric sample assets are created, generated Fabric IDs are consumed by Azure AI Search KS creation, app loads, and deployment RG, generated capacity RG, and generated capacity absence checks pass. |

--- a/docs/maintainers/storyline-and-safe-claims.md
+++ b/docs/maintainers/storyline-and-safe-claims.md
@@ -28,7 +28,7 @@ Classic retrieval samples usually begin by indexing documents. Live Knowledge So
 | Mode | Safe message | Evidence needed before saying it live |
 | --- | --- | --- |
 | `mcp-only` | Fastest path to validate Azure AI Search MCP Server KS with Microsoft Learn MCP. | MCP KS exists, MCP-only KB exists, retrieve returns MCP activity or Microsoft Learn references. |
-| `byo-fabric` | Primary live Fabric path for users who already have a Fabric workspace and ontology. | Fabric KS exists, combined KB includes it, live retrieve shows Fabric activity or source data when delegated auth is provided. |
+| `byo-fabric` | Primary live Fabric path for users who already have a Fabric workspace and ontology. | Fabric KS and Fabric-only KB exist, live retrieve shows Fabric activity or source data, and native MCP matches a known non-sensitive ontology fact when delegated auth is provided. |
 | `full` | Greenfield platform story that creates sample Fabric assets before connecting Azure AI Search. | Fabric capacity/workspace/lakehouse/ontology/GraphModel setup completes, Azure deploy completes, app loads, cleanup evidence exists. |
 
 ## Claims You Can Use
@@ -42,6 +42,7 @@ Use these only when the matching evidence exists:
 - "The demo app shows live or offline source evidence through activity, references, and source-specific data."
 - "Offline replay helps explain trace shape before live Fabric auth is configured."
 - "Generated deployment reports and local screenshots stay under ignored paths."
+- "A native MCP text block proves protocol execution; source grounding additionally requires source-specific retrieve evidence and a known-fact match."
 
 ## Claims To Avoid
 

--- a/docs/maintainers/test-specs/e2e-byo-fabric.md
+++ b/docs/maintainers/test-specs/e2e-byo-fabric.md
@@ -50,6 +50,7 @@ Doctor reads both Fabric assets with a transient Fabric API token. Verify obtain
 - `microsoft-learn-mcp-ks`
 - `fabric-ontology-ks`
 - `live-knowledge-sources-mcp-kb`
+- `live-knowledge-sources-fabric-kb`
 - `live-knowledge-sources-kb`
 - `airline-ops-regulatory-docs` Search index with sample docs
 
@@ -68,6 +69,7 @@ Doctor reads both Fabric assets with a transient Fabric API token. Verify obtain
 | Resource group exists | PASS |
 | MCP retrieve | PASS with MCP activity or references |
 | Fabric live retrieve | PASS with `fabricOntology` evidence |
+| Native Fabric KB MCP | PASS for protocol; known-fact grounding requires an explicit BYO expectation |
 | Combined retrieve | PASS with recognized planner-selected live evidence |
 | App status | HTTP 200 |
 | BYO Fabric cleanup | PASS without deleting Fabric assets |
@@ -77,7 +79,7 @@ Doctor reads both Fabric assets with a transient Fabric API token. Verify obtain
 
 The run passes when all required checks pass and Fabric-specific behavior is clear:
 
-- The dedicated MCP and Fabric checks prove each source independently.
+- The dedicated MCP and Fabric-only KB checks prove each source independently.
 - The combined check records one or both source types selected by the Knowledge Base planner.
 - The existing Fabric workspace and ontology remain readable after cleanup.
 - Cleanup confirms the resource group no longer exists.
@@ -88,8 +90,11 @@ Fail the run if:
 
 - `FABRIC_WORKSPACE_ID` or `FABRIC_ONTOLOGY_ID` is missing.
 - `fabric-ontology-ks` is not created.
+- `live-knowledge-sources-fabric-kb` does not include the Fabric Knowledge Source.
 - `live-knowledge-sources-kb` does not include the Fabric Knowledge Source.
 - Live Fabric retrieve with a token does not show `fabricOntology` activity.
+- Native MCP returns a tool or transport error when authorization and source readiness should allow the call.
+- A known-answer BYO acceptance run supplies an expected term and reports `grounding-content=fail`.
 - Cleanup fails or the resource group remains.
 
 ## Reporting Requirements

--- a/docs/maintainers/test-specs/e2e-full-greenfield.md
+++ b/docs/maintainers/test-specs/e2e-full-greenfield.md
@@ -72,6 +72,7 @@ All generated files must be git ignored and must not contain secrets.
 - `microsoft-learn-mcp-ks`
 - `fabric-ontology-ks`
 - `live-knowledge-sources-mcp-kb`
+- `live-knowledge-sources-fabric-kb`
 - `live-knowledge-sources-kb`
 - `airline-ops-regulatory-docs` Search index
 
@@ -94,6 +95,7 @@ All generated files must be git ignored and must not contain secrets.
 | Ontology-backed GraphModel queryable | PASS |
 | MCP retrieve | PASS with MCP evidence |
 | Fabric live retrieve | PASS with `fabricOntology` evidence |
+| Native Fabric KB MCP | PASS with `grounding-content` matching the generated Airline Ops fact |
 | Combined retrieve | PASS with recognized planner-selected live evidence |
 | App status | HTTP 200 |
 | Generated Fabric cleanup | PASS |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -2,6 +2,26 @@
 
 This is the shortest supported sequence from a fresh clone to verified cleanup.
 
+## 0. Know What To Configure
+
+The canonical input is an ignored `.liveks/<environment>.yaml` ledger. It is not a dotenv file and it is not `azd env`; LiveKS generates the deployment projection after validation.
+
+| Profile | Required authored values | Runtime credential | What it creates |
+| --- | --- | --- | --- |
+| `mcp-only` | None beyond the generated profile and environment. | Azure CLI and Azure Developer CLI sign-in. | Azure resources, MCP Server KS, MCP-only KB, and app. |
+| `byo-fabric` | `fabric.workspace_id` and `fabric.ontology_id`. | Azure sign-in plus a transient delegated Search token during Fabric calls. | Generated Azure resources and a Fabric-only validation KB; the existing Fabric assets are preserved. |
+| `full` | No existing Fabric IDs; optional Fabric location and SKU overrides. | Azure and Fabric access, available quota, and `--accept-fabric-capacity`. | Generated Azure resources and a billable Fabric F2 sample stack. |
+
+Optional external-tenant values belong under `azure`: `tenant_id`, `subscription_id`, and `cli_config_dir`. Secret fields contain an environment-variable reference, never the raw secret:
+
+```yaml
+fabric:
+  user_search_token:
+    env: FABRIC_USER_SEARCH_TOKEN
+```
+
+Normally, do not author that optional token field at all. `verify` and `mcp` acquire the user token transiently from Azure CLI. See [Configuration](21-configuration.md) for the complete field and precedence contract.
+
 ## 1. Replay The Contract
 
 ```bash
@@ -125,7 +145,28 @@ The manual app test proves the user-facing experience. `verify` independently re
 
 Sanitized reports are written under ignored `deployments/<environment>/`.
 
-## 8. Clean Up
+## 8. Call The Knowledge Base Through MCP
+
+The source-specific retrieve checks above prove which Knowledge Source ran. Now call the same single-source Knowledge Base through its native MCP endpoint:
+
+```bash
+./liveks mcp --env liveks-mcp
+```
+
+For an Airline Ops `byo-fabric` or `full` environment:
+
+```bash
+./liveks mcp \
+  --env liveks-byo \
+  --query "Which airlines have the highest customer-care exposure this month?" \
+  --expect-term "Alpine Air"
+```
+
+Expected: `tools/list` publishes `knowledge_base_retrieve`, `tools/call` returns at least one text block, and `grounding-content` matches every expected term. The command keeps raw MCP content in memory and records only sanitized counts. Without `--expect-term`, protocol checks can pass but grounding remains a warning.
+
+Use [Call the Knowledge Base Through MCP](22-knowledge-base-mcp.md) for bearer authentication, a controlled missing-authorization failure, and the complete acceptance contract.
+
+## 9. Clean Up
 
 ```bash
 ./liveks down --env liveks-mcp

--- a/docs/samples/python.md
+++ b/docs/samples/python.md
@@ -17,6 +17,6 @@ python3 samples/python/inspect_retrieve_response.py samples/responses/fabric-air
 python3 samples/python/inspect_retrieve_response.py samples/responses/combined-airline-ops-retrieve.sample.json
 ```
 
-Use `build_payloads.py` when you want representative MCP Server KS, Fabric Ontology KS, MCP-only KB, and combined KB payloads generated from the reusable Python builders.
+Use `build_payloads.py` when you want representative MCP Server KS, Fabric Ontology KS, MCP-only KB, Fabric-only KB, and combined KB payloads generated from the reusable Python builders.
 
 Next: read [Offline Replay](../09-offline-replay.md).

--- a/env/byo-fabric.env.example
+++ b/env/byo-fabric.env.example
@@ -14,6 +14,7 @@ AIRLINE_OPS_INDEX_NAME=airline-ops-regulatory-docs
 MCP_KNOWLEDGE_SOURCE_NAME=microsoft-learn-mcp-ks
 FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME=fabric-ontology-ks
 MCP_ONLY_KNOWLEDGE_BASE_NAME=live-knowledge-sources-mcp-kb
+FABRIC_ONLY_KNOWLEDGE_BASE_NAME=live-knowledge-sources-fabric-kb
 KNOWLEDGE_BASE_NAME=live-knowledge-sources-kb
 MCP_SERVER_URL=https://learn.microsoft.com/api/mcp
 MCP_TOOL_NAME=microsoft_docs_search

--- a/env/full.env.example
+++ b/env/full.env.example
@@ -14,6 +14,7 @@ AIRLINE_OPS_INDEX_NAME=airline-ops-regulatory-docs
 MCP_KNOWLEDGE_SOURCE_NAME=microsoft-learn-mcp-ks
 FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME=fabric-ontology-ks
 MCP_ONLY_KNOWLEDGE_BASE_NAME=live-knowledge-sources-mcp-kb
+FABRIC_ONLY_KNOWLEDGE_BASE_NAME=live-knowledge-sources-fabric-kb
 KNOWLEDGE_BASE_NAME=live-knowledge-sources-kb
 MCP_SERVER_URL=https://learn.microsoft.com/api/mcp
 MCP_TOOL_NAME=microsoft_docs_search

--- a/env/mcp-only.env.example
+++ b/env/mcp-only.env.example
@@ -14,6 +14,7 @@ AIRLINE_OPS_INDEX_NAME=airline-ops-regulatory-docs
 MCP_KNOWLEDGE_SOURCE_NAME=microsoft-learn-mcp-ks
 FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME=fabric-ontology-ks
 MCP_ONLY_KNOWLEDGE_BASE_NAME=live-knowledge-sources-mcp-kb
+FABRIC_ONLY_KNOWLEDGE_BASE_NAME=live-knowledge-sources-fabric-kb
 KNOWLEDGE_BASE_NAME=live-knowledge-sources-kb
 MCP_SERVER_URL=https://learn.microsoft.com/api/mcp
 MCP_TOOL_NAME=microsoft_docs_search

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -101,6 +101,9 @@ param fabricKnowledgeSourceName string = 'fabric-ontology-ks'
 @description('MCP-only Knowledge Base name.')
 param mcpOnlyKnowledgeBaseName string = 'live-knowledge-sources-mcp-kb'
 
+@description('Fabric-only Knowledge Base name.')
+param fabricOnlyKnowledgeBaseName string = 'live-knowledge-sources-fabric-kb'
+
 @description('Combined Knowledge Base name.')
 param knowledgeBaseName string = 'live-knowledge-sources-kb'
 
@@ -176,6 +179,10 @@ var demoRuntimeSettings = [
     value: mcpOnlyKnowledgeBaseName
   }
   {
+    name: 'FABRIC_ONLY_KNOWLEDGE_BASE_NAME'
+    value: fabricOnlyKnowledgeBaseName
+  }
+  {
     name: 'KNOWLEDGE_BASE_NAME'
     value: knowledgeBaseName
   }
@@ -207,6 +214,7 @@ var demoRuntimeSettingsObject = {
   AIRLINE_OPS_INDEX_NAME: airlineOpsIndexName
   MCP_KNOWLEDGE_SOURCE_NAME: mcpKnowledgeSourceName
   MCP_ONLY_KNOWLEDGE_BASE_NAME: mcpOnlyKnowledgeBaseName
+  FABRIC_ONLY_KNOWLEDGE_BASE_NAME: fabricOnlyKnowledgeBaseName
   KNOWLEDGE_BASE_NAME: knowledgeBaseName
   FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME: fabricKnowledgeSourceName
   AZURE_OPENAI_ENDPOINT: openai.properties.endpoint
@@ -374,6 +382,7 @@ output AZURE_WEBAPP_NAME string = hostingMode == 'appservice' ? webApp!.name : '
 output AZURE_WEBAPP_URL string = hostingMode == 'staticwebapp' ? 'https://${staticWebApp!.properties.defaultHostname}' : 'https://${webApp!.properties.defaultHostName}'
 output MCP_KNOWLEDGE_SOURCE_NAME string = mcpKnowledgeSourceName
 output MCP_ONLY_KNOWLEDGE_BASE_NAME string = mcpOnlyKnowledgeBaseName
+output FABRIC_ONLY_KNOWLEDGE_BASE_NAME string = fabricOnlyKnowledgeBaseName
 output KNOWLEDGE_BASE_NAME string = knowledgeBaseName
 output FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME string = fabricKnowledgeSourceName
 output DEPLOYMENT_MODE string = deploymentMode

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -71,6 +71,9 @@
     "mcpOnlyKnowledgeBaseName": {
       "value": "${MCP_ONLY_KNOWLEDGE_BASE_NAME}"
     },
+    "fabricOnlyKnowledgeBaseName": {
+      "value": "${FABRIC_ONLY_KNOWLEDGE_BASE_NAME}"
+    },
     "knowledgeBaseName": {
       "value": "${KNOWLEDGE_BASE_NAME}"
     }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
   - Start Here:
       - Home: index.md
       - Runbook: runbook.md
+      - Knowledge Base MCP Client: 22-knowledge-base-mcp.md
       - LiveKS CLI: 20-liveks-cli.md
       - Configuration: 21-configuration.md
       - Overview: 00-overview.md

--- a/profiles/byo-fabric.yaml
+++ b/profiles/byo-fabric.yaml
@@ -22,6 +22,7 @@ defaults:
     mcp_knowledge_source_name: microsoft-learn-mcp-ks
     fabric_knowledge_source_name: fabric-ontology-ks
     mcp_knowledge_base_name: live-knowledge-sources-mcp-kb
+    fabric_knowledge_base_name: live-knowledge-sources-fabric-kb
     combined_knowledge_base_name: live-knowledge-sources-kb
   mcp:
     server_url: https://learn.microsoft.com/api/mcp

--- a/profiles/full.yaml
+++ b/profiles/full.yaml
@@ -22,6 +22,7 @@ defaults:
     mcp_knowledge_source_name: microsoft-learn-mcp-ks
     fabric_knowledge_source_name: fabric-ontology-ks
     mcp_knowledge_base_name: live-knowledge-sources-mcp-kb
+    fabric_knowledge_base_name: live-knowledge-sources-fabric-kb
     combined_knowledge_base_name: live-knowledge-sources-kb
   mcp:
     server_url: https://learn.microsoft.com/api/mcp

--- a/profiles/mcp-only.yaml
+++ b/profiles/mcp-only.yaml
@@ -22,6 +22,7 @@ defaults:
     mcp_knowledge_source_name: microsoft-learn-mcp-ks
     fabric_knowledge_source_name: fabric-ontology-ks
     mcp_knowledge_base_name: live-knowledge-sources-mcp-kb
+    fabric_knowledge_base_name: live-knowledge-sources-fabric-kb
     combined_knowledge_base_name: live-knowledge-sources-kb
   mcp:
     server_url: https://learn.microsoft.com/api/mcp

--- a/samples/python/README.md
+++ b/samples/python/README.md
@@ -8,7 +8,7 @@ The helpers are intentionally lightweight. They are not an SDK wrapper and they 
 
 | Script | Purpose |
 | --- | --- |
-| [build_payloads.py](build_payloads.py) | Generate representative MCP Server KS, Fabric Ontology KS, MCP-only KB, and combined KB payloads from reusable Python builders. |
+| [build_payloads.py](build_payloads.py) | Generate representative MCP Server KS, Fabric Ontology KS, MCP-only KB, Fabric-only KB, and combined KB payloads from reusable Python builders. |
 | [inspect_retrieve_response.py](inspect_retrieve_response.py) | Print summarized `activity` and `references` from a saved retrieve response. |
 
 ## Generate Payloads

--- a/samples/python/build_payloads.py
+++ b/samples/python/build_payloads.py
@@ -64,12 +64,21 @@ def main() -> None:
         **azure_openai_model,
     )
 
+    fabric_only_knowledge_base = create_knowledge_base(
+        name="live-knowledge-sources-fabric-kb",
+        knowledge_source_names=["fabric-ontology-ks"],
+        description="Knowledge Base for validating Fabric Ontology live grounding.",
+        retrieval_instructions="Use Fabric Ontology for governed business entities and relationships.",
+        **azure_openai_model,
+    )
+
     print(
         json.dumps(
             {
                 "mcp": mcp_source,
                 "mcpOnlyKnowledgeBase": mcp_only_knowledge_base,
                 "fabric": fabric_source,
+                "fabricOnlyKnowledgeBase": fabric_only_knowledge_base,
                 "combinedKnowledgeBase": knowledge_base,
             },
             indent=2,

--- a/samples/rest/07-delete-resources.http
+++ b/samples/rest/07-delete-resources.http
@@ -3,6 +3,7 @@
 @searchApiKey = <search-admin-key>
 @knowledgeBaseName = live-knowledge-sources-kb
 @mcpOnlyKnowledgeBaseName = live-knowledge-sources-mcp-kb
+@fabricOnlyKnowledgeBaseName = live-knowledge-sources-fabric-kb
 @mcpKnowledgeSourceName = microsoft-learn-mcp-ks
 @fabricOntologyKnowledgeSourceName = fabric-ontology-ks
 
@@ -12,6 +13,10 @@ api-key: {{searchApiKey}}
 
 ### Delete MCP-only Knowledge Base
 DELETE {{searchEndpoint}}/knowledgebases/{{mcpOnlyKnowledgeBaseName}}?api-version={{apiVersion}}
+api-key: {{searchApiKey}}
+
+### Delete Fabric-only Knowledge Base
+DELETE {{searchEndpoint}}/knowledgebases/{{fabricOnlyKnowledgeBaseName}}?api-version={{apiVersion}}
 api-key: {{searchApiKey}}
 
 ### Delete MCP Server Knowledge Source

--- a/scripts/ensure_azd_defaults.py
+++ b/scripts/ensure_azd_defaults.py
@@ -52,6 +52,7 @@ def main() -> int:
         "MCP_KNOWLEDGE_SOURCE_NAME": "microsoft-learn-mcp-ks",
         "FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME": "fabric-ontology-ks",
         "MCP_ONLY_KNOWLEDGE_BASE_NAME": "live-knowledge-sources-mcp-kb",
+        "FABRIC_ONLY_KNOWLEDGE_BASE_NAME": "live-knowledge-sources-fabric-kb",
         "KNOWLEDGE_BASE_NAME": "live-knowledge-sources-kb",
         "MCP_SERVER_URL": "https://learn.microsoft.com/api/mcp",
         "MCP_TOOL_NAME": "microsoft_docs_search",

--- a/scripts/postprovision.py
+++ b/scripts/postprovision.py
@@ -180,6 +180,7 @@ def load_regulatory_documents() -> list[dict[str, Any]]:
 
 def write_summary(settings: dict[str, str], smoke: dict[str, Any]) -> Path:
     env_name = settings.get("AZURE_ENV_NAME") or "dev"
+    fabric_enabled = should_create_fabric_source(settings)
     summary_dir = REPO_ROOT / "deployments" / env_name
     summary_dir.mkdir(parents=True, exist_ok=True)
     summary_path = summary_dir / "deployment-summary.md"
@@ -218,6 +219,7 @@ def write_summary(settings: dict[str, str], smoke: dict[str, Any]) -> Path:
         f"- Fabric source created: {'yes' if should_create_fabric_source(settings) else 'no'}",
         f"- Fabric automation status: {fabric_automation_status(settings)}",
         f"- MCP-only KB: {settings.get('MCP_ONLY_KNOWLEDGE_BASE_NAME', '')}",
+        f"- Fabric-only KB: {settings.get('FABRIC_ONLY_KNOWLEDGE_BASE_NAME', '') if fabric_enabled else ''}",
         f"- Combined KB: {settings.get('KNOWLEDGE_BASE_NAME', '')}",
         f"- Airline Ops Search index: {settings.get('AIRLINE_OPS_INDEX_NAME', '')}",
         "",
@@ -229,6 +231,7 @@ def write_summary(settings: dict[str, str], smoke: dict[str, Any]) -> Path:
         f"SEARCH_API_VERSION={settings.get('AZURE_SEARCH_API_VERSION', '2026-05-01-preview')}",
         f"KNOWLEDGE_BASE_NAME={settings.get('KNOWLEDGE_BASE_NAME', '')}",
         f"MCP_ONLY_KNOWLEDGE_BASE_NAME={settings.get('MCP_ONLY_KNOWLEDGE_BASE_NAME', '')}",
+        f"FABRIC_ONLY_KNOWLEDGE_BASE_NAME={settings.get('FABRIC_ONLY_KNOWLEDGE_BASE_NAME', '') if fabric_enabled else ''}",
         f"MCP_KNOWLEDGE_SOURCE_NAME={settings.get('MCP_KNOWLEDGE_SOURCE_NAME', '')}",
         f"FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME={settings.get('FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME', '')}",
         f"FABRIC_WORKSPACE_ID={settings.get('FABRIC_WORKSPACE_ID', '')}",
@@ -304,7 +307,7 @@ def write_full_mode_checklist(settings: dict[str, str]) -> Path:
                 "- Azure AI Search",
                 "- Azure OpenAI / Foundry model deployment",
                 "- Microsoft Learn MCP Server Knowledge Source",
-                "- MCP-only and combined Knowledge Bases",
+                "- MCP-only, Fabric-only when configured, and combined Knowledge Bases",
                 "- Airline Ops Search index",
                 "- Static Web Apps demo UI and managed Functions API",
                 "",
@@ -366,6 +369,7 @@ def main() -> None:
         "MCP_SERVER_URL": get_setting("MCP_SERVER_URL", azd_values, "https://learn.microsoft.com/api/mcp"),
         "MCP_TOOL_NAME": get_setting("MCP_TOOL_NAME", azd_values, "microsoft_docs_search"),
         "MCP_ONLY_KNOWLEDGE_BASE_NAME": get_setting("MCP_ONLY_KNOWLEDGE_BASE_NAME", azd_values, "live-knowledge-sources-mcp-kb"),
+        "FABRIC_ONLY_KNOWLEDGE_BASE_NAME": get_setting("FABRIC_ONLY_KNOWLEDGE_BASE_NAME", azd_values, "live-knowledge-sources-fabric-kb"),
         "KNOWLEDGE_BASE_NAME": get_setting("KNOWLEDGE_BASE_NAME", azd_values, "live-knowledge-sources-kb"),
         "FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME": get_setting("FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME", azd_values, "fabric-ontology-ks"),
         "FABRIC_CAPACITY_ID": get_setting("FABRIC_CAPACITY_ID", azd_values),
@@ -421,8 +425,26 @@ def main() -> None:
         retrieval_instructions="Use Microsoft Learn MCP Server for Azure AI Search and Foundry IQ implementation guidance.",
     )
     combined_source_names = [settings["MCP_KNOWLEDGE_SOURCE_NAME"]]
+    fabric_only_kb = None
     if should_create_fabric_source(settings):
         combined_source_names.append(settings["FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME"])
+        fabric_only_kb = create_knowledge_base(
+            name=settings["FABRIC_ONLY_KNOWLEDGE_BASE_NAME"],
+            knowledge_source_names=[settings["FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME"]],
+            azure_openai_endpoint=settings["AZURE_OPENAI_ENDPOINT"],
+            azure_openai_deployment_id=settings["AZURE_OPENAI_DEPLOYMENT_ID"],
+            azure_openai_model_name=settings["AZURE_OPENAI_MODEL_NAME"],
+            azure_openai_api_key=openai_api_key,
+            description="Knowledge Base for validating Fabric Ontology live grounding.",
+            retrieval_instructions=(
+                "Always query the configured Fabric Ontology Knowledge Source for every request, even when the question "
+                "appears answerable without it. Never use model knowledge as grounding."
+            ),
+            answer_instructions=(
+                "Answer only from retrieved Fabric Ontology grounding. If the source returns no grounding, state that "
+                "the Fabric Ontology Knowledge Source returned no data."
+            ),
+        )
 
     combined_kb = create_knowledge_base(
         name=settings["KNOWLEDGE_BASE_NAME"],
@@ -469,6 +491,19 @@ def main() -> None:
 
     search_request(method="PUT", endpoint=endpoint, api_key=search_api_key, api_version=api_version, path=f"/knowledgebases/{settings['MCP_ONLY_KNOWLEDGE_BASE_NAME']}", body=mcp_only_kb)
     smoke["steps"].append({"name": "create_mcp_only_kb", "status": "ok"})
+
+    if fabric_only_kb is not None:
+        search_request(
+            method="PUT",
+            endpoint=endpoint,
+            api_key=search_api_key,
+            api_version=api_version,
+            path=f"/knowledgebases/{settings['FABRIC_ONLY_KNOWLEDGE_BASE_NAME']}",
+            body=fabric_only_kb,
+        )
+        smoke["steps"].append({"name": "create_fabric_only_kb", "status": "ok"})
+    else:
+        smoke["steps"].append({"name": "create_fabric_only_kb", "status": "skipped"})
 
     search_request(method="PUT", endpoint=endpoint, api_key=search_api_key, api_version=api_version, path=f"/knowledgebases/{settings['KNOWLEDGE_BASE_NAME']}", body=combined_kb)
     smoke["steps"].append({"name": "create_combined_kb_skeleton", "status": "ok"})

--- a/scripts/validate-local.sh
+++ b/scripts/validate-local.sh
@@ -166,7 +166,9 @@ run_required "Python compile" \
     tools/doctor.py \
     tools/try_offline.py \
     samples/python/build_payloads.py \
-    samples/python/inspect_retrieve_response.py
+    samples/python/inspect_retrieve_response.py \
+    src/liveks/runtime.py \
+    src/liveks/cli.py
 
 run_required "Python contract tests" \
   python3 -m unittest discover -s tests

--- a/src/ks_factory/knowledge_base.py
+++ b/src/ks_factory/knowledge_base.py
@@ -15,6 +15,7 @@ def create_knowledge_base(
     azure_openai_api_key: str | None = None,
     description: str = "Knowledge Base with live Knowledge Sources.",
     retrieval_instructions: str | None = "Use the configured live Knowledge Sources to answer with references.",
+    answer_instructions: str | None = None,
     reasoning_effort: str = "low",
 ) -> dict[str, Any]:
     """Build a Knowledge Base request payload."""
@@ -30,6 +31,9 @@ def create_knowledge_base(
 
     if retrieval_instructions:
         payload["retrievalInstructions"] = retrieval_instructions
+
+    if answer_instructions:
+        payload["answerInstructions"] = answer_instructions
 
     if azure_openai_endpoint and azure_openai_deployment_id and azure_openai_model_name:
         payload["models"] = [

--- a/src/liveks/cli.py
+++ b/src/liveks/cli.py
@@ -12,6 +12,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 import yaml
 
@@ -28,7 +29,7 @@ from .config import (
     write_lock,
     write_user_config,
 )
-from .runtime import CommandRunner, http_json, parse_azd_values, parse_version
+from .runtime import CommandRunner, http_json, http_mcp_json, parse_azd_values, parse_version
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -429,6 +430,262 @@ def _evidence_types(payload: Any) -> list[str]:
     return sorted({str(item.get("type")) for item in evidence if isinstance(item, dict) and item.get("type")})
 
 
+def _mcp_text_blocks(payload: Any) -> list[str]:
+    if not isinstance(payload, dict):
+        return []
+    result = payload.get("result")
+    if not isinstance(result, dict):
+        return []
+    content = result.get("content")
+    if not isinstance(content, list):
+        return []
+    return [str(item.get("text", "")) for item in content if isinstance(item, dict) and item.get("type") == "text"]
+
+
+def _mcp_failure_message(status_code: int, payload: Any) -> str:
+    if status_code in {401, 403}:
+        return f"Azure AI Search rejected MCP authentication (HTTP {status_code})."
+    if status_code == 404:
+        return "The Knowledge Base MCP endpoint was not found (HTTP 404)."
+    if status_code >= 500:
+        return f"The Knowledge Base or one of its sources failed (HTTP {status_code})."
+    if isinstance(payload, dict) and payload.get("error"):
+        return "The MCP endpoint returned a JSON-RPC error."
+    if isinstance(payload, dict) and isinstance(payload.get("result"), dict) and payload["result"].get("isError"):
+        return "knowledge_base_retrieve returned a tool error; check source authorization and source readiness."
+    return f"The MCP call did not return usable grounding content (HTTP {status_code})."
+
+
+def _persist_mcp_report(config: ResolvedConfig, report: dict[str, Any]) -> None:
+    report_dir = ROOT / "deployments" / config.environment
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = report_dir / "mcp-call-report.json"
+    report["artifacts"] = [str(report_path.relative_to(ROOT))]
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def mcp_report(
+    config: ResolvedConfig,
+    *,
+    query: str | None = None,
+    expected_terms: list[str] | None = None,
+    auth: str = "admin-key",
+    omit_source_authorization: bool = False,
+    expect_failure: bool = False,
+    knowledge_base: str | None = None,
+    persist: bool = True,
+) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+    if config.profile == "offline":
+        report = envelope(
+            "mcp",
+            "fail",
+            profile=config.profile,
+            environment=config.environment,
+            checks=[_check("deployment", "fail", "A deployed live profile is required for an MCP call.")],
+        )
+        if persist:
+            _persist_mcp_report(config, report)
+        return report
+
+    runner = CommandRunner(root=ROOT, env=config.child_env(), quiet=True)
+    selected = runner.run(["azd", "env", "select", config.environment, "--no-prompt"])
+    if selected.returncode != 0:
+        report = envelope(
+            "mcp",
+            "fail",
+            profile=config.profile,
+            environment=config.environment,
+            checks=[_check("azd-environment", "fail", "The deployment environment was not found.")],
+        )
+        if persist:
+            _persist_mcp_report(config, report)
+        return report
+
+    env_result = runner.run(["azd", "env", "get-values"])
+    azd_values = parse_azd_values(env_result.stdout)
+    search_endpoint = azd_values.get("AZURE_SEARCH_ENDPOINT", "").rstrip("/")
+    search_service = azd_values.get("AZURE_SEARCH_SERVICE_NAME", "")
+    resource_group = azd_values.get("AZURE_RESOURCE_GROUP", str(config.get("azure.resource_group", "")))
+    api_version = azd_values.get("AZURE_SEARCH_API_VERSION", str(config.get("search.api_version")))
+    kb_name = knowledge_base or azd_values.get(
+        "FABRIC_ONLY_KNOWLEDGE_BASE_NAME" if config.profile in {"byo-fabric", "full"} else "MCP_ONLY_KNOWLEDGE_BASE_NAME",
+        str(config.get("search.fabric_knowledge_base_name" if config.profile in {"byo-fabric", "full"} else "search.mcp_knowledge_base_name")),
+    )
+    if not all((search_endpoint, api_version, kb_name)):
+        report = envelope(
+            "mcp",
+            "fail",
+            profile=config.profile,
+            environment=config.environment,
+            checks=[_check("deployment-values", "fail", "Search endpoint, API version, or Knowledge Base name is missing.")],
+        )
+        if persist:
+            _persist_mcp_report(config, report)
+        return report
+    checks.append(_check("deployment-values", "pass", "MCP endpoint inputs resolved from the selected deployment."))
+
+    headers: dict[str, str] = {}
+    if auth == "bearer":
+        auth_result = runner.run(
+            ["az", "account", "get-access-token", "--scope", "https://search.azure.com/.default", "--query", "accessToken", "-o", "tsv"]
+        )
+        service_credential = auth_result.stdout.strip()
+        if not service_credential:
+            checks.append(_check("mcp-auth", "fail", "Unable to acquire an Azure AI Search bearer token."))
+        else:
+            headers["Authorization"] = f"Bearer {service_credential}"
+            checks.append(_check("mcp-auth", "pass", "Using a transient Azure AI Search bearer token."))
+    else:
+        key_result = runner.run(
+            [
+                "az",
+                "search",
+                "admin-key",
+                "show",
+                "--resource-group",
+                resource_group,
+                "--service-name",
+                search_service,
+                "--query",
+                "primaryKey",
+                "-o",
+                "tsv",
+            ]
+        )
+        service_credential = key_result.stdout.strip()
+        if not search_service or not service_credential:
+            checks.append(_check("mcp-auth", "fail", "Unable to acquire the transient Search admin key used by the sample deployment."))
+        else:
+            headers["api-key"] = service_credential
+            checks.append(_check("mcp-auth", "pass", "Using the sample deployment's transient Search admin key; no key is printed or persisted."))
+
+    needs_source_authorization = config.profile in {"byo-fabric", "full"}
+    if needs_source_authorization and not omit_source_authorization:
+        source_result = runner.run(
+            ["az", "account", "get-access-token", "--scope", "https://search.azure.com/.default", "--query", "accessToken", "-o", "tsv"]
+        )
+        source_token = source_result.stdout.strip()
+        if not source_token:
+            checks.append(_check("source-authorization", "fail", "Unable to acquire delegated source authorization."))
+        else:
+            headers["x-ms-query-source-authorization"] = source_token
+            checks.append(_check("source-authorization", "pass", "Delegated source authorization is attached transiently."))
+    elif needs_source_authorization:
+        checks.append(_check("source-authorization", "pass" if expect_failure else "warn", "Delegated source authorization was intentionally omitted."))
+    else:
+        checks.append(_check("source-authorization", "pass", "The selected MCP-only profile does not require Fabric source authorization."))
+
+    if any(check["status"] == "fail" for check in checks):
+        report = envelope("mcp", "fail", profile=config.profile, environment=config.environment, checks=checks)
+        if persist:
+            _persist_mcp_report(config, report)
+        return report
+
+    mcp_url = f"{search_endpoint}/knowledgebases/{quote(kb_name, safe='')}/mcp?api-version={quote(api_version, safe='')}"
+    try:
+        list_code, list_payload = http_mcp_json(
+            mcp_url,
+            body={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            headers=headers,
+            attempts=3,
+            delay_seconds=3,
+            timeout=30,
+        )
+    except Exception:
+        checks.append(_check("tools-list", "fail", "The MCP endpoint could not complete tool discovery."))
+        report = envelope("mcp", "fail", profile=config.profile, environment=config.environment, checks=checks)
+        if persist:
+            _persist_mcp_report(config, report)
+        return report
+    tools = list_payload.get("result", {}).get("tools", []) if isinstance(list_payload, dict) else []
+    has_retrieve_tool = any(isinstance(tool, dict) and tool.get("name") == "knowledge_base_retrieve" for tool in tools)
+    if list_code != 200 or not has_retrieve_tool:
+        failure = _mcp_failure_message(list_code, list_payload)
+        checks.append(_check("tools-list", "fail", failure))
+        report = envelope("mcp", "fail", profile=config.profile, environment=config.environment, checks=checks)
+        if persist:
+            _persist_mcp_report(config, report)
+        return report
+    checks.append(_check("tools-list", "pass", "Knowledge Base publishes knowledge_base_retrieve."))
+
+    effective_query = query or (
+        "Which airlines have the highest customer-care exposure this month?"
+        if needs_source_authorization
+        else "What must be configured for an Azure AI Search MCP Server knowledge source?"
+    )
+    try:
+        call_code, call_payload = http_mcp_json(
+            mcp_url,
+            body={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "knowledge_base_retrieve", "arguments": {"queries": [effective_query]}},
+            },
+            headers=headers,
+            attempts=3,
+            delay_seconds=3,
+            timeout=180,
+        )
+    except Exception:
+        checks.append(_check("tools-call", "fail", "The MCP endpoint could not complete the tool call."))
+        report = envelope("mcp", "fail", profile=config.profile, environment=config.environment, checks=checks)
+        if persist:
+            _persist_mcp_report(config, report)
+        return report
+    text_blocks = _mcp_text_blocks(call_payload)
+    tool_error = isinstance(call_payload, dict) and isinstance(call_payload.get("result"), dict) and bool(call_payload["result"].get("isError"))
+    terms = expected_terms or []
+    combined_text = "\n".join(text_blocks).casefold()
+    matched_terms = sum(1 for term in terms if term.casefold() in combined_text)
+    call_ok = call_code == 200 and bool(text_blocks) and not tool_error
+
+    if expect_failure:
+        if call_ok:
+            checks.append(_check("tools-call", "fail", "The MCP call succeeded, but this run expected a failure."))
+        else:
+            checks.append(_check("tools-call", "pass", f"Expected failure reproduced: {_mcp_failure_message(call_code, call_payload)}"))
+    elif call_ok:
+        checks.append(
+            _check(
+                "tools-call",
+                "pass",
+                f"knowledge_base_retrieve returned {len(text_blocks)} text block(s).",
+                contentBlocks=len(text_blocks),
+            )
+        )
+        if terms:
+            grounding_status = "pass" if matched_terms == len(terms) else "fail"
+            checks.append(
+                _check(
+                    "grounding-content",
+                    grounding_status,
+                    f"MCP content matched {matched_terms}/{len(terms)} expected term(s).",
+                    expectedTermCount=len(terms),
+                    matchedExpectedTermCount=matched_terms,
+                )
+            )
+        else:
+            checks.append(
+                _check(
+                    "grounding-content",
+                    "warn",
+                    "MCP protocol content returned, but source grounding was not content-verified; repeat with --expect-term using a known non-sensitive fact.",
+                    expectedTermCount=0,
+                    matchedExpectedTermCount=0,
+                )
+            )
+    else:
+        checks.append(_check("tools-call", "fail", _mcp_failure_message(call_code, call_payload)))
+
+    status = "fail" if any(check["status"] == "fail" for check in checks) else "pass"
+    report = envelope("mcp", status, profile=config.profile, environment=config.environment, checks=checks)
+    if persist:
+        _persist_mcp_report(config, report)
+    return report
+
+
 def verify_report(config: ResolvedConfig, *, quiet: bool = False) -> dict[str, Any]:
     if config.profile == "offline":
         result = subprocess.run([sys.executable, "tools/try_offline.py", "--format", "json"], cwd=ROOT, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)
@@ -484,6 +741,40 @@ def verify_report(config: ResolvedConfig, *, quiet: bool = False) -> dict[str, A
                     checks.append(_check("combined-retrieve", "pass" if combined_ok else "fail", message, sourceTypes=source_types))
         except Exception as error:
             checks.append(_check("app-api", "fail", str(error)))
+
+    native_expected_terms = (
+        ["Alpine Air"]
+        if config.profile == "full"
+        else ["Azure AI Search"]
+        if config.profile == "mcp-only"
+        else None
+    )
+    native_mcp = mcp_report(
+        config,
+        query=(
+            "Which airlines have the highest customer-care exposure this month?"
+            if config.profile in {"byo-fabric", "full"}
+            else "What must be configured for an Azure AI Search MCP Server knowledge source?"
+        ),
+        expected_terms=native_expected_terms,
+        persist=False,
+    )
+    native_message = next(
+        (
+            str(check.get("message", ""))
+            for check in reversed(native_mcp.get("checks", []))
+            if check.get("name") in {"grounding-content", "tools-call", "tools-list"}
+        ),
+        "Knowledge Base MCP validation did not complete.",
+    )
+    grounding_check = next(
+        (check for check in native_mcp.get("checks", []) if check.get("name") == "grounding-content"),
+        None,
+    )
+    native_status = "fail" if native_mcp.get("status") != "pass" else "pass"
+    if native_status == "pass" and grounding_check and grounding_check.get("status") == "warn":
+        native_status = "warn"
+    checks.append(_check("knowledge-base-mcp", native_status, native_message))
     status = "fail" if any(check["status"] == "fail" for check in checks) else "pass"
     report = envelope("verify", status, profile=config.profile, environment=config.environment, checks=checks, nextActions=[f"Run ./liveks down --env {config.environment} when finished"])
     report_dir = ROOT / "deployments" / config.environment
@@ -727,6 +1018,14 @@ def build_parser() -> argparse.ArgumentParser:
     up_parser.add_argument("--postprovision-only", action="store_true", help=argparse.SUPPRESS)
     verify_parser = subparsers.add_parser("verify", help="Verify deployed resources and retrieve evidence.")
     _common_config_args(verify_parser, require_env=False)
+    mcp_parser = subparsers.add_parser("mcp", help="Call a deployed Knowledge Base through its MCP endpoint.")
+    _common_config_args(mcp_parser, require_env=True)
+    mcp_parser.add_argument("--query")
+    mcp_parser.add_argument("--expect-term", action="append", default=[])
+    mcp_parser.add_argument("--auth", choices=["admin-key", "bearer"], default="admin-key")
+    mcp_parser.add_argument("--omit-source-authorization", action="store_true")
+    mcp_parser.add_argument("--expect-failure", action="store_true")
+    mcp_parser.add_argument("--knowledge-base")
     down_parser = subparsers.add_parser("down", help="Delete only resources owned by an environment.")
     _common_config_args(down_parser, require_env=False)
     down_parser.add_argument("--yes", action="store_true")
@@ -817,6 +1116,16 @@ def main(argv: list[str] | None = None) -> int:
             )
         elif args.command == "verify":
             report = verify_report(config, quiet=args.format == "json")
+        elif args.command == "mcp":
+            report = mcp_report(
+                config,
+                query=args.query,
+                expected_terms=args.expect_term,
+                auth=args.auth,
+                omit_source_authorization=args.omit_source_authorization,
+                expect_failure=args.expect_failure,
+                knowledge_base=args.knowledge_base,
+            )
         elif args.command == "down":
             report = down_report(config, yes=args.yes, quiet=args.format == "json")
         elif args.command == "e2e":

--- a/src/liveks/runtime.py
+++ b/src/liveks/runtime.py
@@ -128,3 +128,67 @@ def http_json(
                 break
         time.sleep(delay_seconds)
     raise RuntimeError(f"Request failed after {attempts} attempts: {url}: {last_error}")
+
+
+def parse_json_or_sse(raw: str, content_type: str) -> Any:
+    """Parse a JSON response or the first JSON data event from an SSE response."""
+    if "text/event-stream" not in content_type.lower():
+        return json.loads(raw) if raw else {}
+
+    event_data: list[str] = []
+    for line in raw.splitlines() + [""]:
+        if line.startswith("data:"):
+            event_data.append(line[5:].lstrip())
+            continue
+        if line or not event_data:
+            continue
+        payload = "\n".join(event_data)
+        event_data = []
+        if payload and payload != "[DONE]":
+            return json.loads(payload)
+    raise ValueError("MCP SSE response did not contain a JSON data event.")
+
+
+def http_mcp_json(
+    url: str,
+    *,
+    body: dict[str, Any],
+    headers: dict[str, str] | None = None,
+    attempts: int = 1,
+    delay_seconds: float = 2,
+    timeout: int = 120,
+) -> tuple[int, Any]:
+    """POST one stateless MCP JSON-RPC request and accept JSON or SSE."""
+    payload = json.dumps(body).encode("utf-8")
+    request_headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        **(headers or {}),
+    }
+    last_error: Exception | None = None
+    for attempt in range(attempts):
+        request = urllib.request.Request(url, data=payload, headers=request_headers, method="POST")
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                raw = response.read().decode("utf-8", errors="replace")
+                content_type = response.headers.get("Content-Type", "application/json")
+                return response.status, parse_json_or_sse(raw, content_type)
+        except urllib.error.HTTPError as error:
+            last_error = error
+            if error.code < 500 or attempt == attempts - 1:
+                try:
+                    raw = error.read().decode("utf-8", errors="replace")
+                    content_type = error.headers.get("Content-Type", "application/json") if error.headers else "application/json"
+                finally:
+                    close_http_error(error)
+                try:
+                    return error.code, parse_json_or_sse(raw, content_type)
+                except (json.JSONDecodeError, ValueError):
+                    return error.code, {"error": "non-JSON MCP error response"}
+            close_http_error(error)
+        except (urllib.error.URLError, TimeoutError) as error:
+            last_error = error
+            if attempt == attempts - 1:
+                break
+        time.sleep(delay_seconds)
+    raise RuntimeError(f"MCP request failed after {attempts} attempts: {last_error}")

--- a/static-app/api/shared/search.js
+++ b/static-app/api/shared/search.js
@@ -5,6 +5,7 @@ function runtimeStatus() {
     searchApiVersion: process.env.AZURE_SEARCH_API_VERSION || '2026-05-01-preview',
     knowledgeBaseName: process.env.KNOWLEDGE_BASE_NAME || 'live-knowledge-sources-kb',
     mcpOnlyKnowledgeBaseName: process.env.MCP_ONLY_KNOWLEDGE_BASE_NAME || 'live-knowledge-sources-mcp-kb',
+    fabricOnlyKnowledgeBaseName: process.env.FABRIC_ONLY_KNOWLEDGE_BASE_NAME || 'live-knowledge-sources-fabric-kb',
     mcpKnowledgeSourceName: process.env.MCP_KNOWLEDGE_SOURCE_NAME || 'microsoft-learn-mcp-ks',
     fabricKnowledgeSourceName: process.env.FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME || 'fabric-ontology-ks',
     airlineOpsIndexName: process.env.AIRLINE_OPS_INDEX_NAME || 'airline-ops-regulatory-docs',
@@ -123,7 +124,11 @@ function buildRetrieveBody(options) {
 
 async function retrieveFromSearch(options) {
   const status = runtimeStatus();
-  const kbName = options.kind === 'mcp' ? status.mcpOnlyKnowledgeBaseName : status.knowledgeBaseName;
+  const kbName = options.kind === 'mcp'
+    ? status.mcpOnlyKnowledgeBaseName
+    : options.kind === 'fabric'
+      ? status.fabricOnlyKnowledgeBaseName
+      : status.knowledgeBaseName;
   const endpoint = process.env.AZURE_SEARCH_ENDPOINT.replace(/\/$/, '');
   const url = `${endpoint}/knowledgebases/${encodeURIComponent(kbName)}/retrieve?api-version=${status.searchApiVersion}`;
   const headers = {

--- a/tests/test_ks_factory.py
+++ b/tests/test_ks_factory.py
@@ -94,6 +94,17 @@ class KnowledgeSourceFactoryTests(unittest.TestCase):
         model_params = payload["models"][0]["azureOpenAIParameters"]
         self.assertEqual(model_params["apiKey"], "<azure-openai-api-key>")
 
+    def test_knowledge_base_can_include_separate_answer_instructions(self):
+        payload = create_knowledge_base(
+            name="fabric-kb",
+            knowledge_source_names=["fabric-ontology-ks"],
+            retrieval_instructions="Always query the ontology.",
+            answer_instructions="Answer only from ontology grounding.",
+        )
+
+        self.assertEqual(payload["retrievalInstructions"], "Always query the ontology.")
+        self.assertEqual(payload["answerInstructions"], "Answer only from ontology grounding.")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_liveks_config.py
+++ b/tests/test_liveks_config.py
@@ -25,6 +25,7 @@ class LiveKsConfigTests(unittest.TestCase):
         self.assertEqual(values["DEPLOYMENT_MODE"], "mcp-only")
         self.assertEqual(values["MCP_SERVER_URL"], "https://learn.microsoft.com/api/mcp")
         self.assertEqual(values["MCP_TOOL_NAME"], "microsoft_docs_search")
+        self.assertEqual(values["FABRIC_ONLY_KNOWLEDGE_BASE_NAME"], "live-knowledge-sources-fabric-kb")
         self.assertEqual(values["AZURE_OPENAI_MODEL_NAME"], "gpt-5-mini")
         self.assertEqual(values["AZURE_RESOURCE_GROUP"], "rg-unit-mcp")
 
@@ -151,6 +152,7 @@ class LiveKsConfigTests(unittest.TestCase):
             "mcpKnowledgeSourceName",
             "fabricKnowledgeSourceName",
             "mcpOnlyKnowledgeBaseName",
+            "fabricOnlyKnowledgeBaseName",
             "knowledgeBaseName",
         }
         self.assertTrue(expected.issubset(parameters))

--- a/tests/test_mcp_invocation.py
+++ b/tests/test_mcp_invocation.py
@@ -1,0 +1,182 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from liveks import cli  # noqa: E402
+from liveks.config import resolve_config  # noqa: E402
+from liveks.runtime import CommandResult, parse_json_or_sse  # noqa: E402
+
+
+class McpRunner:
+    def __init__(self, *, root, env, quiet=False):
+        self.root = root
+        self.env = env
+        self.quiet = quiet
+
+    def run(self, command, **kwargs):
+        args = [str(item) for item in command]
+        if args[:4] == ["azd", "env", "get-values"]:
+            output = (
+                'AZURE_RESOURCE_GROUP="rg-unit-mcp"\n'
+                'AZURE_SEARCH_ENDPOINT="https://unit-search.search.windows.net"\n'
+                'AZURE_SEARCH_SERVICE_NAME="unit-search"\n'
+                'AZURE_SEARCH_API_VERSION="2026-05-01-preview"\n'
+                'FABRIC_ONLY_KNOWLEDGE_BASE_NAME="unit-fabric-kb"\n'
+                'KNOWLEDGE_BASE_NAME="unit-kb"\n'
+            )
+            return CommandResult(args, 0, output)
+        if "admin-key" in args:
+            return CommandResult(args, 0, "super-secret-key\n")
+        if "get-access-token" in args:
+            return CommandResult(args, 0, "super-secret-token\n")
+        return CommandResult(args, 0, "")
+
+
+class McpInvocationTests(unittest.TestCase):
+    def test_json_and_sse_payloads_parse_to_same_shape(self):
+        payload = {"jsonrpc": "2.0", "id": 1, "result": {"tools": []}}
+        raw = json.dumps(payload)
+        self.assertEqual(parse_json_or_sse(raw, "application/json"), payload)
+        self.assertEqual(parse_json_or_sse(f"event: message\ndata: {raw}\n\n", "text/event-stream"), payload)
+
+    def test_mcp_report_records_only_sanitized_counts(self):
+        config = resolve_config(profile="full", environment="unit-mcp")
+        responses = [
+            (
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"tools": [{"name": "knowledge_base_retrieve"}]},
+                },
+            ),
+            (
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "result": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Alpine Air is grounded in the ontology. super-secret-token",
+                            }
+                        ]
+                    },
+                },
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir, mock.patch.object(cli, "ROOT", Path(temp_dir)), mock.patch.object(
+            cli, "CommandRunner", McpRunner
+        ), mock.patch.object(cli, "http_mcp_json", side_effect=responses):
+            report = cli.mcp_report(config, expected_terms=["Alpine Air"])
+            persisted = (Path(temp_dir) / "deployments/unit-mcp/mcp-call-report.json").read_text(encoding="utf-8")
+
+        self.assertEqual(report["status"], "pass")
+        self.assertIn("matched 1/1 expected term", persisted)
+        self.assertNotIn("super-secret", persisted)
+        self.assertNotIn("Alpine Air", persisted)
+        self.assertNotIn("unit-search.search.windows.net", persisted)
+
+    def test_mcp_report_marks_content_unverified_without_expected_terms(self):
+        config = resolve_config(profile="full", environment="unit-mcp")
+        responses = [
+            (200, {"result": {"tools": [{"name": "knowledge_base_retrieve"}]}}),
+            (200, {"result": {"content": [{"type": "text", "text": "A fluent but unverified answer."}]}}),
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir, mock.patch.object(cli, "ROOT", Path(temp_dir)), mock.patch.object(
+            cli, "CommandRunner", McpRunner
+        ), mock.patch.object(cli, "http_mcp_json", side_effect=responses):
+            report = cli.mcp_report(config)
+
+        grounding = next(check for check in report["checks"] if check["name"] == "grounding-content")
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(grounding["status"], "warn")
+
+    def test_expected_term_mismatch_fails_grounding_without_persisting_content(self):
+        config = resolve_config(profile="full", environment="unit-mcp")
+        responses = [
+            (200, {"result": {"tools": [{"name": "knowledge_base_retrieve"}]}}),
+            (200, {"result": {"content": [{"type": "text", "text": "A fluent but ungrounded answer."}]}}),
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir, mock.patch.object(cli, "ROOT", Path(temp_dir)), mock.patch.object(
+            cli, "CommandRunner", McpRunner
+        ), mock.patch.object(cli, "http_mcp_json", side_effect=responses):
+            report = cli.mcp_report(config, expected_terms=["Known ontology fact"])
+            persisted = (Path(temp_dir) / "deployments/unit-mcp/mcp-call-report.json").read_text(encoding="utf-8")
+
+        grounding = next(check for check in report["checks"] if check["name"] == "grounding-content")
+        self.assertEqual(report["status"], "fail")
+        self.assertEqual(grounding["status"], "fail")
+        self.assertNotIn("ungrounded", persisted)
+        self.assertNotIn("Known ontology fact", persisted)
+
+    def test_expected_failure_requires_protocol_or_tool_failure(self):
+        config = resolve_config(profile="full", environment="unit-mcp")
+        responses = [
+            (200, {"result": {"tools": [{"name": "knowledge_base_retrieve"}]}}),
+            (200, {"result": {"content": [{"type": "text", "text": "Ordinary content."}]}}),
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir, mock.patch.object(cli, "ROOT", Path(temp_dir)), mock.patch.object(
+            cli, "CommandRunner", McpRunner
+        ), mock.patch.object(cli, "http_mcp_json", side_effect=responses):
+            report = cli.mcp_report(config, expected_terms=["Missing"], expect_failure=True)
+
+        self.assertEqual(report["status"], "fail")
+        self.assertIn("expected a failure", report["checks"][-1]["message"])
+
+    def test_tool_discovery_exception_is_normalized_even_when_failure_is_expected(self):
+        config = resolve_config(profile="full", environment="unit-mcp")
+        raw_error = "https://private-search.example/secret-token"
+        with tempfile.TemporaryDirectory() as temp_dir, mock.patch.object(cli, "ROOT", Path(temp_dir)), mock.patch.object(
+            cli, "CommandRunner", McpRunner
+        ), mock.patch.object(cli, "http_mcp_json", side_effect=RuntimeError(raw_error)):
+            report = cli.mcp_report(config, expect_failure=True)
+            persisted = (Path(temp_dir) / "deployments/unit-mcp/mcp-call-report.json").read_text(encoding="utf-8")
+
+        self.assertEqual(report["status"], "fail")
+        self.assertIn("could not complete tool discovery", persisted)
+        self.assertNotIn(raw_error, persisted)
+
+    def test_expected_tool_failure_is_normalized_without_raw_error(self):
+        config = resolve_config(profile="full", environment="unit-mcp")
+        raw_error = "workspace 11111111-1111-1111-1111-111111111111 denied for super-secret-token"
+        responses = [
+            (
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {"tools": [{"name": "knowledge_base_retrieve"}]},
+                },
+            ),
+            (
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "result": {"isError": True, "content": [{"type": "text", "text": raw_error}]},
+                },
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir, mock.patch.object(cli, "ROOT", Path(temp_dir)), mock.patch.object(
+            cli, "CommandRunner", McpRunner
+        ), mock.patch.object(cli, "http_mcp_json", side_effect=responses):
+            report = cli.mcp_report(config, omit_source_authorization=True, expect_failure=True)
+            persisted = (Path(temp_dir) / "deployments/unit-mcp/mcp-call-report.json").read_text(encoding="utf-8")
+
+        self.assertEqual(report["status"], "pass")
+        self.assertIn("Expected failure reproduced", persisted)
+        self.assertNotIn(raw_error, persisted)
+        self.assertNotIn("11111111-1111-1111-1111-111111111111", persisted)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reframe the README and GitHub Pages manual around one managed-organization journey: components, one live source, grounding evidence, native MCP consumption, then configuration and limitations.
- Add a configuration-first runbook, official Microsoft Learn references, and a traceable Langflow benchmark adaptation record without copying external implementation or assets.
- Add a native Knowledge Base MCP client, an isolated Fabric-only Knowledge Base, sanitized success/failure reports, and tests that distinguish protocol content from known-fact grounding evidence.
- Deploy Pages for public repositories while keeping pull requests and private mirrors build-only.

## Validation
- `bash scripts/validate-local.sh --no-color` (15/15, 45 Python tests)
- `mkdocs build --strict --site-dir _site`
- `python tools/validate.py --profile offline --format json`
- Live BYO rehearsal: MCP Server, Fabric Ontology, and combined REST evidence passed; native Microsoft Learn MCP content matched a known fact; missing Fabric authorization produced a normalized tool error.
- The connected BYO ontology did not implement the checked-in Airline Ops fact, so the MCP expected-term check correctly failed instead of treating a fluent text block as grounded success.
- Generated Azure resources were removed and the reused Fabric workspace and ontology remained readable.

This branch has the same file tree as the validated personal-repository mirror.
