### PR TITLE
Enforce Fabric release verification after E2E cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ Use the evidence that matches the claim:
 | Combined routing worked | Recognized live evidence from the source or sources selected by the combined KB planner |
 | Knowledge Base MCP is callable | `liveks mcp` passes `tools/list` and `tools/call` |
 | Knowledge Base MCP returned expected grounding | `liveks mcp --expect-term <known-fact>` passes `grounding-content`; pair it with source-specific `verify` evidence before naming the source that ran |
+| Fabric-only rehearsal is complete | `scripts/fabric-e2e-test.sh --cleanup` ends with `fabric_release=PASS`; generated workspace and, for create mode, capacity resource group and ARM capacity are absent |
 | Full rehearsal is complete | Create and retrieve checks pass; deployment RG, generated capacity RG, and generated capacity absence checks pass |
 
 Final answer text alone is not routing evidence. Inspect `activity`, `references`, and `sourceData`, and use the single-source KB checks to prove MCP and Fabric independently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this accelerator are documented here.
 - Full runs reconcile generated Fabric state, tolerate initial OneLake metadata propagation, and hand preprovisioned capacity IDs to Bicep without duplicate creation.
 - Cleanup polls for Azure resource-group deletion and removes an accelerator-created residual group only when the pre-preview ownership record proves it was not pre-existing.
 - Full cleanup now proves both generated resource groups are absent and the matching Fabric capacity resource count is zero, while omitting deletion claims for reused capacity.
+- Fabric-only E2E cleanup now waits for deletion and ends with a mandatory release check that proves generated workspaces and create-mode capacities are absent while preserving BYO capacity.
 
 ### Compatibility
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ Before cleanup, open the App URL in `deployments/<environment>/deployment-summar
 
 Require `resource-group-absent`. A `full` run that generated Fabric capacity must also report `fabric-capacity-resource-group-absent` and `fabric-capacity-absent`.
 
+A Fabric-only rehearsal must run `scripts/fabric-e2e-test.sh --cleanup` and end with `fabric_release=PASS`. Create mode proves the generated workspace, capacity resource group, and capacity are absent; BYO mode proves the generated workspace is absent while preserving the existing capacity.
+
 For a controlled end-to-end rehearsal:
 
 ```bash

--- a/docs/maintainers/test-specs/e2e-fabric-greenfield.md
+++ b/docs/maintainers/test-specs/e2e-fabric-greenfield.md
@@ -70,6 +70,7 @@ bash scripts/fabric-e2e-test.sh \
 | Ontology definition readable | PASS |
 | Ontology-backed GraphModel queryable | PASS |
 | Cleanup completes | PASS when `--cleanup` is used |
+| Fabric release verification | PASS after generated assets are confirmed absent |
 
 ## Pass Criteria
 
@@ -82,5 +83,7 @@ The run passes when `deployments/<env>/fabric-test-report.md` shows all checks p
 - `ontologyValidation.status == "ok"`
 - `graphValidation.status == "ok"`
 - `graphValidation.probe.rowCount > 0`
+
+The final `fabric_release` check is mandatory when `--cleanup` is used. In `create` mode it confirms that the generated workspace, capacity resource group, and ARM Fabric capacity are absent. In `byo` mode it confirms that the generated workspace is absent while the existing capacity is preserved. A delete request by itself is not release evidence.
 
 Generated reports are ignored by git and must not contain tokens or credentials.

--- a/scripts/fabric-destroy.py
+++ b/scripts/fabric-destroy.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -16,12 +17,19 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FABRIC_API = "https://api.fabric.microsoft.com/v1"
 FABRIC_RESOURCE = "https://api.fabric.microsoft.com"
+FABRIC_DELETE_ATTEMPTS = 60
+FABRIC_DELETE_DELAY_SECONDS = 5
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Clean up generated Fabric sample assets.")
     parser.add_argument("--env-name", help="Deployment environment name.")
     parser.add_argument("--yes", action="store_true", help="Delete without interactive confirmation.")
+    parser.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Verify that generated Fabric assets are absent without deleting anything.",
+    )
     return parser.parse_args()
 
 
@@ -65,6 +73,35 @@ def fabric_delete(path: str, token: str) -> None:
         raise RuntimeError(f"DELETE {path} failed: {error.code}\n{detail}") from error
 
 
+def fabric_exists(path: str, token: str) -> bool:
+    request = urllib.request.Request(
+        f"{FABRIC_API}{path}",
+        headers={"Authorization": f"Bearer {token}"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return response.status in (200, 202, 204)
+    except urllib.error.HTTPError as error:
+        try:
+            detail = error.read().decode("utf-8", errors="replace")
+        finally:
+            error.close()
+        if error.code == 404:
+            return False
+        raise RuntimeError(f"GET {path} failed: {error.code}\n{detail}") from error
+
+
+def wait_for_fabric_absent(path: str, token: str, label: str) -> None:
+    for attempt in range(FABRIC_DELETE_ATTEMPTS):
+        if not fabric_exists(path, token):
+            print(f"[verify] Generated {label} is absent.")
+            return
+        if attempt < FABRIC_DELETE_ATTEMPTS - 1:
+            time.sleep(FABRIC_DELETE_DELAY_SECONDS)
+    raise RuntimeError(f"Generated {label} still exists after cleanup: {path}")
+
+
 def load_summary(env_name: str) -> dict[str, Any] | None:
     path = REPO_ROOT / "deployments" / env_name / "fabric-summary.json"
     if not path.exists():
@@ -80,18 +117,129 @@ def confirm(summary: dict[str, Any]) -> None:
         raise SystemExit("Fabric cleanup cancelled.")
 
 
-def delete_capacity_resource_group(summary: dict[str, Any], azd_values: dict[str, str]) -> None:
+def resource_group_exists(name: str) -> bool:
+    output = run(["az", "group", "exists", "--name", name]).strip().lower()
+    if output not in {"true", "false"}:
+        raise RuntimeError(f"Could not determine whether resource group {name} exists: {output}")
+    return output == "true"
+
+
+def arm_capacity_exists(name: str) -> bool:
+    output = run(["az", "resource", "list", "--resource-type", "Microsoft.Fabric/capacities", "--output", "json"])
+    try:
+        capacities = json.loads(output or "[]")
+    except json.JSONDecodeError as error:
+        raise RuntimeError("Could not parse the Fabric capacity inventory returned by Azure CLI.") from error
+    return any(
+        str(capacity.get("name") or "") == name
+        for capacity in capacities
+        if isinstance(capacity, dict)
+    )
+
+
+def fabric_capacity_exists(name: str, token: str) -> bool:
+    request = urllib.request.Request(
+        f"{FABRIC_API}/capacities",
+        headers={"Authorization": f"Bearer {token}"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        try:
+            detail = error.read().decode("utf-8", errors="replace")
+        finally:
+            error.close()
+        raise RuntimeError(f"GET /capacities failed: {error.code}\n{detail}") from error
+    return any(
+        str(capacity.get("displayName") or "") == name
+        for capacity in payload.get("value", [])
+        if isinstance(capacity, dict)
+    )
+
+
+def wait_for_capacity_absent(name: str, token: str) -> None:
+    arm_present = False
+    fabric_present = False
+    for attempt in range(FABRIC_DELETE_ATTEMPTS):
+        arm_present = arm_capacity_exists(name)
+        fabric_present = fabric_capacity_exists(name, token)
+        if not arm_present and not fabric_present:
+            print(f"[verify] Generated Fabric capacity {name} is absent from ARM and Fabric API.")
+            return
+        if attempt < FABRIC_DELETE_ATTEMPTS - 1:
+            time.sleep(FABRIC_DELETE_DELAY_SECONDS)
+    raise RuntimeError(
+        f"Generated Fabric capacity still exists after cleanup: {name} "
+        f"(ARM={arm_present}, Fabric API={fabric_present})"
+    )
+
+
+def delete_capacity_resource_group(summary: dict[str, Any], azd_values: dict[str, str]) -> bool:
     if not summary.get("capacityCreated"):
-        return
+        return False
     rg = str(summary.get("capacityResourceGroup") or "")
     if not rg:
-        return
+        raise RuntimeError("Generated Fabric capacity is missing capacityResourceGroup in the cleanup summary.")
     azure_rg = azd_values.get("AZURE_RESOURCE_GROUP", "")
-    if rg == azure_rg:
+    if rg.lower() == azure_rg.lower():
         print(f"[skip] Fabric capacity is in azd resource group {rg}; azd down will delete it.")
-        return
-    print(f"[delete] Azure resource group for generated Fabric capacity: {rg}")
-    run(["az", "group", "delete", "--name", rg, "--yes", "--no-wait"], allow_failure=True)
+        return True
+    if resource_group_exists(rg):
+        print(f"[delete] Azure resource group for generated Fabric capacity: {rg}")
+        run(["az", "group", "delete", "--name", rg, "--yes", "--no-wait"])
+        run(["az", "group", "wait", "--name", rg, "--deleted", "--timeout", "1800"])
+    return False
+
+
+def verify_cleanup(summary: dict[str, Any], token: str, *, verify_capacity: bool = True) -> None:
+    generated_items = (
+        (
+            "ontology",
+            "ontologyCreated",
+            "ontologyId",
+            lambda workspace_id, item_id: f"/workspaces/{workspace_id}/ontologies/{item_id}",
+        ),
+        (
+            "Lakehouse",
+            "lakehouseCreated",
+            "lakehouseId",
+            lambda workspace_id, item_id: f"/workspaces/{workspace_id}/lakehouses/{item_id}",
+        ),
+    )
+    workspace_id = str(summary.get("workspaceId") or "")
+    for label, created_key, id_key, path_for in generated_items:
+        if not summary.get(created_key):
+            continue
+        item_id = str(summary.get(id_key) or "")
+        if not workspace_id or not item_id:
+            raise RuntimeError(f"Generated {label} is missing its workspace or item ID in the cleanup summary.")
+        wait_for_fabric_absent(path_for(workspace_id, item_id), token, label)
+
+    if summary.get("workspaceCreated"):
+        if not workspace_id:
+            raise RuntimeError("Generated Fabric workspace is missing workspaceId in the cleanup summary.")
+        wait_for_fabric_absent(f"/workspaces/{workspace_id}", token, "workspace")
+
+    if summary.get("capacityCreated") and verify_capacity:
+        capacity_name = str(summary.get("capacityName") or "")
+        capacity_group = str(summary.get("capacityResourceGroup") or "")
+        if not capacity_name or not capacity_group:
+            raise RuntimeError("Generated Fabric capacity is missing its name or resource group in the cleanup summary.")
+        if resource_group_exists(capacity_group):
+            raise RuntimeError(f"Generated Fabric capacity resource group still exists: {capacity_group}")
+        wait_for_capacity_absent(capacity_name, token)
+        print(f"[verify] Generated Fabric capacity resource group {capacity_group} is absent.")
+    elif summary.get("capacityCreated"):
+        print("[verify] Generated Fabric capacity release is deferred to azd down.")
+    else:
+        capacity_name = str(summary.get("capacityName") or "")
+        if not capacity_name:
+            raise RuntimeError("Reused Fabric capacity is missing capacityName in the cleanup summary.")
+        if not fabric_capacity_exists(capacity_name, token):
+            raise RuntimeError(f"Reused Fabric capacity is no longer present: {capacity_name}")
+        print(f"[verify] Reused Fabric capacity {capacity_name} is preserved.")
 
 
 def main() -> None:
@@ -100,12 +248,18 @@ def main() -> None:
     env_name = args.env_name or os.environ.get("AZURE_ENV_NAME") or azd_values.get("AZURE_ENV_NAME") or "dev"
     summary = load_summary(env_name)
     if not summary:
+        if args.verify_only:
+            raise RuntimeError(f"Fabric cleanup summary is missing for {env_name}; release cannot be verified.")
         print(f"No Fabric summary found for {env_name}; nothing to delete.")
+        return
+    token = get_token()
+    if args.verify_only:
+        verify_cleanup(summary, token)
+        print("Fabric release verified.")
         return
     if not args.yes:
         confirm(summary)
 
-    token = get_token()
     workspace_id = str(summary.get("workspaceId") or "")
     ontology_id = str(summary.get("ontologyId") or "")
     lakehouse_id = str(summary.get("lakehouseId") or "")
@@ -120,8 +274,9 @@ def main() -> None:
         print(f"[delete] Workspace {workspace_id}")
         fabric_delete(f"/workspaces/{workspace_id}", token)
 
-    delete_capacity_resource_group(summary, azd_values)
-    print("Fabric cleanup complete.")
+    capacity_release_deferred = delete_capacity_resource_group(summary, azd_values)
+    verify_cleanup(summary, token, verify_capacity=not capacity_release_deferred)
+    print("Fabric cleanup and release verification complete.")
 
 
 if __name__ == "__main__":

--- a/scripts/fabric-e2e-test.sh
+++ b/scripts/fabric-e2e-test.sh
@@ -25,6 +25,7 @@ CHECK_IDS=(
   "ontology_definition"
   "graph_model"
   "cleanup"
+  "fabric_release"
 )
 CHECK_LABELS=(
   "External tenant login is active"
@@ -37,6 +38,7 @@ CHECK_LABELS=(
   "Ontology definition is readable"
   "Ontology-backed GraphModel is queryable"
   "Fabric cleanup completes"
+  "Generated Fabric assets are released"
 )
 CHECK_STATUS=()
 CHECK_NOTES=()
@@ -187,12 +189,24 @@ json_expr() {
 cleanup() {
   if [[ "$CLEANUP" == "true" ]]; then
     if python3 scripts/fabric-destroy.py --env-name "$ENV_NAME" --yes 2>&1 | tee -a "$LOG_FILE"; then
-      set_check "cleanup" "PASS" "fabric-destroy.py completed"
+      set_check "cleanup" "PASS" "fabric-destroy.py completed and waited for deletion"
     else
       set_check "cleanup" "FAIL" "fabric-destroy.py failed"
+      set_check "fabric_release" "FAIL" "Cleanup failed; Fabric release could not be verified."
+      return
+    fi
+    if python3 scripts/fabric-destroy.py --env-name "$ENV_NAME" --verify-only 2>&1 | tee -a "$LOG_FILE"; then
+      if [[ "$FABRIC_CAPACITY_MODE" == "create" ]]; then
+        set_check "fabric_release" "PASS" "Generated workspace, capacity resource group, and capacity are absent."
+      else
+        set_check "fabric_release" "PASS" "Generated workspace is absent and the BYO capacity is preserved."
+      fi
+    else
+      set_check "fabric_release" "FAIL" "Generated Fabric assets are still present or could not be verified."
     fi
   else
     set_check "cleanup" "SKIP" "Resources kept for debugging."
+    set_check "fabric_release" "SKIP" "Resources intentionally retained; release was not requested."
   fi
 }
 

--- a/tests/test_deployment_safety.py
+++ b/tests/test_deployment_safety.py
@@ -27,6 +27,15 @@ def load_fabric_provision_module():
     return module
 
 
+def load_fabric_destroy_module():
+    path = ROOT / "scripts/fabric-destroy.py"
+    spec = importlib.util.spec_from_file_location("fabric_destroy_for_tests", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
 class FakeHttpResponse:
     status = 200
     headers = {}
@@ -142,6 +151,109 @@ class FabricProvisionSafetyTests(unittest.TestCase):
             self.assertEqual(summary["status"], "failed")
             self.assertTrue(summary["capacityCreated"])
             self.assertIn("workspace boom", summary["error"])
+
+
+class FabricDestroySafetyTests(unittest.TestCase):
+    def test_verify_only_fails_when_cleanup_summary_is_missing(self):
+        module = load_fabric_destroy_module()
+        with (
+            mock.patch.object(sys, "argv", ["fabric-destroy.py", "--env-name", "missing", "--verify-only"]),
+            mock.patch.object(module, "load_azd_env", return_value={}),
+            mock.patch.object(module, "load_summary", return_value=None),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "release cannot be verified"):
+                module.main()
+
+    def test_generated_capacity_group_delete_waits_for_completion(self):
+        module = load_fabric_destroy_module()
+        summary = {
+            "capacityCreated": True,
+            "capacityName": "fabunit",
+            "capacityResourceGroup": "rg-unit-fabric",
+        }
+        with (
+            mock.patch.object(module, "resource_group_exists", return_value=True),
+            mock.patch.object(module, "run", return_value="") as run,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            deferred = module.delete_capacity_resource_group(summary, {"AZURE_RESOURCE_GROUP": "rg-unit-app"})
+        self.assertFalse(deferred)
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertIn(["az", "group", "delete", "--name", "rg-unit-fabric", "--yes", "--no-wait"], commands)
+        self.assertIn(["az", "group", "wait", "--name", "rg-unit-fabric", "--deleted", "--timeout", "1800"], commands)
+
+    def test_cleanup_verification_requires_generated_assets_to_be_absent(self):
+        module = load_fabric_destroy_module()
+        summary = {
+            "capacityCreated": True,
+            "capacityName": "fabunit",
+            "capacityResourceGroup": "rg-unit-fabric",
+            "workspaceCreated": True,
+            "workspaceId": "workspace-id",
+            "lakehouseCreated": True,
+            "lakehouseId": "lakehouse-id",
+            "ontologyCreated": True,
+            "ontologyId": "ontology-id",
+        }
+        with (
+            mock.patch.object(module, "wait_for_fabric_absent") as wait,
+            mock.patch.object(module, "resource_group_exists", return_value=False),
+            mock.patch.object(module, "wait_for_capacity_absent") as capacity_wait,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            module.verify_cleanup(summary, "token")
+        self.assertEqual(wait.call_count, 3)
+        capacity_wait.assert_called_once_with("fabunit", "token")
+
+    def test_cleanup_verification_fails_when_generated_capacity_remains(self):
+        module = load_fabric_destroy_module()
+        summary = {
+            "capacityCreated": True,
+            "capacityName": "fabunit",
+            "capacityResourceGroup": "rg-unit-fabric",
+        }
+        with (
+            mock.patch.object(module, "resource_group_exists", return_value=False),
+            mock.patch.object(
+                module,
+                "wait_for_capacity_absent",
+                side_effect=RuntimeError("Generated Fabric capacity still exists after cleanup: fabunit"),
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "capacity still exists"):
+                module.verify_cleanup(summary, "token")
+
+    def test_capacity_absence_waits_for_arm_and_fabric_inventories(self):
+        module = load_fabric_destroy_module()
+        with (
+            mock.patch.object(module, "arm_capacity_exists", side_effect=[True, False]) as arm_exists,
+            mock.patch.object(module, "fabric_capacity_exists", side_effect=[True, False]) as fabric_exists,
+            mock.patch.object(module.time, "sleep") as sleep,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            module.wait_for_capacity_absent("fabunit", "token")
+        self.assertEqual(arm_exists.call_count, 2)
+        self.assertEqual(fabric_exists.call_count, 2)
+        sleep.assert_called_once_with(module.FABRIC_DELETE_DELAY_SECONDS)
+
+    def test_cleanup_verification_preserves_reused_capacity(self):
+        module = load_fabric_destroy_module()
+        summary = {
+            "capacityCreated": False,
+            "capacityName": "fab-byo",
+            "workspaceCreated": True,
+            "workspaceId": "workspace-id",
+        }
+        with (
+            mock.patch.object(module, "wait_for_fabric_absent") as wait,
+            mock.patch.object(module, "resource_group_exists") as group_exists,
+            mock.patch.object(module, "fabric_capacity_exists", return_value=True) as capacity_exists,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            module.verify_cleanup(summary, "token")
+        wait.assert_called_once_with("/workspaces/workspace-id", "token", "workspace")
+        group_exists.assert_not_called()
+        capacity_exists.assert_called_once_with("fab-byo", "token")
 
 
 class FakeCleanupRunner:


### PR DESCRIPTION
## Summary
- wait for generated Fabric workspace and capacity deletion instead of treating a delete request as completion
- add a final `fabric_release` gate to Fabric-only E2E while preserving and verifying BYO capacity
- document the release evidence contract and add cleanup safety tests

## Validation
- `bash scripts/validate-local.sh --no-color` (15/15; 51 tests)
- live read-only `fabric-destroy.py --verify-only` against a previously cleaned full environment (workspace, Lakehouse, ontology, capacity RG, ARM capacity, and Fabric API capacity absent)