### PR TITLE
docs: show architecture hero in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this accelerator are documented here.
 
 ### Added
 
-- Landing-page architecture hero that shows the representative REST and native MCP client paths through Foundry IQ to Fabric Ontology and HTTPS MCP Server knowledge sources, including their distinct evidence contracts.
+- README and manual landing-page architecture hero that shows the representative REST and native MCP client paths through Foundry IQ to Fabric Ontology and HTTPS MCP Server knowledge sources, including their distinct evidence contracts.
 - Managed-organization GitHub Pages manual that leads operators from profile configuration through one Live Knowledge Source, Foundry IQ grounding evidence, native Knowledge Base MCP invocation, and known limitations, with official Microsoft Learn references.
 - Native `liveks mcp` client for JSON and SSE transports, tool discovery and calls, delegated Fabric source authorization, known-fact assertions, redacted reports, and reproducible expected-failure evidence.
 - Dedicated Fabric-only Knowledge Base configuration through `FABRIC_ONLY_KNOWLEDGE_BASE_NAME` so Fabric Ontology grounding can be verified independently of combined planner routing.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@
 
 [Read the execution manual](https://microsoft.github.io/azure-ai-search-foundry-iq-live-knowledge-sources/) | [Open the trace demo](https://microsoft.github.io/azure-ai-search-foundry-iq-live-knowledge-sources/demo/?demo=combined) | [Watch the KO/EN walkthrough](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/releases/tag/walkthrough-v1)
 
+<p align="center">
+  <img
+    src="docs/assets/live-knowledge-sources-hero.webp"
+    alt="REST retrieve and native MCP clients calling a Foundry IQ Knowledge Base backed by Fabric Ontology and HTTPS MCP Server knowledge sources, with separate REST and MCP evidence contracts."
+    width="1200"
+  />
+</p>
+
 This public accelerator is designed for managed-organization evaluation, field demos, and implementation review. It is not a production reference architecture.
 
 ## Components At A Glance


### PR DESCRIPTION
## Summary

- show the existing architecture hero directly below the README badges and project links
- update the changelog to cover both README and manual landing surfaces

## Validation

- `bash scripts/validate-local.sh --no-color` (15/15 passed, 45 Python tests)
- `git diff --check`