### PR TITLE
Harden Fabric ownership and cleanup lifecycle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,19 @@ updates:
       static-app-dependencies:
         patterns:
           - "*"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - python
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,8 +84,8 @@ Use the evidence that matches the claim:
 | Combined routing worked | Recognized live evidence from the source or sources selected by the combined KB planner |
 | Knowledge Base MCP is callable | `liveks mcp` passes `tools/list` and `tools/call` |
 | Knowledge Base MCP returned expected grounding | `liveks mcp --expect-term <known-fact>` passes `grounding-content`; pair it with source-specific `verify` evidence before naming the source that ran |
-| Fabric-only rehearsal is complete | `scripts/fabric-e2e-test.sh --cleanup` ends with `fabric_release=PASS`; generated workspace and, for create mode, capacity resource group and ARM capacity are absent |
-| Full rehearsal is complete | Create and retrieve checks pass; deployment RG, generated capacity RG, and generated capacity absence checks pass |
+| Fabric-only rehearsal is complete | `scripts/fabric-e2e-test.sh --cleanup` ends with `fabric_release=PASS`; generated workspace and, for create mode, ARM capacity are absent, while the capacity group is deleted or preserved according to its ownership record |
+| Full rehearsal is complete | Create and retrieve checks pass; deployment RG and generated capacity absence checks pass, with capacity-group deletion or preservation matching its ownership record |
 
 Final answer text alone is not routing evidence. Inspect `activity`, `references`, and `sourceData`, and use the single-source KB checks to prove MCP and Fabric independently.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this accelerator are documented here.
 
 ### Added
 
+- Fabric capacity and dedicated resource-group ownership journaling, environment tags, and cleanup tests for partial provisioning, failed capacity creation, shared resource groups, missing summaries, and pre-existing capacities.
+- Weekly Dependabot coverage for the root Python requirements files.
 - Outcome-first clone-to-grounded-proof hero for the README and manual landing page, backed by the actual LiveKS profile, lifecycle, evidence, and cleanup contracts.
 - MCP Server KS first-live-success procedure and an architecture-to-code traceability map that connect each public claim to checked-in configuration, implementation, CLI, and CI boundaries.
 - Managed-organization GitHub Pages manual that leads operators from profile configuration through one Live Knowledge Source, Foundry IQ grounding evidence, native Knowledge Base MCP invocation, and known limitations, with official Microsoft Learn references.
@@ -24,6 +26,8 @@ All notable changes to this accelerator are documented here.
 ### Changed
 
 - The MCP Server guide now uses one payload-to-cleanup execution contract that distinguishes representative JSON, the resolved deployment dry-run, live retrieve evidence, and native Knowledge Base MCP content proof.
+- Full create mode now rejects an existing capacity unless the same environment summary or exact tagged Bicep output proves ownership, records ARM ownership before readiness polling, and redacts administrator and generated IDs from provisioning settings output.
+- Fabric cleanup deletes a capacity resource group only when this run created the group and no unrelated resources are present; otherwise it deletes only the owned capacity and verifies preservation of a pre-existing group. Missing, conflicting, or unresolved full-mode ownership now reports partial cleanup instead of a false pass.
 - MCP Server and public-preview guidance now provide a reciprocal reader path, backed by a maintainer audit of the repository's documentation, CI, deployment, authentication, and traffic evidence.
 - README and manual onboarding now reserve the hero for the user journey and leave Knowledge Base topology to the detailed Architecture section.
 - The overview reader path now starts with dependency-free offline replay, then moves through profile selection, guarded planning, live evidence, and repository validation.

--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ Before cleanup, open the App URL in `deployments/<environment>/deployment-summar
 ./liveks down --env liveks-byo
 ```
 
-Require `resource-group-absent`. A `full` run that generated Fabric capacity must also report `fabric-capacity-resource-group-absent` and `fabric-capacity-absent`.
+Require `resource-group-absent`. A `full` run that generated Fabric capacity must also report `fabric-capacity-absent`, plus either `fabric-capacity-resource-group-absent` for a generated group or `fabric-capacity-resource-group-preserved` for a pre-existing group.
 
-A Fabric-only rehearsal must run `scripts/fabric-e2e-test.sh --cleanup` and end with `fabric_release=PASS`. Create mode proves the generated workspace, capacity resource group, and capacity are absent; BYO mode proves the generated workspace is absent while preserving the existing capacity.
+A Fabric-only rehearsal must run `scripts/fabric-e2e-test.sh --cleanup` and end with `fabric_release=PASS`. Create mode proves the generated workspace and capacity are absent, and separately proves that the capacity group was deleted or preserved according to its ownership record. BYO mode proves the generated workspace is absent while preserving the existing capacity.
 
 For a controlled end-to-end rehearsal:
 

--- a/docs/07-troubleshooting.md
+++ b/docs/07-troubleshooting.md
@@ -106,7 +106,7 @@ Start with machine-readable diagnostics:
 - Read the ownership check in the `down` output and the redacted `.liveks/<env>.lock.json`.
 - BYO Fabric assets must remain untouched even when Azure cleanup fails.
 - For full mode, Azure cleanup continues after a Fabric cleanup warning.
-- Every live cleanup must pass `resource-group-absent`. A full run that created capacity must also pass `fabric-capacity-resource-group-absent` and `fabric-capacity-absent`.
+- Every live cleanup must pass `resource-group-absent`. A full run that created capacity must also pass `fabric-capacity-absent`, plus `fabric-capacity-resource-group-absent` for a generated group or `fabric-capacity-resource-group-preserved` for a pre-existing group.
 - If an absence check is still pending, wait for ARM deletion propagation and rerun `liveks down --env <environment> --yes --format json` before deleting anything manually.
 - Before manually deleting a Fabric capacity resource group, list its contents and verify in Fabric that no shared workspace is assigned.
 - Return code `4` means cleanup needs explicit follow-up; do not report the rehearsal as complete.

--- a/docs/10-one-command-deployment.md
+++ b/docs/10-one-command-deployment.md
@@ -147,27 +147,26 @@ Cleanup order:
 3. delete Fabric only when both identify it as generated,
 4. run `azd down --purge --force`,
 5. verify the generated deployment resource group is absent,
-6. when this run created a Fabric capacity, verify its dedicated resource group is absent and the matching ARM capacity count is zero.
+6. when this run created a Fabric capacity, verify the matching ARM capacity is absent,
+7. when this run also created the dedicated capacity resource group, verify that group is absent.
 
-For `byo-fabric`, Fabric cleanup is always skipped. For `full`, a Fabric cleanup failure is reported as partial but Azure cleanup continues.
+For `byo-fabric`, Fabric cleanup is always skipped. For `full`, a Fabric cleanup failure, missing or invalid lock, or missing ownership summary is reported as partial but Azure cleanup continues. Create mode refuses to adopt an existing capacity unless the same environment's prior summary proves ownership. The direct `azd` compatibility path can instead prove the exact Bicep-created ARM ID with matching environment, solution, and manager tags.
 
 Successful `down --format json` output contains these checks:
 
 | Check | Applies to | Required result |
 | --- | --- | --- |
 | `resource-group-absent` | Every live profile | `pass` |
-| `fabric-capacity-resource-group-absent` | `full` when the run created capacity | `pass` |
+| `fabric-capacity-resource-group-absent` | `full` when the run created the dedicated capacity group | `pass` |
+| `fabric-capacity-resource-group-preserved` | `full` when the capacity was created in a pre-existing group | `pass` |
 | `fabric-capacity-absent` | `full` when the run created capacity | `pass` |
 
-For an independent Azure CLI confirmation, take the generated names from the ignored Fabric summary and expect `false`, `false`, and `0`:
+For an independent Azure CLI confirmation, take the generated values from the ignored Fabric summary. Expect the deployment group to be absent and the exact capacity lookup to return `ResourceNotFound`. Expect the capacity group to be absent when `capacityResourceGroupCreated` is true, present when it is false, and manually reviewed when the field is missing:
 
 ```bash
 az group exists --name <deployment-resource-group>
 az group exists --name <fabric-capacity-resource-group>
-az resource list \
-  --resource-type Microsoft.Fabric/capacities \
-  --query "length([?name=='<fabric-capacity-name>'])" \
-  --output tsv
+az resource show --ids <fabric-capacity-arm-id> --only-show-errors
 ```
 
 Do not apply the Fabric absence checks to `byo-fabric`: preserving its existing capacity, workspace, and ontology is the required result.
@@ -197,17 +196,21 @@ The lifecycle writes ignored `deployments/<environment>/e2e-report.json` and `te
 If full cleanup reports a residual capacity:
 
 1. inspect `deployments/<environment>/fabric-summary.json`,
-2. confirm the capacity was created by this exact environment,
-3. list every resource in its Azure resource group,
-4. confirm no shared workspace is assigned in Fabric,
-5. delete only the generated capacity or its dedicated empty resource group.
+2. confirm `capacityCreated` is true for this exact environment,
+3. check `capacityResourceGroupCreated` before treating the whole group as owned,
+4. list every resource in its Azure resource group,
+5. confirm no shared workspace is assigned in Fabric,
+6. delete only the generated capacity or its owned, otherwise empty resource group.
 
 ```bash
 az resource list --resource-group <fabric-capacity-resource-group> -o table
+# Use only when capacityResourceGroupCreated is true and the inventory is otherwise empty:
 az group delete --name <fabric-capacity-resource-group> --yes --no-wait
+# Otherwise delete the proven generated capacity and preserve the group:
+az resource delete --ids <fabric-capacity-arm-id>
 ```
 
-Do not delete a group that contains non-sample resources, a BYO capacity, or an asset whose ownership cannot be proven. Inspect both Azure and the Fabric admin portal before manual cleanup.
+Do not delete a group that contains non-sample resources, a BYO capacity, or an asset whose ownership cannot be proven. New full runs tag generated capacity resources with the environment and solution, but tags support the ownership record rather than replacing it. Inspect both Azure and the Fabric admin portal before manual cleanup.
 
 ## Direct azd Compatibility
 

--- a/docs/20-liveks-cli.md
+++ b/docs/20-liveks-cli.md
@@ -56,7 +56,7 @@ Use JSON output when cleanup evidence will be reviewed:
 ./liveks down --env liveks-full --yes --format json
 ```
 
-Every live profile must report `resource-group-absent=pass`. A `full` run that created capacity must additionally report `fabric-capacity-resource-group-absent=pass` and `fabric-capacity-absent=pass`. These checks are omitted for reused capacity so preservation is not misreported as failed deletion.
+Every live profile must report `resource-group-absent=pass`. A `full` run that created capacity must additionally report `fabric-capacity-absent=pass`. It must also report `fabric-capacity-resource-group-absent=pass` when the same run created that dedicated group, or `fabric-capacity-resource-group-preserved=pass` when the group predated the run. A missing summary or unresolved ownership produces partial cleanup instead of a deletion claim.
 
 For `byo-fabric` and `full`, `mcp` attaches delegated source authorization by default. It records text-block and expected-term counts but never persists the endpoint, query, response content, key, or token. A call without `--expect-term` can pass protocol checks but reports `grounding-content=warn`; use a known non-sensitive fact for source-content acceptance. See [Call the Knowledge Base Through MCP](22-knowledge-base-mcp.md).
 

--- a/docs/fabric-ontology-prerequisites.md
+++ b/docs/fabric-ontology-prerequisites.md
@@ -43,7 +43,7 @@ The YAML ledger is the authoring source. LiveKS derives and projects the followi
 | `FABRIC_CAPACITY_NAME` | generated from env name | Optional capacity display/resource name. | None by itself |
 | `FABRIC_CAPACITY_ID` | empty before provisioning | Generated capacity ID. | Identifies generated billing |
 | `FABRIC_CAPACITY_ARM_ID` | empty before provisioning | Generated ARM capacity ID. | Identifies generated billing |
-| `FABRIC_CAPACITY_RESOURCE_GROUP` | `AZURE_RESOURCE_GROUP` or `rg-<env>-fabric` | Resource group for generated capacity. | Deleted by `fabric-destroy.py` only when this run created the capacity |
+| `FABRIC_CAPACITY_RESOURCE_GROUP` | `AZURE_RESOURCE_GROUP` or `rg-<env>-fabric` | Resource group for generated capacity. | The group is deleted only when this run created it and it contains no unrelated resources; otherwise only the owned capacity is deleted |
 | `FABRIC_CAPACITY_ADMIN` | signed-in Azure user | UPN assigned as capacity administrator when creating capacity. | None by itself |
 | `FABRIC_LOCATION` | `AZURE_LOCATION` or `westus3` | Fabric capacity location. Use a region with Fabric quota. | Region quota controls whether capacity can be created |
 | `FABRIC_WORKSPACE_ID` | empty before provisioning | Generated workspace ID. | Uses generated capacity |
@@ -53,7 +53,7 @@ The YAML ledger is the authoring source. LiveKS derives and projects the followi
 | `FABRIC_ONTOLOGY_ID` | empty before provisioning | Generated ontology item ID. | Uses generated workspace |
 | `FABRIC_ONTOLOGY_NAME` | `AirlineOpsOntology` | Generated ontology name. | Uses selected capacity |
 
-`full` rejects authored workspace and ontology IDs. Fresh runs clear stale generated IDs before resolving assets by their derived names. Generated IDs are written only to ignored deployment state so cleanup can find partially created assets, then cleared from `azd env` after `down`.
+`full` rejects authored workspace and ontology IDs. Fresh runs clear stale generated IDs before resolving assets by their derived names. Create mode also rejects a same-named existing capacity unless the same environment summary proves it was created by an earlier attempt, or the direct `azd` path supplies the exact Bicep-created ARM ID with matching ownership tags. Generated IDs and separate capacity/resource-group ownership flags are written only to ignored deployment state so cleanup can find partially created assets, then generated IDs are cleared from `azd env` after `down`.
 
 If the Azure portal shows a leftover generated Fabric capacity resource group after a test run, use [Residual Fabric Capacity](10-one-command-deployment.md#residual-fabric-capacity) before assuming the resource is still needed.
 

--- a/docs/maintainers/repository-lifecycle-hardening-audit-2026-08-13.md
+++ b/docs/maintainers/repository-lifecycle-hardening-audit-2026-08-13.md
@@ -1,0 +1,72 @@
+# Repository Lifecycle Hardening Audit
+
+This maintainer record captures the repository-wide review completed on 2026-08-13. The review concentrated on deployment ownership, Fabric billing release, cleanup evidence, public logging boundaries, dependency maintenance, and the local validation contract. No customer or tenant identifiers are included.
+
+## Baseline
+
+The starting branch passed the complete local contract before modification:
+
+- `python3 tools/validate.py --profile offline --format json`: pass.
+- `bash scripts/validate-local.sh`: 15 of 15 gates passed.
+- `python3 -m unittest discover -s tests`: 51 tests passed.
+- `az bicep lint --file infra/main.bicep`: no diagnostics.
+- `npm --prefix static-app audit --omit=dev --json`: no vulnerabilities.
+- `git diff --check`: pass.
+
+The current `2026-05-01-preview` Search API remains intentional. [Microsoft Learn's retrieve guidance](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-retrieve) documents that the preview is required for the repository's synthesized Knowledge Base response and MCP feature set.
+
+## Findings
+
+| Priority | Finding | Risk | Resolution |
+| --- | --- | --- | --- |
+| High | Full create mode accepted any same-named capacity returned by the Fabric API. | A greenfield run could silently adopt a capacity created by another environment, then preserve it during cleanup while reporting success. | Create mode now requires the same-environment summary or the direct `azd` path's exact tagged Bicep ARM output. BYO remains explicit. |
+| High | Capacity ownership was written only after ARM readiness and Fabric API visibility. | A failure during resource-group creation, the capacity PUT, or either propagation window could leave residual infrastructure without a usable cleanup record. | Resource-group ownership is journaled immediately after group creation; ARM ID and capacity ownership are journaled immediately after the ARM PUT and before readiness polling. |
+| High | Capacity ownership implied ownership of the whole resource group. | Cleanup could delete a pre-existing group or a group that later acquired unrelated resources. | Capacity and resource-group ownership are separate. Whole-group deletion requires both group ownership and an inventory containing no unrelated resources; otherwise only the exact capacity is deleted. |
+| High | A missing or invalid environment lock fell back to configured ownership. | Fabric deletion could proceed without the required agreement between resolved configuration and the lock. | Any absent, invalid, or conflicting Fabric ownership record now preserves all Fabric assets, continues Azure cleanup, and returns partial. |
+| Medium | A missing full-mode Fabric summary was treated as "nothing to delete." | Cleanup could return success without proving release of a billable capacity. | Missing or invalid ownership evidence now produces partial cleanup while Azure cleanup continues. |
+| Medium | Configuration/lock disagreement preserved Fabric but still reported a passing cleanup. | Operators could close a run without assigning the uncertain residual for follow-up. | Ownership disagreement now remains non-destructive and produces an explicit partial result. |
+| Medium | Provisioning printed the complete settings object. | Administrator UPNs and generated Fabric IDs could enter local or CI logs. | Administrator and runtime ID fields are masked in settings output. |
+| Low | Dependabot covered Actions and npm but not root Python requirements. | Pinned Python dependencies required manual update discovery. | Weekly grouped pip updates now cover the repository root. |
+
+## External Comparison
+
+Only primary Microsoft and Azure repositories and Microsoft Learn documentation were used. The review borrowed lifecycle principles, not source text or implementation code.
+
+| Source | Observed pattern | Decision here |
+| --- | --- | --- |
+| [Build 2026 LAB532](https://github.com/microsoft/Build26-LAB532-from-data-to-context-agent-ready-knowledge-with-foundry-iq) | Fabric capacity is deployed in the lab resource group, and lab teardown explicitly removes capacities to release regional quota. | Adopt explicit capacity-release evidence. Keep this repository's separate group because Fabric preprovisioning must complete before the main deployment consumes the capacity. |
+| [Microsoft IQ Solution Accelerator](https://github.com/microsoft/microsoft-iq-solution-accelerator) | `predown` removes Fabric workspace assets before `azd down`; CI cleanup runs with `always()` and has a direct RG fallback. | Adopt ordered external-service cleanup and continuation into Azure cleanup. Do not add an unconditional RG fallback because this repository requires resolved configuration and lock agreement before Fabric deletion. |
+| [Azure Verified Module for Fabric capacity](https://github.com/Azure/bicep-registry-modules/tree/main/avm/res/fabric/capacity) | Capacity modules expose tags and return exact resource IDs and resource-group names. | Add environment, solution, and manager tags to the Python ARM creation path and retain exact ARM IDs in the ignored summary. |
+| [Deploy Your AI Application In Production](https://github.com/microsoft/Deploy-Your-AI-Application-In-Production) | Orphan cleanup uses preview/detection filters and preserves resources outside the proven target set. | Adopt target inventory checks and preservation of unrelated resources. Do not add global orphan auto-deletion because age and naming are weaker evidence than this repository's ownership ledger. |
+| [Azure Developer CLI hooks](https://learn.microsoft.com/azure/developer/azure-developer-cli/azd-extensibility) | `predown` and `postdown` can wrap resource removal. | Keep `liveks down` as the authoritative path. Direct `azd down` lacks the YAML-plus-lock ownership agreement required by this repository, so a destructive compatibility hook was not added. |
+
+## Resulting Contract
+
+For `full` create mode:
+
+1. A same-named capacity is either proven by the same-environment journal or by the exact tagged Bicep output used by direct `azd`, otherwise it is rejected.
+2. The capacity and resource group receive environment and solution tags when created by the Python preprovisioner, and group ownership is recorded before the capacity PUT.
+3. The summary distinguishes `capacityCreated` from `capacityResourceGroupCreated`.
+4. Cleanup deletes generated Fabric items before Azure resources.
+5. The dedicated group is deleted only when it is owned and contains no unrelated resources.
+6. The exact capacity must be absent after owned cleanup; owned dedicated groups must also be absent.
+7. A pre-existing capacity group must remain present and receives an explicit preservation check.
+8. Missing or conflicting evidence preserves uncertain assets and returns partial cleanup for manual follow-up.
+
+For `byo-fabric`, capacity, workspace, and ontology preservation remains unchanged.
+
+## Validation
+
+The implementation must pass:
+
+```bash
+python3 tools/validate.py --profile offline --format json
+bash scripts/validate-local.sh
+python3 -m unittest discover -s tests -v
+az bicep lint --file infra/main.bicep
+git diff --check
+```
+
+Live resource creation was not required for this repository audit. The focused tests mock the ARM and Fabric boundaries and assert the destructive command targets exactly.
+
+After implementation, all 15 local validation gates and 71 Python contract tests pass.

--- a/docs/maintainers/test-specs/e2e-fabric-greenfield.md
+++ b/docs/maintainers/test-specs/e2e-fabric-greenfield.md
@@ -84,6 +84,6 @@ The run passes when `deployments/<env>/fabric-test-report.md` shows all checks p
 - `graphValidation.status == "ok"`
 - `graphValidation.probe.rowCount > 0`
 
-The final `fabric_release` check is mandatory when `--cleanup` is used. In `create` mode it confirms that the generated workspace, capacity resource group, and ARM Fabric capacity are absent. In `byo` mode it confirms that the generated workspace is absent while the existing capacity is preserved. A delete request by itself is not release evidence.
+The final `fabric_release` check is mandatory when `--cleanup` is used. In `create` mode it confirms that the generated workspace and ARM Fabric capacity are absent, and that the capacity resource group was deleted or preserved according to `capacityResourceGroupCreated`. In `byo` mode it confirms that the generated workspace is absent while the existing capacity is preserved. A delete request by itself is not release evidence.
 
 Generated reports are ignored by git and must not contain tokens or credentials.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -172,13 +172,13 @@ Use [Call the Knowledge Base Through MCP](22-knowledge-base-mcp.md) for bearer a
 ./liveks down --env liveks-mcp
 ```
 
-Type `delete liveks-mcp`. The command verifies the generated deployment resource group is absent afterward. For a generated `full` capacity, it also waits for the Fabric capacity resource group to disappear and confirms that the matching ARM capacity count is zero.
+Type `delete liveks-mcp`. The command verifies the generated deployment resource group is absent afterward. For a generated `full` capacity, it also confirms that the exact ARM capacity is absent. When the run created the dedicated capacity resource group, it waits for that group to disappear as well.
 
 - `mcp-only` deletes generated Azure resources.
 - `byo-fabric` deletes generated Azure resources and preserves the existing Fabric workspace and ontology.
 - `full` deletes generated Fabric assets first, continues with Azure cleanup if Fabric reports a partial failure, and returns a nonzero partial-cleanup status.
 
-Do not close a rehearsal until `resource-group-absent` passes. For generated `full`, also require `fabric-capacity-resource-group-absent` and `fabric-capacity-absent`.
+Do not close a rehearsal until `resource-group-absent` passes. For generated `full`, also require `fabric-capacity-absent`; require `fabric-capacity-resource-group-absent` for a generated group or `fabric-capacity-resource-group-preserved` for a pre-existing group. Treat a missing summary or unresolved create-mode ownership as partial cleanup.
 
 The YAML and redacted lock must both identify Fabric assets as generated before Fabric deletion is allowed.
 

--- a/scripts/fabric-destroy.py
+++ b/scripts/fabric-destroy.py
@@ -106,7 +106,15 @@ def load_summary(env_name: str) -> dict[str, Any] | None:
     path = REPO_ROOT / "deployments" / env_name / "fabric-summary.json"
     if not path.exists():
         return None
-    return json.loads(path.read_text(encoding="utf-8"))
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Fabric cleanup summary is not a JSON object: {path}")
+    recorded_environment = str(payload.get("environmentName") or "")
+    if recorded_environment and recorded_environment != env_name:
+        raise RuntimeError(
+            f"Fabric cleanup summary identity mismatch: expected {env_name}, found {recorded_environment}"
+        )
+    return payload
 
 
 def confirm(summary: dict[str, Any]) -> None:
@@ -124,16 +132,37 @@ def resource_group_exists(name: str) -> bool:
     return output == "true"
 
 
-def arm_capacity_exists(name: str) -> bool:
-    output = run(["az", "resource", "list", "--resource-type", "Microsoft.Fabric/capacities", "--output", "json"])
+def list_resource_group_resources(resource_group: str) -> list[dict[str, Any]]:
+    output = run(["az", "resource", "list", "--resource-group", resource_group, "--output", "json"])
     try:
-        capacities = json.loads(output or "[]")
+        resources = json.loads(output or "[]")
     except json.JSONDecodeError as error:
-        raise RuntimeError("Could not parse the Fabric capacity inventory returned by Azure CLI.") from error
+        raise RuntimeError(f"Could not parse the Azure resource inventory for {resource_group}.") from error
+    if not isinstance(resources, list):
+        raise RuntimeError(f"Azure resource inventory for {resource_group} is not a list.")
+    return [resource for resource in resources if isinstance(resource, dict)]
+
+
+def capacity_resource(resources: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    return next(
+        (
+            resource
+            for resource in resources
+            if str(resource.get("type") or "").lower() == "microsoft.fabric/capacities"
+            and str(resource.get("name") or "").lower() == name.lower()
+        ),
+        None,
+    )
+
+
+def arm_capacity_exists(name: str, resource_group: str) -> bool:
+    if not resource_group_exists(resource_group):
+        return False
+    resources = list_resource_group_resources(resource_group)
     return any(
-        str(capacity.get("name") or "") == name
-        for capacity in capacities
-        if isinstance(capacity, dict)
+        str(resource.get("type") or "").lower() == "microsoft.fabric/capacities"
+        and str(resource.get("name") or "").lower() == name.lower()
+        for resource in resources
     )
 
 
@@ -159,11 +188,11 @@ def fabric_capacity_exists(name: str, token: str) -> bool:
     )
 
 
-def wait_for_capacity_absent(name: str, token: str) -> None:
+def wait_for_capacity_absent(name: str, resource_group: str, token: str) -> None:
     arm_present = False
     fabric_present = False
     for attempt in range(FABRIC_DELETE_ATTEMPTS):
-        arm_present = arm_capacity_exists(name)
+        arm_present = arm_capacity_exists(name, resource_group)
         fabric_present = fabric_capacity_exists(name, token)
         if not arm_present and not fabric_present:
             print(f"[verify] Generated Fabric capacity {name} is absent from ARM and Fabric API.")
@@ -177,19 +206,55 @@ def wait_for_capacity_absent(name: str, token: str) -> None:
 
 
 def delete_capacity_resource_group(summary: dict[str, Any], azd_values: dict[str, str]) -> bool:
-    if not summary.get("capacityCreated"):
+    if not summary.get("capacityCreated") and summary.get("capacityResourceGroupCreated") is not True:
         return False
     rg = str(summary.get("capacityResourceGroup") or "")
-    if not rg:
-        raise RuntimeError("Generated Fabric capacity is missing capacityResourceGroup in the cleanup summary.")
+    capacity_name = str(summary.get("capacityName") or "")
+    if not rg or not capacity_name:
+        raise RuntimeError("Generated Fabric capacity is missing its name or resource group in the cleanup summary.")
     azure_rg = azd_values.get("AZURE_RESOURCE_GROUP", "")
     if rg.lower() == azure_rg.lower():
         print(f"[skip] Fabric capacity is in azd resource group {rg}; azd down will delete it.")
         return True
-    if resource_group_exists(rg):
+
+    if not resource_group_exists(rg):
+        return False
+
+    resources = list_resource_group_resources(rg)
+    target = capacity_resource(resources, capacity_name)
+    unexpected = [resource for resource in resources if resource is not target]
+    group_owned = summary.get("capacityResourceGroupCreated") is True
+    target_id = ""
+    if target:
+        target_id = str(target.get("id") or summary.get("capacityArmId") or "")
+        if not target_id:
+            raise RuntimeError(f"Generated Fabric capacity {capacity_name} is missing its ARM resource ID.")
+        recorded_id = str(summary.get("capacityArmId") or "")
+        if recorded_id and target_id.lower() != recorded_id.lower():
+            raise RuntimeError(
+                f"Fabric capacity ARM identity mismatch for {capacity_name}; preserving the unresolved resource."
+            )
+
+    if group_owned and not unexpected:
         print(f"[delete] Azure resource group for generated Fabric capacity: {rg}")
         run(["az", "group", "delete", "--name", rg, "--yes", "--no-wait"])
         run(["az", "group", "wait", "--name", rg, "--deleted", "--timeout", "1800"])
+        return False
+
+    if target:
+        print(f"[delete] Generated Fabric capacity from preserved resource group: {capacity_name}")
+        run(["az", "resource", "delete", "--ids", target_id])
+
+    if group_owned and unexpected:
+        print(
+            f"[preserve] Fabric capacity resource group {rg} contains {len(unexpected)} additional resource(s); "
+            "only the generated capacity was deleted."
+        )
+    elif not group_owned:
+        if summary.get("capacityResourceGroupCreated") is False:
+            print(f"[preserve] Fabric capacity resource group {rg} was not created by this run.")
+        else:
+            print(f"[preserve] Fabric capacity resource group {rg} has no ownership record.")
     return False
 
 
@@ -222,16 +287,33 @@ def verify_cleanup(summary: dict[str, Any], token: str, *, verify_capacity: bool
             raise RuntimeError("Generated Fabric workspace is missing workspaceId in the cleanup summary.")
         wait_for_fabric_absent(f"/workspaces/{workspace_id}", token, "workspace")
 
-    if summary.get("capacityCreated") and verify_capacity:
+    capacity_or_group_created = bool(
+        summary.get("capacityCreated") or summary.get("capacityResourceGroupCreated") is True
+    )
+    if capacity_or_group_created and verify_capacity:
         capacity_name = str(summary.get("capacityName") or "")
         capacity_group = str(summary.get("capacityResourceGroup") or "")
         if not capacity_name or not capacity_group:
             raise RuntimeError("Generated Fabric capacity is missing its name or resource group in the cleanup summary.")
-        if resource_group_exists(capacity_group):
-            raise RuntimeError(f"Generated Fabric capacity resource group still exists: {capacity_group}")
-        wait_for_capacity_absent(capacity_name, token)
-        print(f"[verify] Generated Fabric capacity resource group {capacity_group} is absent.")
-    elif summary.get("capacityCreated"):
+        group_ownership = summary.get("capacityResourceGroupCreated")
+        group_owned = group_ownership is True
+        if group_ownership is False and not resource_group_exists(capacity_group):
+            raise RuntimeError(f"Pre-existing Fabric capacity resource group is no longer present: {capacity_group}")
+        wait_for_capacity_absent(capacity_name, capacity_group, token)
+        if group_owned:
+            if resource_group_exists(capacity_group):
+                raise RuntimeError(f"Generated Fabric capacity resource group still exists: {capacity_group}")
+            print(f"[verify] Generated Fabric capacity resource group {capacity_group} is absent.")
+        elif group_ownership is False:
+            if not resource_group_exists(capacity_group):
+                raise RuntimeError(f"Pre-existing Fabric capacity resource group is no longer present: {capacity_group}")
+            print(f"[verify] Pre-existing Fabric capacity resource group {capacity_group} is preserved.")
+        else:
+            raise RuntimeError(
+                f"Fabric capacity {capacity_name} is absent, but resource-group ownership is missing; "
+                f"preserved {capacity_group} for manual review."
+            )
+    elif capacity_or_group_created:
         print("[verify] Generated Fabric capacity release is deferred to azd down.")
     else:
         capacity_name = str(summary.get("capacityName") or "")
@@ -248,7 +330,8 @@ def main() -> None:
     env_name = args.env_name or os.environ.get("AZURE_ENV_NAME") or azd_values.get("AZURE_ENV_NAME") or "dev"
     summary = load_summary(env_name)
     if not summary:
-        if args.verify_only:
+        deployment_mode = os.environ.get("DEPLOYMENT_MODE") or azd_values.get("DEPLOYMENT_MODE")
+        if args.verify_only or deployment_mode == "full":
             raise RuntimeError(f"Fabric cleanup summary is missing for {env_name}; release cannot be verified.")
         print(f"No Fabric summary found for {env_name}; nothing to delete.")
         return

--- a/scripts/fabric-e2e-test.sh
+++ b/scripts/fabric-e2e-test.sh
@@ -197,7 +197,11 @@ cleanup() {
     fi
     if python3 scripts/fabric-destroy.py --env-name "$ENV_NAME" --verify-only 2>&1 | tee -a "$LOG_FILE"; then
       if [[ "$FABRIC_CAPACITY_MODE" == "create" ]]; then
-        set_check "fabric_release" "PASS" "Generated workspace, capacity resource group, and capacity are absent."
+        if json_expr 'd.get("capacityResourceGroupCreated") is True' < "deployments/${ENV_NAME}/fabric-summary.json"; then
+          set_check "fabric_release" "PASS" "Generated workspace, capacity resource group, and capacity are absent."
+        else
+          set_check "fabric_release" "PASS" "Generated workspace and capacity are absent; the pre-existing capacity resource group is preserved."
+        fi
       else
         set_check "fabric_release" "PASS" "Generated workspace is absent and the BYO capacity is preserved."
       fi
@@ -259,6 +263,8 @@ if [[ -z "$FABRIC_CAPACITY_NAME" ]]; then
   FABRIC_CAPACITY_NAME="$(printf 'fab%s' "$ENV_NAME" | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9' | cut -c1-63)"
 fi
 azd env set FABRIC_CAPACITY_NAME "$FABRIC_CAPACITY_NAME" 2>&1 | tee -a "$LOG_FILE"
+azd env set FABRIC_CAPACITY_ID "" >/dev/null
+azd env set FABRIC_CAPACITY_ARM_ID "" >/dev/null
 azd env set FABRIC_WORKSPACE_ID "" >/dev/null
 azd env set FABRIC_ONTOLOGY_ID "" >/dev/null
 azd env set FABRIC_LAKEHOUSE_ID "" >/dev/null

--- a/scripts/fabric-provision.py
+++ b/scripts/fabric-provision.py
@@ -23,7 +23,7 @@ import urllib.parse
 import urllib.request
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DATA_DIR = REPO_ROOT / "samples" / "data" / "airline-ops"
@@ -46,6 +46,9 @@ FABRIC_CAPACITY_LIST_ATTEMPTS = 72
 FABRIC_GRAPH_PROBE_ATTEMPTS = 60
 FABRIC_GRAPH_SECOND_PROBE_ATTEMPTS = 45
 FABRIC_GRAPH_PROBE_DELAY_SECONDS = 20
+SOLUTION_TAG = "foundry-iq-live-knowledge-sources"
+FABRIC_MANAGED_BY_TAG = "liveks-fabric-provision"
+BICEP_MANAGED_BY_TAG = "azd-bicep"
 
 ENTITY_SPECS = [
     ("Airline", "airlines.csv", "airline_code"),
@@ -238,6 +241,21 @@ def az_rest(method: str, url: str, body: dict[str, Any] | None = None) -> dict[s
     return json.loads(output) if output else {}
 
 
+def resource_group_exists(name: str) -> bool:
+    output = run(["az", "group", "exists", "--name", name]).strip().lower()
+    if output not in {"true", "false"}:
+        raise RuntimeError(f"Could not determine whether resource group {name} exists: {output}")
+    return output == "true"
+
+
+def capacity_resource_tags(settings: dict[str, str]) -> dict[str, str]:
+    return {
+        "azdEnvName": settings["AZURE_ENV_NAME"],
+        "solution": SOLUTION_TAG,
+        "managedBy": FABRIC_MANAGED_BY_TAG,
+    }
+
+
 def wait_for_arm_capacity(resource_id: str, *, attempts: int = 60, delay_seconds: int = 5) -> dict[str, Any]:
     url = f"https://management.azure.com{resource_id}?api-version={FABRIC_CAPACITY_API_VERSION}"
     last: dict[str, Any] = {}
@@ -274,36 +292,159 @@ def capacity_by_name_with_retry(token: str, name: str, *, attempts: int = 3, del
     return None
 
 
-def create_arm_capacity(settings: dict[str, str], *, dry_run: bool) -> str:
+def previous_capacity_is_owned(
+    previous: dict[str, Any],
+    settings: dict[str, str],
+    *,
+    fabric_id: str = "",
+) -> bool:
+    if not previous.get("capacityCreated"):
+        return False
+
+    capacity_name = settings["FABRIC_CAPACITY_NAME"]
+    if str(previous.get("capacityName") or "") != capacity_name:
+        return False
+
+    expected_group = settings.get("FABRIC_CAPACITY_RESOURCE_GROUP", "")
+    recorded_group = str(previous.get("capacityResourceGroup") or "")
+    if expected_group and recorded_group.lower() != expected_group.lower():
+        return False
+
+    recorded_id = str(previous.get("capacityId") or "")
+    recorded_arm_id = str(previous.get("capacityArmId") or "")
+    configured_arm_id = settings.get("FABRIC_CAPACITY_ARM_ID", "")
+    if configured_arm_id and recorded_arm_id and configured_arm_id.lower() != recorded_arm_id.lower():
+        return False
+    if fabric_id and recorded_id:
+        return recorded_id == fabric_id
+
+    if not recorded_arm_id or not recorded_group:
+        return False
+
+    expected_suffix = (
+        f"/resourcegroups/{recorded_group}/providers/microsoft.fabric/capacities/{capacity_name}"
+    ).lower()
+    return recorded_arm_id.lower().startswith("/subscriptions/") and recorded_arm_id.lower().endswith(expected_suffix)
+
+
+def bicep_capacity_is_owned(settings: dict[str, str]) -> bool:
+    arm_id = settings.get("FABRIC_CAPACITY_ARM_ID", "")
+    environment = settings.get("AZURE_ENV_NAME", "")
+    resource_group = settings.get("FABRIC_CAPACITY_RESOURCE_GROUP", "")
+    capacity_name = settings.get("FABRIC_CAPACITY_NAME", "")
+    if not all((arm_id, environment, resource_group, capacity_name)):
+        return False
+
+    expected_suffix = (
+        f"/resourcegroups/{resource_group}/providers/microsoft.fabric/capacities/{capacity_name}"
+    ).lower()
+    if not arm_id.lower().startswith("/subscriptions/") or not arm_id.lower().endswith(expected_suffix):
+        return False
+
+    output = run(["az", "resource", "show", "--ids", arm_id, "--output", "json"], allow_failure=True)
+    try:
+        resource = json.loads(output or "{}")
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(resource, dict) or str(resource.get("id") or "").lower() != arm_id.lower():
+        return False
+    tags = resource.get("tags")
+    return bool(
+        isinstance(tags, dict)
+        and tags.get("azdEnvName") == environment
+        and tags.get("solution") == SOLUTION_TAG
+        and tags.get("managedBy") == BICEP_MANAGED_BY_TAG
+    )
+
+
+def create_arm_capacity(
+    settings: dict[str, str],
+    *,
+    dry_run: bool,
+    resource_group_previously_owned: bool = False,
+    on_ownership_update: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
     subscription_id = run(["az", "account", "show", "--query", "id", "-o", "tsv"])
     resource_group = settings["FABRIC_CAPACITY_RESOURCE_GROUP"]
     location = settings["FABRIC_LOCATION"]
     name = settings["FABRIC_CAPACITY_NAME"]
     admin = settings["FABRIC_CAPACITY_ADMIN"]
     sku = settings["FABRIC_CAPACITY_SKU"]
+    resource_id = f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}/providers/Microsoft.Fabric/capacities/{name}"
     if dry_run:
         print(f"[dry-run] create Microsoft.Fabric/capacities {name} ({sku}, {location}) in {resource_group}")
-        return f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}/providers/Microsoft.Fabric/capacities/{name}"
+        return {"armId": resource_id, "resourceGroupCreated": False}
 
-    run(["az", "group", "create", "--name", resource_group, "--location", location, "-o", "none"])
     check_url = f"https://management.azure.com/subscriptions/{subscription_id}/providers/Microsoft.Fabric/locations/{location}/checkNameAvailability?api-version={FABRIC_CAPACITY_API_VERSION}"
     availability = az_rest("post", check_url, {"name": name, "type": "Microsoft.Fabric/capacities"})
     if availability.get("nameAvailable") is False:
         raise RuntimeError(f"Fabric capacity name is not available: {name} ({availability})")
 
+    group_preexisting = resource_group_exists(resource_group)
+    tags = capacity_resource_tags(settings)
+    group_owned = not group_preexisting or resource_group_previously_owned
+    if not group_preexisting:
+        tag_arguments = [f"{key}={value}" for key, value in tags.items()]
+        run(
+            [
+                "az",
+                "group",
+                "create",
+                "--name",
+                resource_group,
+                "--location",
+                location,
+                "--tags",
+                *tag_arguments,
+                "-o",
+                "none",
+            ]
+        )
+    if on_ownership_update:
+        on_ownership_update(
+            {
+                "capacityId": "",
+                "capacityArmId": "",
+                "capacityName": name,
+                "capacityResourceGroup": resource_group,
+                "capacityResourceGroupCreated": group_owned,
+                "capacityCreated": False,
+            }
+        )
+
     resource_url = f"https://management.azure.com/subscriptions/{subscription_id}/resourceGroups/{resource_group}/providers/Microsoft.Fabric/capacities/{name}?api-version={FABRIC_CAPACITY_API_VERSION}"
     body = {
         "location": location,
+        "tags": tags,
         "sku": {"name": sku, "tier": "Fabric"},
         "properties": {"administration": {"members": [admin]}},
     }
     created = az_rest("put", resource_url, body)
-    resource_id = created.get("id") or f"/subscriptions/{subscription_id}/resourceGroups/{resource_group}/providers/Microsoft.Fabric/capacities/{name}"
+    resource_id = created.get("id") or resource_id
+    creation = {"armId": resource_id, "resourceGroupCreated": group_owned}
+    if on_ownership_update:
+        on_ownership_update(
+            {
+                "capacityId": "",
+                "capacityArmId": resource_id,
+                "capacityName": name,
+                "capacityResourceGroup": resource_group,
+                "capacityResourceGroupCreated": group_owned,
+                "capacityCreated": True,
+            }
+        )
     wait_for_arm_capacity(resource_id)
-    return resource_id
+    return creation
 
 
-def ensure_capacity(settings: dict[str, str], token: str, *, dry_run: bool) -> tuple[str, dict[str, Any]]:
+def ensure_capacity(
+    settings: dict[str, str],
+    token: str,
+    *,
+    dry_run: bool,
+    previous_summary: dict[str, Any] | None = None,
+    on_ownership_update: Callable[[dict[str, Any]], None] | None = None,
+) -> tuple[str, dict[str, Any]]:
     mode = settings["FABRIC_CAPACITY_MODE"]
     if mode == "skip":
         raise RuntimeError("FABRIC_CAPACITY_MODE=skip cannot create a greenfield Fabric workspace.")
@@ -311,24 +452,84 @@ def ensure_capacity(settings: dict[str, str], token: str, *, dry_run: bool) -> t
     capacity_name = settings["FABRIC_CAPACITY_NAME"]
     existing = capacity_by_name_with_retry(token, capacity_name) if not dry_run else None
     if existing:
-        return str(existing["id"]), {**existing, "created": False}
+        existing_id = str(existing["id"])
+        previous = previous_summary or {}
+        previously_owned = previous_capacity_is_owned(
+            previous,
+            settings,
+            fabric_id=existing_id,
+        )
+        bicep_owned = mode == "create" and not previously_owned and bicep_capacity_is_owned(settings)
+        if mode == "create" and not previously_owned and not bicep_owned:
+            raise RuntimeError(
+                f"Fabric capacity '{capacity_name}' already exists but is not owned by this environment. "
+                "Use a unique environment or capacity name; use BYO mode only for intentionally shared capacity."
+            )
+        if previously_owned:
+            resource_group_created = previous.get("capacityResourceGroupCreated")
+        elif bicep_owned:
+            resource_group_created = None
+        else:
+            resource_group_created = False
+        return existing_id, {
+            **existing,
+            "created": False,
+            "owned": previously_owned or bicep_owned,
+            "armId": previous.get("capacityArmId") or settings.get("FABRIC_CAPACITY_ARM_ID", ""),
+            "resourceGroupCreated": resource_group_created,
+        }
 
     if mode != "create":
         raise RuntimeError(f"Fabric capacity '{capacity_name}' was not found and FABRIC_CAPACITY_MODE={mode}.")
 
     arm_id = settings.get("FABRIC_CAPACITY_ARM_ID", "")
+    resource_group_created = (previous_summary or {}).get("capacityResourceGroupCreated")
+    created_now = False
+    owned = False
     if arm_id and not dry_run:
+        if not previous_capacity_is_owned(previous_summary or {}, settings) and not bicep_capacity_is_owned(settings):
+            raise RuntimeError(
+                f"Fabric capacity ARM resource '{arm_id}' is not proven as owned by this environment."
+            )
         wait_for_arm_capacity(arm_id)
+        owned = True
     else:
-        arm_id = create_arm_capacity(settings, dry_run=dry_run)
+        creation = create_arm_capacity(
+            settings,
+            dry_run=dry_run,
+            resource_group_previously_owned=bool(
+                (previous_summary or {}).get("capacityResourceGroupCreated") is True
+                and str((previous_summary or {}).get("capacityResourceGroup") or "").lower()
+                == settings.get("FABRIC_CAPACITY_RESOURCE_GROUP", "").lower()
+            ),
+            on_ownership_update=on_ownership_update,
+        )
+        arm_id = str(creation["armId"])
+        resource_group_created = creation.get("resourceGroupCreated")
+        created_now = True
+        owned = True
 
     if dry_run:
-        return "00000000-0000-0000-0000-000000000010", {"displayName": capacity_name, "id": "dry-run-capacity", "state": "DryRun", "created": True, "armId": arm_id}
+        return "00000000-0000-0000-0000-000000000010", {
+            "displayName": capacity_name,
+            "id": "dry-run-capacity",
+            "state": "DryRun",
+            "created": True,
+            "owned": True,
+            "armId": arm_id,
+            "resourceGroupCreated": resource_group_created,
+        }
 
     for _ in range(FABRIC_CAPACITY_LIST_ATTEMPTS):
         found = capacity_by_name(token, capacity_name)
         if found:
-            return str(found["id"]), {**found, "created": True, "armId": arm_id}
+            return str(found["id"]), {
+                **found,
+                "created": created_now,
+                "owned": owned,
+                "armId": arm_id,
+                "resourceGroupCreated": resource_group_created,
+            }
         time.sleep(5)
     raise RuntimeError(
         f"Created Fabric capacity '{capacity_name}' in ARM, but Fabric API did not list it before the sample timeout. "
@@ -1069,6 +1270,7 @@ def base_summary(settings: dict[str, str]) -> dict[str, Any]:
         "capacityState": "",
         "capacityArmId": settings.get("FABRIC_CAPACITY_ARM_ID", ""),
         "capacityResourceGroup": settings["FABRIC_CAPACITY_RESOURCE_GROUP"],
+        "capacityResourceGroupCreated": None,
         "capacityCreated": False,
         "workspaceId": settings.get("FABRIC_WORKSPACE_ID", ""),
         "workspaceName": settings["FABRIC_WORKSPACE_NAME"],
@@ -1140,6 +1342,65 @@ def retain_created_ownership(previous: dict[str, Any], kind: str, item_id: str, 
     return created_now or bool(previous.get(f"{kind}Created") and str(previous.get(f"{kind}Id") or "") == item_id)
 
 
+def retain_capacity_group_ownership(
+    previous: dict[str, Any],
+    resource_group: str,
+    *,
+    capacity_owned: bool,
+    created_now: bool | None,
+) -> bool | None:
+    if created_now is not None:
+        return created_now
+    if not capacity_owned:
+        return False
+    if str(previous.get("capacityResourceGroup") or "").lower() != resource_group.lower():
+        return None
+    recorded = previous.get("capacityResourceGroupCreated")
+    return recorded if isinstance(recorded, bool) else None
+
+
+def seed_previous_capacity_ownership(
+    summary: dict[str, Any], previous: dict[str, Any], settings: dict[str, str]
+) -> None:
+    if str(previous.get("capacityName") or "") != settings["FABRIC_CAPACITY_NAME"]:
+        return
+    if str(previous.get("capacityResourceGroup") or "").lower() != settings["FABRIC_CAPACITY_RESOURCE_GROUP"].lower():
+        return
+    if previous.get("capacityResourceGroupCreated") is True:
+        summary["capacityName"] = previous["capacityName"]
+        summary["capacityResourceGroup"] = previous["capacityResourceGroup"]
+        summary["capacityResourceGroupCreated"] = True
+    if not previous.get("capacityCreated"):
+        return
+    for key in (
+        "capacityId",
+        "capacityName",
+        "capacitySku",
+        "capacityState",
+        "capacityArmId",
+        "capacityResourceGroup",
+        "capacityResourceGroupCreated",
+        "capacityCreated",
+    ):
+        if key in previous:
+            summary[key] = previous[key]
+
+
+def settings_for_log(settings: dict[str, str]) -> dict[str, str]:
+    private_keys = {
+        "FABRIC_CAPACITY_ADMIN",
+        "FABRIC_CAPACITY_ID",
+        "FABRIC_CAPACITY_ARM_ID",
+        "FABRIC_WORKSPACE_ID",
+        "FABRIC_LAKEHOUSE_ID",
+        "FABRIC_ONTOLOGY_ID",
+    }
+    return {
+        key: "<configured>" if key in private_keys and value else value
+        for key, value in settings.items()
+    }
+
+
 def main() -> None:
     args = parse_args()
     azd_values = load_azd_env()
@@ -1153,7 +1414,7 @@ def main() -> None:
         raise SystemExit("FABRIC_CAPACITY_ADMIN is required when FABRIC_CAPACITY_MODE=create.")
 
     print("Fabric provision settings loaded")
-    print(json.dumps(settings, indent=2))
+    print(json.dumps(settings_for_log(settings), indent=2))
 
     if args.dry_run:
         definition, manifest = build_ontology_definition(
@@ -1166,12 +1427,33 @@ def main() -> None:
 
     previous_summary = load_previous_summary(settings["AZURE_ENV_NAME"])
     summary = base_summary(settings)
+    seed_previous_capacity_ownership(summary, previous_summary, settings)
 
     try:
         fabric_token = get_token(FABRIC_RESOURCE)
         storage_token = get_token(STORAGE_RESOURCE)
 
-        capacity_id, capacity = ensure_capacity(settings, fabric_token, dry_run=False)
+        def record_capacity_creation(created: dict[str, Any]) -> None:
+            summary.update(
+                {
+                    **created,
+                    "capacitySku": settings["FABRIC_CAPACITY_SKU"],
+                    "capacityState": "Provisioning" if created.get("capacityCreated") else "ResourceGroupReady",
+                }
+            )
+            write_partial_outputs(settings, summary)
+            sync_capacity_to_azd(summary, dry_run=False)
+
+        capacity_id, capacity = ensure_capacity(
+            settings,
+            fabric_token,
+            dry_run=False,
+            previous_summary=previous_summary,
+            on_ownership_update=record_capacity_creation,
+        )
+        capacity_owned = bool(capacity.get("owned")) or retain_created_ownership(
+            previous_summary, "capacity", capacity_id, bool(capacity.get("created"))
+        )
         summary.update(
             {
                 "capacityId": capacity_id,
@@ -1180,7 +1462,17 @@ def main() -> None:
                 "capacityState": capacity.get("state", ""),
                 "capacityArmId": capacity.get("armId") or settings.get("FABRIC_CAPACITY_ARM_ID", ""),
                 "capacityResourceGroup": settings["FABRIC_CAPACITY_RESOURCE_GROUP"],
-                "capacityCreated": retain_created_ownership(previous_summary, "capacity", capacity_id, bool(capacity.get("created"))),
+                "capacityResourceGroupCreated": retain_capacity_group_ownership(
+                    previous_summary,
+                    settings["FABRIC_CAPACITY_RESOURCE_GROUP"],
+                    capacity_owned=capacity_owned,
+                    created_now=(
+                        bool(capacity.get("resourceGroupCreated"))
+                        if capacity.get("created")
+                        else None
+                    ),
+                ),
+                "capacityCreated": capacity_owned,
             }
         )
         write_partial_outputs(settings, summary)

--- a/scripts/maintainers/extract-review-evidence.py
+++ b/scripts/maintainers/extract-review-evidence.py
@@ -119,9 +119,12 @@ def render_evidence(mode_verdicts: list[tuple[str, str, str]], checks_by_mode: d
         )
         v2_pass = all(checks.get(name) == "PASS" for name in ("fabric-cleanup", "azure-cleanup", "resource-group-absent"))
         if mode == "full" and v2_pass:
-            v2_pass = all(
-                checks.get(name) == "PASS"
-                for name in ("fabric-capacity-resource-group-absent", "fabric-capacity-absent")
+            group_release = checks.get("fabric-capacity-resource-group-absent") == "PASS" or checks.get(
+                "fabric-capacity-resource-group-preserved"
+            ) == "PASS"
+            v2_pass = (
+                checks.get("fabric-capacity-absent") == "PASS"
+                and group_release
             )
         if legacy_pass or v2_pass:
             cleanup_pass_modes.append(mode)
@@ -171,7 +174,7 @@ def render_evidence(mode_verdicts: list[tuple[str, str, str]], checks_by_mode: d
         ),
         "- Cleanup: "
         + (
-            f"Fabric ownership, Azure cleanup, and all required absence checks PASS in {', '.join(cleanup_pass_modes)}."
+            f"Fabric ownership, Azure cleanup, and all required release checks PASS in {', '.join(cleanup_pass_modes)}."
             if cleanup_pass_modes
             else "not fully proven by the sanitized summary."
         ),

--- a/src/liveks/cli.py
+++ b/src/liveks/cli.py
@@ -808,6 +808,11 @@ def _load_fabric_summary(environment: str) -> dict[str, Any] | None:
         raise ConfigError(f"Invalid Fabric summary: {summary_path}: {error}") from error
     if not isinstance(summary, dict):
         raise ConfigError(f"Invalid Fabric summary object: {summary_path}")
+    recorded_environment = str(summary.get("environmentName") or "")
+    if recorded_environment and recorded_environment != environment:
+        raise ConfigError(
+            f"Fabric summary identity mismatch: expected {environment}, found {recorded_environment}"
+        )
     return summary
 
 
@@ -821,15 +826,32 @@ def _locked_identity(environment: str) -> tuple[str | None, dict[str, str] | Non
 
 def _cleanup_ownership(config: ResolvedConfig) -> tuple[dict[str, str], str]:
     configured = config.ownership()
-    _, locked = _locked_identity(config.environment)
+    try:
+        _, locked = _locked_identity(config.environment)
+    except ConfigError as error:
+        locked = None
+        missing_reason = f"invalid environment lock: {error}"
+    else:
+        missing_reason = "environment lock is missing"
     if locked is None:
-        return configured, "resolved configuration"
+        effective = dict(configured)
+        for key in ("fabricCapacity", "fabricWorkspace", "fabricOntology"):
+            if configured.get(key) == "create":
+                effective[key] = "none"
+        return effective, f"resolved configuration; {missing_reason}"
 
     # Deletion is allowed only when both records identify the Fabric asset as generated.
     effective = dict(configured)
     for key in ("fabricCapacity", "fabricWorkspace", "fabricOntology"):
         if configured.get(key) != "create" or locked.get(key) != "create":
             effective[key] = "reuse" if "reuse" in {configured.get(key), locked.get(key)} else "none"
+    if any(
+        configured.get(key) != effective.get(key)
+        for key in ("fabricCapacity", "fabricWorkspace", "fabricOntology")
+    ):
+        for key in ("fabricCapacity", "fabricWorkspace", "fabricOntology"):
+            if configured.get(key) == "create":
+                effective[key] = "none"
     return effective, "resolved configuration + environment lock"
 
 
@@ -845,11 +867,74 @@ def down_report(config: ResolvedConfig, *, yes: bool, quiet: bool = False) -> di
     if selected.returncode != 0:
         return envelope("down", "fail", profile=config.profile, environment=config.environment, checks=[_check("azd-environment", "fail", f"Environment not found: {config.environment}")])
     ownership, ownership_source = _cleanup_ownership(config)
-    fabric_summary = _load_fabric_summary(config.environment) if ownership["fabricWorkspace"] == "create" else None
-    checks.append(_check("ownership", "pass", ownership_source, ownership=ownership))
+    configured_ownership = config.ownership()
+    ownership_disagreement = any(
+        configured_ownership.get(key) != ownership.get(key)
+        for key in ("fabricCapacity", "fabricWorkspace", "fabricOntology")
+    )
+    checks.append(
+        _check(
+            "ownership",
+            "warn" if ownership_disagreement else "pass",
+            (
+                f"Fabric ownership cannot be proven ({ownership_source}); uncertain assets are preserved for manual review"
+                if ownership_disagreement
+                else ownership_source
+            ),
+            ownership=ownership,
+        )
+    )
+    fabric_summary = None
     if ownership["fabricWorkspace"] == "create":
+        try:
+            fabric_summary = _load_fabric_summary(config.environment)
+        except ConfigError as error:
+            checks.append(_check("fabric-summary", "warn", str(error)))
+        if fabric_summary is None and not any(check["name"] == "fabric-summary" for check in checks):
+            checks.append(
+                _check(
+                    "fabric-summary",
+                    "warn",
+                    "Fabric ownership summary is missing; generated Fabric release cannot be verified",
+                )
+            )
+    if ownership["fabricWorkspace"] == "create":
+        if (
+            fabric_summary is not None
+            and ownership.get("fabricCapacity") == "create"
+            and not fabric_summary.get("capacityCreated")
+            and fabric_summary.get("capacityResourceGroupCreated") is not True
+        ):
+            checks.append(
+                _check(
+                    "fabric-capacity-ownership",
+                    "warn",
+                    "Full-mode capacity was not created by this environment; it was preserved and needs an explicit cleanup owner review",
+                )
+            )
+        if (
+            fabric_summary is not None
+            and fabric_summary.get("capacityCreated")
+            and not isinstance(fabric_summary.get("capacityResourceGroupCreated"), bool)
+        ):
+            checks.append(
+                _check(
+                    "fabric-capacity-resource-group-ownership",
+                    "warn",
+                    "Capacity resource-group ownership is missing; the group is preserved for manual review",
+                )
+            )
         fabric = runner.run([sys.executable, "scripts/fabric-destroy.py", "--env-name", config.environment, "--yes"])
-        checks.append(_check("fabric-cleanup", "pass" if fabric.returncode == 0 else "warn", "Generated Fabric assets deleted" if fabric.returncode == 0 else "Fabric cleanup needs manual follow-up; Azure cleanup continued"))
+        if (
+            fabric.returncode == 0
+            and fabric_summary is not None
+            and not fabric_summary.get("capacityCreated")
+            and fabric_summary.get("capacityResourceGroupCreated") is not True
+        ):
+            fabric_message = "Generated Fabric workspace assets deleted; unowned capacity preserved"
+        else:
+            fabric_message = "Generated Fabric assets deleted" if fabric.returncode == 0 else "Fabric cleanup needs manual follow-up; Azure cleanup continued"
+        checks.append(_check("fabric-cleanup", "pass" if fabric.returncode == 0 else "warn", fabric_message))
     else:
         checks.append(_check("fabric-cleanup", "pass", "No generated Fabric assets owned by this environment"))
     azure = runner.run(["azd", "down", "--environment", config.environment, "--purge", "--force", "--no-prompt"])
@@ -868,7 +953,11 @@ def down_report(config: ResolvedConfig, *, yes: bool, quiet: bool = False) -> di
             break
         if attempt < 11:
             time.sleep(5)
-    lock = _load_lock(config.environment)
+    try:
+        lock = _load_lock(config.environment)
+    except ConfigError as error:
+        lock = None
+        checks.append(_check("environment-lock", "warn", str(error)))
     preexisting = lock.get("resourceGroupPreexisting") if lock else None
     if not absent and preexisting is False:
         fallback = runner.run(["az", "group", "delete", "--name", resource_group, "--yes", "--no-wait"])
@@ -889,8 +978,14 @@ def down_report(config: ResolvedConfig, *, yes: bool, quiet: bool = False) -> di
                     time.sleep(5)
     checks.append(_check("resource-group-absent", "pass" if absent else "fail", f"Deployment resource group {resource_group} is absent" if absent else f"Deployment resource group {resource_group} still exists"))
 
-    capacity_created = bool(fabric_summary and fabric_summary.get("capacityCreated"))
-    if ownership.get("fabricCapacity") == "create" and capacity_created:
+    capacity_cleanup_owned = bool(
+        fabric_summary
+        and (
+            fabric_summary.get("capacityCreated")
+            or fabric_summary.get("capacityResourceGroupCreated") is True
+        )
+    )
+    if ownership.get("fabricCapacity") == "create" and capacity_cleanup_owned:
         capacity_group = str(
             fabric_summary.get("capacityResourceGroup")
             or projected.get("FABRIC_CAPACITY_RESOURCE_GROUP")
@@ -901,38 +996,66 @@ def down_report(config: ResolvedConfig, *, yes: bool, quiet: bool = False) -> di
             or projected.get("FABRIC_CAPACITY_NAME")
             or config.get("fabric.capacity_name")
         )
+        capacity_group_ownership = fabric_summary.get("capacityResourceGroupCreated")
+        capacity_group_owned = capacity_group_ownership is True
         capacity_group_absent = False
         capacity_absent = False
         for attempt in range(12):
             group_probe = runner.run(["az", "group", "exists", "--name", capacity_group])
             capacity_group_absent = group_probe.returncode == 0 and group_probe.stdout.strip().lower() == "false"
-            capacity_probe = runner.run(
-                [
-                    "az",
-                    "resource",
-                    "list",
-                    "--resource-type",
-                    "Microsoft.Fabric/capacities",
-                    "--query",
-                    f"length([?name=='{capacity_name}'])",
-                    "--output",
-                    "tsv",
-                ]
-            )
-            capacity_absent = capacity_probe.returncode == 0 and capacity_probe.stdout.strip() in {"", "0"}
-            if capacity_group_absent and capacity_absent:
+            if capacity_group_absent:
+                capacity_absent = True
+            else:
+                capacity_probe = runner.run(
+                    [
+                        "az",
+                        "resource",
+                        "list",
+                        "--resource-group",
+                        capacity_group,
+                        "--resource-type",
+                        "Microsoft.Fabric/capacities",
+                        "--output",
+                        "json",
+                    ]
+                )
+                try:
+                    capacities = json.loads(capacity_probe.stdout or "[]")
+                except json.JSONDecodeError:
+                    capacities = None
+                capacity_absent = bool(
+                    capacity_probe.returncode == 0
+                    and isinstance(capacities, list)
+                    and not any(
+                        isinstance(capacity, dict)
+                        and str(capacity.get("name") or "").lower() == capacity_name.lower()
+                        for capacity in capacities
+                    )
+                )
+            if capacity_absent:
                 break
             if attempt < 11:
                 time.sleep(5)
-        checks.append(
-            _check(
-                "fabric-capacity-resource-group-absent",
-                "pass" if capacity_group_absent else "fail",
-                f"Generated Fabric capacity resource group {capacity_group} is absent"
-                if capacity_group_absent
-                else f"Generated Fabric capacity resource group {capacity_group} still exists",
+        if capacity_group_owned:
+            checks.append(
+                _check(
+                    "fabric-capacity-resource-group-absent",
+                    "pass" if capacity_group_absent else "fail",
+                    f"Generated Fabric capacity resource group {capacity_group} is absent"
+                    if capacity_group_absent
+                    else f"Generated Fabric capacity resource group {capacity_group} still exists",
+                )
             )
-        )
+        elif capacity_group_ownership is False:
+            checks.append(
+                _check(
+                    "fabric-capacity-resource-group-preserved",
+                    "pass" if not capacity_group_absent else "fail",
+                    f"Pre-existing Fabric capacity resource group {capacity_group} is preserved"
+                    if not capacity_group_absent
+                    else f"Pre-existing Fabric capacity resource group {capacity_group} is absent",
+                )
+            )
         checks.append(
             _check(
                 "fabric-capacity-absent",

--- a/tests/test_deployment_safety.py
+++ b/tests/test_deployment_safety.py
@@ -107,7 +107,11 @@ class FabricProvisionSafetyTests(unittest.TestCase):
         }
         with (
             mock.patch.object(module, "capacity_by_name_with_retry", return_value=None),
-            mock.patch.object(module, "create_arm_capacity", return_value="arm-id") as create,
+            mock.patch.object(
+                module,
+                "create_arm_capacity",
+                return_value={"armId": "arm-id", "resourceGroupCreated": True},
+            ) as create,
             mock.patch.object(
                 module,
                 "capacity_by_name",
@@ -124,6 +128,242 @@ class FabricProvisionSafetyTests(unittest.TestCase):
         previous = {"workspaceCreated": True, "workspaceId": "owned-id"}
         self.assertTrue(module.retain_created_ownership(previous, "workspace", "owned-id", False))
         self.assertFalse(module.retain_created_ownership(previous, "workspace", "different-id", False))
+
+    def test_create_mode_refuses_existing_capacity_without_environment_ownership(self):
+        module = load_fabric_provision_module()
+        settings = {
+            "FABRIC_CAPACITY_MODE": "create",
+            "FABRIC_CAPACITY_NAME": "fabshared",
+        }
+        with mock.patch.object(
+            module,
+            "capacity_by_name_with_retry",
+            return_value={"id": "shared-id", "displayName": "fabshared"},
+        ):
+            with self.assertRaisesRegex(RuntimeError, "not owned by this environment"):
+                module.ensure_capacity(settings, "token", dry_run=False)
+
+    def test_create_mode_reuses_capacity_owned_by_same_environment(self):
+        module = load_fabric_provision_module()
+        settings = {
+            "FABRIC_CAPACITY_MODE": "create",
+            "FABRIC_CAPACITY_NAME": "fabunit",
+            "FABRIC_CAPACITY_ARM_ID": "",
+        }
+        previous = {
+            "capacityCreated": True,
+            "capacityId": "owned-id",
+            "capacityName": "fabunit",
+            "capacityArmId": "arm-id",
+            "capacityResourceGroupCreated": True,
+        }
+        with mock.patch.object(
+            module,
+            "capacity_by_name_with_retry",
+            return_value={"id": "owned-id", "displayName": "fabunit"},
+        ):
+            capacity_id, capacity = module.ensure_capacity(
+                settings,
+                "token",
+                dry_run=False,
+                previous_summary=previous,
+            )
+        self.assertEqual(capacity_id, "owned-id")
+        self.assertFalse(capacity["created"])
+        self.assertTrue(capacity["owned"])
+        self.assertTrue(capacity["resourceGroupCreated"])
+
+    def test_create_mode_reuses_arm_journal_before_fabric_id_was_recorded(self):
+        module = load_fabric_provision_module()
+        arm_id = "/subscriptions/sub/resourceGroups/rg-unit-fabric/providers/Microsoft.Fabric/capacities/fabunit"
+        settings = {
+            "FABRIC_CAPACITY_MODE": "create",
+            "FABRIC_CAPACITY_NAME": "fabunit",
+            "FABRIC_CAPACITY_RESOURCE_GROUP": "rg-unit-fabric",
+            "FABRIC_CAPACITY_ARM_ID": "",
+        }
+        previous = {
+            "capacityCreated": True,
+            "capacityId": "",
+            "capacityName": "fabunit",
+            "capacityArmId": arm_id,
+            "capacityResourceGroup": "rg-unit-fabric",
+            "capacityResourceGroupCreated": True,
+        }
+        with mock.patch.object(
+            module,
+            "capacity_by_name_with_retry",
+            return_value={"id": "eventual-id", "displayName": "fabunit"},
+        ):
+            capacity_id, capacity = module.ensure_capacity(
+                settings,
+                "token",
+                dry_run=False,
+                previous_summary=previous,
+            )
+        self.assertEqual(capacity_id, "eventual-id")
+        self.assertTrue(capacity["owned"])
+        self.assertTrue(capacity["resourceGroupCreated"])
+
+    def test_create_mode_refuses_unjournaled_arm_capacity(self):
+        module = load_fabric_provision_module()
+        settings = {
+            "FABRIC_CAPACITY_MODE": "create",
+            "FABRIC_CAPACITY_NAME": "fabunit",
+            "FABRIC_CAPACITY_RESOURCE_GROUP": "rg-unit-fabric",
+            "FABRIC_CAPACITY_ARM_ID": "/subscriptions/sub/resourceGroups/rg-unit-fabric/providers/Microsoft.Fabric/capacities/fabunit",
+        }
+        with (
+            mock.patch.object(module, "capacity_by_name_with_retry", return_value=None),
+            mock.patch.object(module, "wait_for_arm_capacity") as wait,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "not proven as owned"):
+                module.ensure_capacity(settings, "token", dry_run=False)
+        wait.assert_not_called()
+
+    def test_create_mode_accepts_exact_bicep_managed_capacity_during_propagation(self):
+        module = load_fabric_provision_module()
+        arm_id = "/subscriptions/sub/resourceGroups/rg-unit/providers/Microsoft.Fabric/capacities/fabunit"
+        settings = {
+            "AZURE_ENV_NAME": "unit",
+            "FABRIC_CAPACITY_MODE": "create",
+            "FABRIC_CAPACITY_NAME": "fabunit",
+            "FABRIC_CAPACITY_RESOURCE_GROUP": "rg-unit",
+            "FABRIC_CAPACITY_ARM_ID": arm_id,
+        }
+        resource = {
+            "id": arm_id,
+            "tags": {
+                "azdEnvName": "unit",
+                "solution": module.SOLUTION_TAG,
+                "managedBy": module.BICEP_MANAGED_BY_TAG,
+            },
+        }
+        with (
+            mock.patch.object(module, "capacity_by_name_with_retry", return_value=None),
+            mock.patch.object(module, "run", return_value=json.dumps(resource)),
+            mock.patch.object(module, "wait_for_arm_capacity") as wait,
+            mock.patch.object(
+                module,
+                "capacity_by_name",
+                return_value={"id": "capacity-id", "displayName": "fabunit"},
+            ),
+        ):
+            capacity_id, capacity = module.ensure_capacity(settings, "token", dry_run=False)
+        self.assertEqual(capacity_id, "capacity-id")
+        self.assertFalse(capacity["created"])
+        self.assertTrue(capacity["owned"])
+        self.assertIsNone(capacity["resourceGroupCreated"])
+        wait.assert_called_once_with(arm_id)
+
+    def test_arm_creation_records_tagged_ownership_before_readiness_wait(self):
+        module = load_fabric_provision_module()
+        settings = {
+            "AZURE_ENV_NAME": "unit-full",
+            "FABRIC_CAPACITY_RESOURCE_GROUP": "rg-unit-full-fabric",
+            "FABRIC_LOCATION": "westus3",
+            "FABRIC_CAPACITY_NAME": "fabunitfull",
+            "FABRIC_CAPACITY_ADMIN": "admin@example.com",
+            "FABRIC_CAPACITY_SKU": "F2",
+        }
+        arm_id = "/subscriptions/sub/resourceGroups/rg-unit-full-fabric/providers/Microsoft.Fabric/capacities/fabunitfull"
+        ownership_callback = mock.Mock()
+        with (
+            mock.patch.object(module, "run", return_value="sub") as run,
+            mock.patch.object(module, "resource_group_exists", return_value=False),
+            mock.patch.object(
+                module,
+                "az_rest",
+                side_effect=[{"nameAvailable": True}, {"id": arm_id}],
+            ) as az_rest,
+            mock.patch.object(module, "wait_for_arm_capacity", side_effect=RuntimeError("ARM wait timed out")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "ARM wait timed out"):
+                module.create_arm_capacity(
+                    settings,
+                    dry_run=False,
+                    on_ownership_update=ownership_callback,
+                )
+        self.assertEqual(
+            ownership_callback.call_args_list,
+            [
+                mock.call(
+                    {
+                        "capacityId": "",
+                        "capacityArmId": "",
+                        "capacityName": "fabunitfull",
+                        "capacityResourceGroup": "rg-unit-full-fabric",
+                        "capacityResourceGroupCreated": True,
+                        "capacityCreated": False,
+                    }
+                ),
+                mock.call(
+                    {
+                        "capacityId": "",
+                        "capacityArmId": arm_id,
+                        "capacityName": "fabunitfull",
+                        "capacityResourceGroup": "rg-unit-full-fabric",
+                        "capacityResourceGroupCreated": True,
+                        "capacityCreated": True,
+                    }
+                ),
+            ],
+        )
+        create_body = az_rest.call_args_list[1].args[2]
+        self.assertEqual(create_body["tags"]["azdEnvName"], "unit-full")
+        self.assertEqual(create_body["tags"]["managedBy"], module.FABRIC_MANAGED_BY_TAG)
+        group_create = next(call.args[0] for call in run.call_args_list if call.args[0][:3] == ["az", "group", "create"])
+        self.assertIn("azdEnvName=unit-full", group_create)
+
+    def test_arm_creation_journals_group_before_capacity_put_failure(self):
+        module = load_fabric_provision_module()
+        settings = {
+            "AZURE_ENV_NAME": "unit-full",
+            "FABRIC_CAPACITY_RESOURCE_GROUP": "rg-unit-full-fabric",
+            "FABRIC_LOCATION": "westus3",
+            "FABRIC_CAPACITY_NAME": "fabunitfull",
+            "FABRIC_CAPACITY_ADMIN": "admin@example.com",
+            "FABRIC_CAPACITY_SKU": "F2",
+        }
+        ownership_callback = mock.Mock()
+        with (
+            mock.patch.object(module, "run", return_value="sub"),
+            mock.patch.object(module, "resource_group_exists", return_value=False),
+            mock.patch.object(
+                module,
+                "az_rest",
+                side_effect=[{"nameAvailable": True}, RuntimeError("capacity PUT failed")],
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "capacity PUT failed"):
+                module.create_arm_capacity(
+                    settings,
+                    dry_run=False,
+                    on_ownership_update=ownership_callback,
+                )
+        ownership_callback.assert_called_once_with(
+            {
+                "capacityId": "",
+                "capacityArmId": "",
+                "capacityName": "fabunitfull",
+                "capacityResourceGroup": "rg-unit-full-fabric",
+                "capacityResourceGroupCreated": True,
+                "capacityCreated": False,
+            }
+        )
+
+    def test_provision_log_settings_redact_admin_and_runtime_ids(self):
+        module = load_fabric_provision_module()
+        logged = module.settings_for_log(
+            {
+                "FABRIC_CAPACITY_ADMIN": "admin@example.com",
+                "FABRIC_WORKSPACE_ID": "workspace-id",
+                "FABRIC_CAPACITY_NAME": "fabunit",
+            }
+        )
+        self.assertEqual(logged["FABRIC_CAPACITY_ADMIN"], "<configured>")
+        self.assertEqual(logged["FABRIC_WORKSPACE_ID"], "<configured>")
+        self.assertEqual(logged["FABRIC_CAPACITY_NAME"], "fabunit")
 
     def test_main_writes_capacity_summary_when_later_step_fails(self):
         module = load_fabric_provision_module()
@@ -170,10 +410,20 @@ class FabricDestroySafetyTests(unittest.TestCase):
             "capacityCreated": True,
             "capacityName": "fabunit",
             "capacityResourceGroup": "rg-unit-fabric",
+            "capacityResourceGroupCreated": True,
         }
+        resources = json.dumps(
+            [
+                {
+                    "id": "/subscriptions/000/resourceGroups/rg-unit-fabric/providers/Microsoft.Fabric/capacities/fabunit",
+                    "name": "fabunit",
+                    "type": "Microsoft.Fabric/capacities",
+                }
+            ]
+        )
         with (
             mock.patch.object(module, "resource_group_exists", return_value=True),
-            mock.patch.object(module, "run", return_value="") as run,
+            mock.patch.object(module, "run", side_effect=[resources, "", ""]) as run,
             contextlib.redirect_stdout(io.StringIO()),
         ):
             deferred = module.delete_capacity_resource_group(summary, {"AZURE_RESOURCE_GROUP": "rg-unit-app"})
@@ -182,12 +432,95 @@ class FabricDestroySafetyTests(unittest.TestCase):
         self.assertIn(["az", "group", "delete", "--name", "rg-unit-fabric", "--yes", "--no-wait"], commands)
         self.assertIn(["az", "group", "wait", "--name", "rg-unit-fabric", "--deleted", "--timeout", "1800"], commands)
 
+    def test_group_created_before_failed_capacity_put_is_deleted(self):
+        module = load_fabric_destroy_module()
+        summary = {
+            "capacityCreated": False,
+            "capacityName": "fabunit",
+            "capacityResourceGroup": "rg-unit-fabric",
+            "capacityResourceGroupCreated": True,
+        }
+        with (
+            mock.patch.object(module, "resource_group_exists", return_value=True),
+            mock.patch.object(module, "run", side_effect=["[]", "", ""]) as run,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            deferred = module.delete_capacity_resource_group(summary, {"AZURE_RESOURCE_GROUP": "rg-unit-app"})
+        self.assertFalse(deferred)
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertIn(["az", "group", "delete", "--name", "rg-unit-fabric", "--yes", "--no-wait"], commands)
+
+    def test_cleanup_preserves_group_with_other_resources_and_deletes_only_capacity(self):
+        module = load_fabric_destroy_module()
+        capacity_id = "/subscriptions/000/resourceGroups/rg-shared/providers/Microsoft.Fabric/capacities/fabunit"
+        summary = {
+            "capacityCreated": True,
+            "capacityName": "fabunit",
+            "capacityArmId": capacity_id,
+            "capacityResourceGroup": "rg-shared",
+            "capacityResourceGroupCreated": True,
+        }
+        resources = json.dumps(
+            [
+                {"id": capacity_id, "name": "fabunit", "type": "Microsoft.Fabric/capacities"},
+                {
+                    "id": "/subscriptions/000/resourceGroups/rg-shared/providers/Microsoft.Storage/storageAccounts/shared",
+                    "name": "shared",
+                    "type": "Microsoft.Storage/storageAccounts",
+                },
+            ]
+        )
+        with (
+            mock.patch.object(module, "resource_group_exists", return_value=True),
+            mock.patch.object(module, "run", side_effect=[resources, ""]) as run,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            deferred = module.delete_capacity_resource_group(summary, {"AZURE_RESOURCE_GROUP": "rg-app"})
+        self.assertFalse(deferred)
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertIn(["az", "resource", "delete", "--ids", capacity_id], commands)
+        self.assertFalse(any(command[:3] == ["az", "group", "delete"] for command in commands))
+
+    def test_cleanup_refuses_capacity_arm_identity_mismatch_before_group_delete(self):
+        module = load_fabric_destroy_module()
+        recorded_id = "/subscriptions/expected/resourceGroups/rg-unit/providers/Microsoft.Fabric/capacities/fabunit"
+        discovered_id = "/subscriptions/other/resourceGroups/rg-unit/providers/Microsoft.Fabric/capacities/fabunit"
+        summary = {
+            "capacityCreated": True,
+            "capacityName": "fabunit",
+            "capacityArmId": recorded_id,
+            "capacityResourceGroup": "rg-unit",
+            "capacityResourceGroupCreated": True,
+        }
+        resources = json.dumps(
+            [{"id": discovered_id, "name": "fabunit", "type": "Microsoft.Fabric/capacities"}]
+        )
+        with (
+            mock.patch.object(module, "resource_group_exists", return_value=True),
+            mock.patch.object(module, "run", return_value=resources) as run,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "identity mismatch"):
+                module.delete_capacity_resource_group(summary, {"AZURE_RESOURCE_GROUP": "rg-app"})
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertFalse(any(command[:3] == ["az", "group", "delete"] for command in commands))
+
+    def test_full_cleanup_fails_closed_when_summary_is_missing(self):
+        module = load_fabric_destroy_module()
+        with (
+            mock.patch.object(sys, "argv", ["fabric-destroy.py", "--env-name", "unit-full", "--yes"]),
+            mock.patch.object(module, "load_azd_env", return_value={"DEPLOYMENT_MODE": "full"}),
+            mock.patch.object(module, "load_summary", return_value=None),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "release cannot be verified"):
+                module.main()
+
     def test_cleanup_verification_requires_generated_assets_to_be_absent(self):
         module = load_fabric_destroy_module()
         summary = {
             "capacityCreated": True,
             "capacityName": "fabunit",
             "capacityResourceGroup": "rg-unit-fabric",
+            "capacityResourceGroupCreated": True,
             "workspaceCreated": True,
             "workspaceId": "workspace-id",
             "lakehouseCreated": True,
@@ -203,7 +536,7 @@ class FabricDestroySafetyTests(unittest.TestCase):
         ):
             module.verify_cleanup(summary, "token")
         self.assertEqual(wait.call_count, 3)
-        capacity_wait.assert_called_once_with("fabunit", "token")
+        capacity_wait.assert_called_once_with("fabunit", "rg-unit-fabric", "token")
 
     def test_cleanup_verification_fails_when_generated_capacity_remains(self):
         module = load_fabric_destroy_module()
@@ -211,6 +544,7 @@ class FabricDestroySafetyTests(unittest.TestCase):
             "capacityCreated": True,
             "capacityName": "fabunit",
             "capacityResourceGroup": "rg-unit-fabric",
+            "capacityResourceGroupCreated": True,
         }
         with (
             mock.patch.object(module, "resource_group_exists", return_value=False),
@@ -223,6 +557,34 @@ class FabricDestroySafetyTests(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "capacity still exists"):
                 module.verify_cleanup(summary, "token")
 
+    def test_cleanup_verification_requires_preexisting_capacity_group_to_remain(self):
+        module = load_fabric_destroy_module()
+        summary = {
+            "capacityCreated": True,
+            "capacityName": "fabunit",
+            "capacityResourceGroup": "rg-shared",
+            "capacityResourceGroupCreated": False,
+        }
+        with (
+            mock.patch.object(module, "resource_group_exists", return_value=True) as group_exists,
+            mock.patch.object(module, "wait_for_capacity_absent") as capacity_wait,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            module.verify_cleanup(summary, "token")
+        self.assertEqual(group_exists.call_count, 2)
+        capacity_wait.assert_called_once_with("fabunit", "rg-shared", "token")
+
+    def test_cleanup_verification_flags_unknown_capacity_group_ownership(self):
+        module = load_fabric_destroy_module()
+        summary = {
+            "capacityCreated": True,
+            "capacityName": "fabunit",
+            "capacityResourceGroup": "rg-unknown",
+        }
+        with mock.patch.object(module, "wait_for_capacity_absent"):
+            with self.assertRaisesRegex(RuntimeError, "ownership is missing"):
+                module.verify_cleanup(summary, "token")
+
     def test_capacity_absence_waits_for_arm_and_fabric_inventories(self):
         module = load_fabric_destroy_module()
         with (
@@ -231,7 +593,7 @@ class FabricDestroySafetyTests(unittest.TestCase):
             mock.patch.object(module.time, "sleep") as sleep,
             contextlib.redirect_stdout(io.StringIO()),
         ):
-            module.wait_for_capacity_absent("fabunit", "token")
+            module.wait_for_capacity_absent("fabunit", "rg-unit-fabric", "token")
         self.assertEqual(arm_exists.call_count, 2)
         self.assertEqual(fabric_exists.call_count, 2)
         sleep.assert_called_once_with(module.FABRIC_DELETE_DELAY_SECONDS)
@@ -268,7 +630,7 @@ class FakeCleanupRunner:
         if args[:3] == ["az", "group", "exists"]:
             output = "false\n"
         elif args[:3] == ["az", "resource", "list"]:
-            output = "0\n"
+            output = "[]\n"
         else:
             output = "ok\n"
         return CommandResult(args, 0, output)
@@ -304,6 +666,18 @@ class OwnedResidualCleanupRunner(FakeCleanupRunner):
             return CommandResult(args, 0, "false\n" if self.__class__.deleted else "true\n")
         if args[:3] == ["az", "group", "delete"]:
             self.__class__.deleted = True
+        return CommandResult(args, 0, "ok\n")
+
+
+class PreexistingCapacityGroupCleanupRunner(FakeCleanupRunner):
+    def run(self, command, **kwargs):
+        args = [str(item) for item in command]
+        self.__class__.history.append(args)
+        if args[:3] == ["az", "group", "exists"]:
+            group_name = args[args.index("--name") + 1]
+            return CommandResult(args, 0, "true\n" if group_name == "rg-unit-full-shared" else "false\n")
+        if args[:3] == ["az", "resource", "list"]:
+            return CommandResult(args, 0, "[]\n")
         return CommandResult(args, 0, "ok\n")
 
 
@@ -363,9 +737,11 @@ class CleanupOwnershipTests(unittest.TestCase):
             "capacityCreated": True,
             "capacityName": "fabunitfull",
             "capacityResourceGroup": "rg-unit-full-fabric",
+            "capacityResourceGroupCreated": True,
         }
         with (
             mock.patch.object(cli, "CommandRunner", FakeCleanupRunner),
+            mock.patch.object(cli, "_locked_identity", return_value=("full", config.ownership())),
             mock.patch.object(cli, "_load_fabric_summary", return_value=fabric_summary),
             mock.patch.object(cli, "write_lock"),
         ):
@@ -379,20 +755,111 @@ class CleanupOwnershipTests(unittest.TestCase):
         self.assertEqual(checks["fabric-capacity-resource-group-absent"], "pass")
         self.assertEqual(checks["fabric-capacity-absent"], "pass")
 
+    def test_full_cleanup_preserves_preexisting_capacity_group(self):
+        config = resolve_config(profile="full", environment="unit-full-shared-group")
+        fabric_summary = {
+            "capacityCreated": True,
+            "capacityName": "fabunitfull",
+            "capacityResourceGroup": "rg-unit-full-shared",
+            "capacityResourceGroupCreated": False,
+        }
+        with (
+            mock.patch.object(cli, "CommandRunner", PreexistingCapacityGroupCleanupRunner),
+            mock.patch.object(cli, "_locked_identity", return_value=("full", config.ownership())),
+            mock.patch.object(cli, "_load_fabric_summary", return_value=fabric_summary),
+            mock.patch.object(cli, "write_lock"),
+        ):
+            report = cli.down_report(config, yes=True, quiet=True)
+        checks = {check["name"]: check["status"] for check in report["checks"]}
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(checks["fabric-capacity-resource-group-preserved"], "pass")
+        self.assertEqual(checks["fabric-capacity-absent"], "pass")
+
+    def test_full_cleanup_releases_group_left_by_failed_capacity_put(self):
+        config = resolve_config(profile="full", environment="unit-full-group-only")
+        fabric_summary = {
+            "capacityCreated": False,
+            "capacityName": "fabunitfull",
+            "capacityResourceGroup": "rg-unit-full-fabric",
+            "capacityResourceGroupCreated": True,
+        }
+        with (
+            mock.patch.object(cli, "CommandRunner", FakeCleanupRunner),
+            mock.patch.object(cli, "_locked_identity", return_value=("full", config.ownership())),
+            mock.patch.object(cli, "_load_fabric_summary", return_value=fabric_summary),
+            mock.patch.object(cli, "write_lock"),
+        ):
+            report = cli.down_report(config, yes=True, quiet=True)
+        checks = {check["name"]: check["status"] for check in report["checks"]}
+        self.assertEqual(report["status"], "pass")
+        self.assertNotIn("fabric-capacity-ownership", checks)
+        self.assertEqual(checks["fabric-capacity-resource-group-absent"], "pass")
+        self.assertEqual(checks["fabric-capacity-absent"], "pass")
+
     def test_full_cleanup_preserves_reused_capacity_without_absence_claim(self):
         config = resolve_config(profile="full", environment="unit-full-reused-capacity")
         with (
             mock.patch.object(cli, "CommandRunner", FakeCleanupRunner),
+            mock.patch.object(cli, "_locked_identity", return_value=("full", config.ownership())),
             mock.patch.object(cli, "_load_fabric_summary", return_value={"capacityCreated": False}),
             mock.patch.object(cli, "write_lock"),
         ):
             report = cli.down_report(config, yes=True, quiet=True)
         check_names = {check["name"] for check in report["checks"]}
-        self.assertEqual(report["status"], "pass")
+        self.assertEqual(report["status"], "partial")
+        checks = {check["name"]: check["status"] for check in report["checks"]}
+        self.assertEqual(checks["fabric-capacity-ownership"], "warn")
         self.assertNotIn("fabric-capacity-resource-group-absent", check_names)
         self.assertNotIn("fabric-capacity-absent", check_names)
 
-    def test_lock_disagreement_preserves_fabric(self):
+    def test_full_cleanup_with_missing_summary_is_partial_but_continues_azure_cleanup(self):
+        config = resolve_config(profile="full", environment="unit-full-missing-summary")
+        with (
+            mock.patch.object(cli, "CommandRunner", FakeCleanupRunner),
+            mock.patch.object(cli, "_locked_identity", return_value=("full", config.ownership())),
+            mock.patch.object(cli, "_load_fabric_summary", return_value=None),
+            mock.patch.object(cli, "write_lock"),
+        ):
+            report = cli.down_report(config, yes=True, quiet=True)
+        checks = {check["name"]: check["status"] for check in report["checks"]}
+        commands = [" ".join(command) for command in FakeCleanupRunner.history]
+        self.assertEqual(report["status"], "partial")
+        self.assertEqual(checks["fabric-summary"], "warn")
+        self.assertTrue(any("azd down" in command for command in commands))
+
+    def test_full_cleanup_with_unknown_capacity_group_ownership_is_partial(self):
+        config = resolve_config(profile="full", environment="unit-full-unknown-group")
+        fabric_summary = {
+            "capacityCreated": True,
+            "capacityName": "fabunitfull",
+            "capacityResourceGroup": "rg-unit-full-fabric",
+        }
+        with (
+            mock.patch.object(cli, "CommandRunner", FakeCleanupRunner),
+            mock.patch.object(cli, "_locked_identity", return_value=("full", config.ownership())),
+            mock.patch.object(cli, "_load_fabric_summary", return_value=fabric_summary),
+            mock.patch.object(cli, "write_lock"),
+        ):
+            report = cli.down_report(config, yes=True, quiet=True)
+        checks = {check["name"]: check["status"] for check in report["checks"]}
+        self.assertEqual(report["status"], "partial")
+        self.assertEqual(checks["fabric-capacity-resource-group-ownership"], "warn")
+
+    def test_full_cleanup_without_lock_preserves_fabric_and_continues_azure_cleanup(self):
+        config = resolve_config(profile="full", environment="unit-full-missing-lock")
+        with (
+            mock.patch.object(cli, "CommandRunner", FakeCleanupRunner),
+            mock.patch.object(cli, "write_lock"),
+        ):
+            report = cli.down_report(config, yes=True, quiet=True)
+        checks = {check["name"]: check["status"] for check in report["checks"]}
+        commands = [" ".join(command) for command in FakeCleanupRunner.history]
+        self.assertEqual(report["status"], "partial")
+        self.assertEqual(checks["ownership"], "warn")
+        self.assertFalse(any("fabric-destroy.py" in command for command in commands))
+        self.assertTrue(any("azd down" in command for command in commands))
+
+    def test_any_lock_disagreement_preserves_all_fabric(self):
         config = resolve_config(profile="full", environment="unit-lock-safety")
         lock = {
             "environment": "unit-lock-safety",
@@ -400,8 +867,8 @@ class CleanupOwnershipTests(unittest.TestCase):
             "ownership": {
                 "azure": "create",
                 "fabricCapacity": "reuse",
-                "fabricWorkspace": "reuse",
-                "fabricOntology": "reuse",
+                "fabricWorkspace": "create",
+                "fabricOntology": "create",
             },
         }
         config.lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -410,7 +877,9 @@ class CleanupOwnershipTests(unittest.TestCase):
         with mock.patch.object(cli, "CommandRunner", FakeCleanupRunner), mock.patch.object(cli, "write_lock"):
             report = cli.down_report(config, yes=True, quiet=True)
         commands = [" ".join(command) for command in FakeCleanupRunner.history]
-        self.assertEqual(report["status"], "pass")
+        self.assertEqual(report["status"], "partial")
+        checks = {check["name"]: check["status"] for check in report["checks"]}
+        self.assertEqual(checks["ownership"], "warn")
         self.assertFalse(any("fabric-destroy.py" in command for command in commands))
 
 

--- a/tests/test_maintainer_evidence.py
+++ b/tests/test_maintainer_evidence.py
@@ -52,7 +52,47 @@ class MaintainerEvidenceTests(unittest.TestCase):
         self.assertIn("Microsoft Learn MCP KS PASS in byo-fabric", extracted)
         self.assertIn("Fabric Ontology KS PASS in byo-fabric", extracted)
         self.assertIn("Combined KB PASS in byo-fabric", extracted)
-        self.assertIn("all required absence checks PASS in byo-fabric", extracted)
+        self.assertIn("all required release checks PASS in byo-fabric", extracted)
+
+    def test_full_cleanup_accepts_preexisting_capacity_group_preservation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            report = root / "test-report.md"
+            summary = root / "summary.md"
+            report.write_text(
+                "# LiveKS E2E Test Report\n\n"
+                "- Deployment mode: `full`\n"
+                "- Location: `eastus`\n"
+                "- Cleanup requested: `yes`\n"
+                "- Generated: `2026-08-13 12:00 KST`\n\n"
+                "| Status | Check | Note |\n"
+                "| --- | --- | --- |\n"
+                "| `PASS` | fabric-cleanup | deleted |\n"
+                "| `PASS` | azure-cleanup | deleted |\n"
+                "| `PASS` | resource-group-absent | absent |\n"
+                "| `PASS` | fabric-capacity-absent | absent |\n"
+                "| `PASS` | fabric-capacity-resource-group-preserved | preserved |\n",
+                encoding="utf-8",
+            )
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "scripts/maintainers/summarize-e2e-evidence.py"),
+                    str(report),
+                    "--output",
+                    str(summary),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            extracted = subprocess.run(
+                [sys.executable, str(ROOT / "scripts/maintainers/extract-review-evidence.py"), str(summary)],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        self.assertIn("all required release checks PASS in full", extracted)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- journal Fabric capacity and resource-group ownership before propagation waits, while preserving direct azd Bicep ownership proof
- reject ambiguous same-name capacity adoption and fail closed when lock or summary ownership is missing or conflicting
- delete only proven generated capacity resources, preserve shared groups, and verify group deletion or preservation explicitly
- align E2E evidence, operator docs, maintainer audit, and Python dependency update coverage with the lifecycle contract

## Validation

- `python3 tools/validate.py --profile offline --format json`
- `bash scripts/validate-local.sh` (15/15 gates, 71 tests)
- `az bicep lint --file infra/main.bicep`
- `.deployment/docs-venv/bin/mkdocs build --strict --site-dir /tmp/liveks-lifecycle-hardening-site-final`
- `npm --prefix static-app audit --omit=dev`
- `git diff --check`