### PR TITLE
Make first-run evidence executable

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,6 +37,15 @@ jobs:
       - name: Run local validation gate
         run: bash scripts/validate-local.sh --no-color
 
+      - name: Upload first-success evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: first-success-evidence
+          path: .deployment/first-run-evidence.json
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 14
+
       - name: Check whitespace
         run: git diff --check
 
@@ -57,7 +66,7 @@ jobs:
       - name: Bootstrap and run the Windows launcher
         shell: pwsh
         run: |
-          .\liveks.ps1 try --format json
+          .\liveks.ps1 try --format json --evidence-out .deployment/windows-first-run-evidence.json
           .\liveks.ps1 bootstrap
           .\liveks.ps1 profiles --format json
           .\liveks.ps1 doctor --profile offline --format json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this accelerator are documented here.
 
 ### Added
 
+- Executable offline first-success assertions and revision-bound evidence capsules for the documented `liveks try` path, plus allowlist-sanitized JSON and Markdown capsules for live E2E runs.
+- Pull-request retention of the exact no-cloud first-success capsule as a short-lived `first-success-evidence` Actions artifact.
 - Fabric capacity and dedicated resource-group ownership journaling, environment tags, and cleanup tests for partial provisioning, failed capacity creation, shared resource groups, missing summaries, and pre-existing capacities.
 - Weekly Dependabot coverage for the root Python requirements files.
 - Outcome-first clone-to-grounded-proof hero for the README and manual landing page, backed by the actual LiveKS profile, lifecycle, evidence, and cleanup contracts.
@@ -25,6 +27,7 @@ All notable changes to this accelerator are documented here.
 
 ### Changed
 
+- Local and Windows validation now execute the documented first-success command; a damaged known-answer, activity, reference, or source-identity fixture fails the same entry point shown to users.
 - The MCP Server guide now uses one payload-to-cleanup execution contract that distinguishes representative JSON, the resolved deployment dry-run, live retrieve evidence, and native Knowledge Base MCP content proof.
 - Full create mode now rejects an existing capacity unless the same environment summary or exact tagged Bicep output proves ownership, records ARM ownership before readiness polling, and redacts administrator and generated IDs from provisioning settings output.
 - Fabric cleanup deletes a capacity resource group only when this run created the group and no unrelated resources are present; otherwise it deletes only the owned capacity and verifies preservation of a pre-existing group. Missing, conflicting, or unresolved full-mode ownership now reports partial cleanup instead of a false pass.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > Platform teams connect a governed Fabric Ontology or remote HTTPS MCP tool, submit a natural-language question to a Foundry IQ Knowledge Base, and receive a grounded result with source evidence that can also be consumed through MCP.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Validate](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/actions/workflows/validate.yml/badge.svg)](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/actions/workflows/validate.yml)
 ![Azure AI Search](https://img.shields.io/badge/Azure%20AI%20Search-2026--05--01--preview-orange)
 ![Python](https://img.shields.io/badge/Python-3.11%2B-blue)
 ![Node.js](https://img.shields.io/badge/Node.js-22%2B-green)
@@ -26,10 +27,12 @@ From a fresh clone, inspect the complete answer-and-evidence contract before ins
 ```bash
 git clone --depth 1 https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources.git
 cd azure-ai-search-foundry-iq-live-knowledge-sources
-./liveks try
+./liveks try --evidence-out .deployment/first-run-evidence.json
 ```
 
-Python 3.11 or newer is the only requirement for this first pass. The answer prints before trace details, and the replay exposes both `mcpServer` and `fabricOntology` evidence. It creates no cloud resources and proves the packaged response contract only, not a live source call.
+Python 3.11 or newer is the only requirement for this first pass. Require `Contract: PASS (4/4 assertions)`: the known synthetic fact, both required activity types, both required reference types, and both Knowledge Source names must be present. The ignored evidence capsule records the repository revision, runtime, fixture digest, source counts, and assertion statuses without the answer, query, raw response, or credentials.
+
+The pull-request `Validate` workflow executes this same entry point and retains the capsule as the `first-success-evidence` artifact. This creates no cloud resources and proves the packaged response contract only, not a live source call.
 
 ## Components At A Glance
 

--- a/docs/07-troubleshooting.md
+++ b/docs/07-troubleshooting.md
@@ -16,7 +16,11 @@ Generated diagnostics are written under ignored paths:
 deployments/<env>/deployment-summary.md
 deployments/<env>/test-report.md
 deployments/<env>/e2e-report.json
+deployments/<env>/evidence-capsule.md
+deployments/<env>/evidence-capsule.json
 ```
+
+Use the detailed reports for local diagnosis. The evidence capsules omit messages and environment-specific identifiers, but still review them before sharing.
 
 Start with machine-readable diagnostics:
 
@@ -96,6 +100,7 @@ Start with machine-readable diagnostics:
 
 - `FAIL` means the required behavior for the selected mode did not complete.
 - `SKIP` is acceptable only when the selected mode explicitly does not require that path, such as Fabric checks in `mcp-only`.
+- `evidence-capsule.json` is the machine-readable safe-field view. Use `e2e-report.json` when the omitted diagnostic messages are needed locally.
 - For `byo-fabric`, missing Fabric IDs should fail during configuration resolution, before deployment starts.
 - For `full`, missing Fabric IDs are acceptable only if the greenfield Fabric provisioning step produced generated IDs.
 - Separate MCP and Fabric checks prove both live paths. A combined KB check passes with recognized live evidence from one or both because the Knowledge Base planner chooses which attached source to call for each query.

--- a/docs/09-offline-replay.md
+++ b/docs/09-offline-replay.md
@@ -5,13 +5,25 @@ Offline replay exposes the Foundry IQ retrieve response contract without Azure r
 ## CLI
 
 ```bash
-./liveks try
+./liveks try --evidence-out .deployment/first-run-evidence.json
 ./liveks try --sample mcp
 ./liveks try --sample fabric
 ./liveks try --sample combined --details
 ```
 
-The default combined replay prints the answer before trace details. `--details` expands `activity`, `references`, and source-specific `sourceData`.
+The default combined replay prints the answer before trace details and fails unless all four packaged assertions pass: known answer, required activity types, required reference types, and required Knowledge Source names. `--details` expands `activity`, `references`, and source-specific `sourceData`.
+
+## Evidence Capsule
+
+`--evidence-out` writes a machine-readable, ignored capsule for the exact first-success command. It includes:
+
+- repository revision and runtime,
+- fixture path and SHA-256 digest,
+- activity and reference counts,
+- expected and observed source types and names,
+- assertion statuses and the explicit `offline-replay` boundary.
+
+The capsule excludes the answer, query, raw response, and credentials. The `Validate` workflow runs this entry point and uploads the resulting `first-success-evidence` artifact after the local gate passes.
 
 ## Browser
 
@@ -38,4 +50,4 @@ The three canonical fixtures live under `samples/responses/`. The CLI, Pages bui
 
 ## Boundary
 
-The responses use synthetic Airline Ops data and demonstrate trace shape and teaching flow. They do not prove that Azure AI Search called Microsoft Learn MCP, that a Fabric GraphModel was ready, or that delegated Fabric authorization worked. Use `liveks verify` and live E2E reports for those claims.
+The responses use synthetic Airline Ops data and demonstrate trace shape and teaching flow. They do not prove that Azure AI Search called Microsoft Learn MCP, that a Fabric GraphModel was ready, or that delegated Fabric authorization worked. Use `liveks verify` and live E2E reports for those claims. Live E2E writes detailed ignored reports plus allowlist-sanitized JSON and Markdown evidence capsules; the capsule records assertion names and statuses without copying live messages or identifiers.

--- a/docs/10-one-command-deployment.md
+++ b/docs/10-one-command-deployment.md
@@ -189,7 +189,7 @@ Full mode:
 
 Choose exactly one of `--cleanup` or `--keep-resources`. Use the latter only for active debugging with an assigned cleanup owner.
 
-The lifecycle writes ignored `deployments/<environment>/e2e-report.json` and `test-report.md` files for machine inspection and the existing maintainer evidence workflow.
+The lifecycle writes detailed ignored `e2e-report.json` and `test-report.md` files, plus allowlist-sanitized `evidence-capsule.json` and `evidence-capsule.md` views. The capsules retain revision, profile, assertion status, proved source types, and a detailed-report digest while omitting messages and environment-specific identifiers.
 
 ## Residual Fabric Capacity
 

--- a/docs/20-liveks-cli.md
+++ b/docs/20-liveks-cli.md
@@ -7,9 +7,11 @@ LiveKS is the plan-first lifecycle entry point for this accelerator. The same co
 Offline replay has no package installation step:
 
 ```bash
-./liveks try
+./liveks try --evidence-out .deployment/first-run-evidence.json
 ./liveks try --sample mcp --details
 ```
+
+The first command exits nonzero if the packaged known-answer, activity, reference, or source-identity contract fails. Its evidence capsule is safe-field-only and does not include the answer, query, raw response, or credentials.
 
 Install the pinned CLI dependency into the ignored `.liveks/venv` before using the remaining commands:
 
@@ -91,7 +93,16 @@ Choose exactly one cleanup behavior:
 
 Use `--keep-resources` only while debugging. Release evidence should include successful cleanup.
 
-Every E2E run writes ignored `deployments/<environment>/e2e-report.json` and `test-report.md` artifacts. The JSON preserves the nested lifecycle result; the Markdown format remains compatible with the maintainer evidence summarizer.
+Every E2E run writes four ignored artifacts under `deployments/<environment>/`:
+
+| Artifact | Purpose |
+| --- | --- |
+| `e2e-report.json` | Complete nested lifecycle result for local diagnosis. |
+| `test-report.md` | Detailed maintainer report compatible with the evidence summarizer. |
+| `evidence-capsule.json` | Allowlist-sanitized machine manifest with revision, profile, assertion statuses, proved source types, and source-report digest. |
+| `evidence-capsule.md` | Human-readable view of the same sanitized assertion set. |
+
+The capsules omit the environment name, check messages, resource identifiers, endpoints, raw responses, and credentials. Review them before sharing because the detailed reports beside them remain local-only.
 
 ## Machine-Readable Output
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Platform teams connect a governed Fabric Ontology or remote HTTPS MCP tool, subm
 </figure>
 
 !!! tip "First success from a fresh clone"
-    Run `./liveks try`. It requires Python 3.11 or newer, installs no packages, creates no cloud resources, and prints the answer before the MCP Server and Fabric Ontology evidence trace. This proves the packaged replay contract only.
+    Run `./liveks try --evidence-out .deployment/first-run-evidence.json`. It requires Python 3.11 or newer, installs no packages, creates no cloud resources, and must report `Contract: PASS (4/4 assertions)`. The ignored capsule records revision, fixture digest, source identities, counts, and assertion status without answer or query text. This proves the packaged replay contract only.
 
 The representative path below reuses an existing Fabric workspace and ontology. It proves one source first, then calls the same Knowledge Base through its native MCP endpoint. It does not publish Fabric identifiers, tokens, endpoints, or raw live responses.
 

--- a/docs/maintainers/mempalace-first-run-evidence-audit-2026-08-15.md
+++ b/docs/maintainers/mempalace-first-run-evidence-audit-2026-08-15.md
@@ -1,0 +1,62 @@
+# MemPalace First-Run Evidence Adaptation Audit
+
+This maintainer record captures the 2026-08-15 read-only benchmark review and the repository-native adaptation. It is excluded from the public Pages build. No MemPalace code, workflow YAML, prose, branding, visual assets, commands, or domain model were copied.
+
+## External Evidence
+
+| Item | Verified value |
+| --- | --- |
+| Repository | `MemPalace/mempalace` |
+| Default branch at review | `develop` |
+| Reviewed revision | `06cb6987f02610784fefbad4b2bd5d026d164ba6` |
+| Commit time | `2026-08-15T01:20:07Z` |
+| License | MIT, confirmed by GitHub metadata and the root `LICENSE` at the reviewed revision |
+| Repository snapshot | 58,379 stars and 7,498 forks when queried on 2026-08-15 |
+
+Observed paths and the abstract pattern considered:
+
+| Upstream path | Observation | Adaptation boundary |
+| --- | --- | --- |
+| `README.md` headings `What it is`, `Install`, `Docker`, `Quickstart`, and `Benchmarks` | The reader moves from product boundary to a short run path and then to evidence. | Keep LiveKS terminology and the existing replay-to-live progression; make the first documented command assert its own contract. |
+| `.github/workflows/docker-publish.yml` | A runtime smoke job gates image publication and calls a dedicated smoke script. | Run the LiveKS no-cloud entry point in the existing validation gate. Do not introduce Docker because this repository's first path is a dependency-free Python replay. |
+| `scripts/docker-smoke.sh` | The shipped runtime, persistence, MCP handshake, and Compose syntax are tested rather than inferred from a build. | Assert the Foundry IQ fixture's known answer, activity, references, and source identities. Retain the existing protected live retrieve and Knowledge Base MCP checks for cloud claims. |
+| `LICENSE` | MIT permission and notice are present. | No substantial material was reused, so no copied notice is added. This repository remains under its existing MIT license. |
+
+The official `actions/upload-artifact` action added for short-lived CI evidence was separately checked as an active MIT-licensed GitHub repository. It follows this repository's existing major-version action policy.
+
+## Internal Baseline
+
+| Contract | Existing state | Finding |
+| --- | --- | --- |
+| First documented command | README and manual start with dependency-free `./liveks try`. | Correct user path, but Linux validation did not execute the wrapper exactly as documented. |
+| Offline result | `tools/try_offline.py` printed canonical response fixtures. | `status` was fixed to `pass`, so missing source evidence could still produce a successful command. |
+| Configuration failures | Schema v2 fails closed on unknown fields, raw secret values, and missing BYO Fabric IDs. | Already meets the no-credential PR contract; retain it. |
+| Southbound MCP transport | MCP Server KS is documented and built as a reachable remote HTTPS endpoint. | Already explicit; stdio Docker flags are inapplicable. |
+| Northbound MCP transport | `liveks mcp` uses stateless JSON-RPC 2.0 over HTTP and parses JSON or SSE. | Already covered by protocol, content, failure-normalization, and persistence tests. |
+| Protected live evidence | `verify`, `mcp`, and `e2e` separate source trace proof, protocol success, known-fact grounding, controlled failure, and cleanup. | Keep protected and tenant-specific. Do not add cloud mutations to PR validation. |
+| Evidence files | Detailed JSON and Markdown E2E reports are ignored. | They can contain local messages or identifiers and lacked a separate allowlist-sanitized machine manifest. |
+
+## Independent Implementation
+
+1. `liveks try` now derives its status from four Foundry IQ replay invariants: a known synthetic fact, required activity source types, required reference source types, and required Knowledge Source identities.
+2. `--evidence-out` writes a no-cloud capsule with repository revision, runtime, fixture digest, source counts, and assertion status. Answer text, query text, the raw response, and credentials are excluded by construction.
+3. The existing local gate runs the same first-success entry point shown in README. Pull requests retain the resulting capsule for 14 days.
+4. Live E2E writes separate allowlist-sanitized JSON and Markdown capsules. Only profile, revision, assertion names and statuses, proved source types, and a digest of the detailed local report cross into the capsule.
+5. Detailed E2E messages, environment names, resource identifiers, service endpoints, raw responses, and credentials remain outside the sanitized capsules and outside git.
+
+## Validation Contract
+
+| Claim | Required check |
+| --- | --- |
+| Packaged first success is intact | `./liveks try --evidence-out .deployment/first-run-evidence.json` returns zero and reports four passing assertions. |
+| A fixture regression fails visibly | Unit tests remove expected reference evidence and require a failing report. |
+| Offline capsule is safe-field-only | Unit tests inject answer and query markers and require both to be absent from serialized evidence. |
+| Live capsule is safe-field-only | Unit tests inject a token-like value, private endpoint, and environment name into detailed evidence and require all to be absent from the capsule. |
+| Repository contracts remain aligned | `bash scripts/validate-local.sh --no-color` and `git diff --check` pass. |
+
+## Explicit Non-Adaptations
+
+- No MemPalace name, palace terminology, benchmark result, product claim, branding, image, or community wording is used.
+- No Docker image, persistence volume, stdio `-i`, Compose setting, backend plugin, coverage threshold, platform matrix, retry rule, release branch, or package publishing design is adopted.
+- No MemPalace performance number is presented as LiveKS evidence.
+- Offline replay still proves response shape only. Live `mcpServer` or `fabricOntology` claims still require protected source-specific verification, and native MCP grounding still requires a known-fact assertion paired with retrieve evidence.

--- a/docs/maintainers/release-readiness-checklist.md
+++ b/docs/maintainers/release-readiness-checklist.md
@@ -65,6 +65,8 @@ For each deployment mode you plan to demonstrate, keep an ignored local report:
 
 ```text
 deployments/<env>/test-report.md
+deployments/<env>/evidence-capsule.json
+deployments/<env>/evidence-capsule.md
 ```
 
 Expected evidence:

--- a/docs/maintainers/reviewer-evidence.md
+++ b/docs/maintainers/reviewer-evidence.md
@@ -11,6 +11,7 @@ The important point: do not judge the sample only by final answer text. A good r
 | Local validation gate | Terminal output from `bash scripts/validate-local.sh` | No | The repo builds, notebooks parse, payloads generate, offline traces inspect, no-secret scan passes, and Bicep compiles when Azure CLI is available. |
 | Deployment summary | `deployments/<env>/deployment-summary.md` | No | The deployed app URL, resource names, endpoints, Knowledge Source names, Knowledge Base names, and smoke-test status. |
 | E2E test report | `deployments/<env>/test-report.md` | No | Create-call-load-delete checks with PASS, FAIL, or SKIP per deployment mode. |
+| Sanitized evidence capsule | `deployments/<env>/evidence-capsule.json` and `.md` | Review first | Revision, profile, assertion statuses, proved source types, and detailed-report digest without messages or environment-specific identifiers. |
 | Sanitized E2E evidence summary | `scratch/review-packets/e2e-evidence-summary-*.local.md` | No | PASS, FAIL, and SKIP counts plus checklist names without raw report notes, endpoints, tenant IDs, or resource names. |
 | Offline replay samples | `samples/responses/*.json` | Yes | Expected retrieve trace shape without live tenant dependencies. |
 | Test specifications | `docs/maintainers/test-specs/*.md` | Yes | The expected checks and pass criteria for each full-run path. |

--- a/docs/maintainers/test-specs/README.md
+++ b/docs/maintainers/test-specs/README.md
@@ -20,8 +20,12 @@ Every live full-run should write ignored evidence:
 ```text
 deployments/<env>/test-report.md
 deployments/<env>/e2e-report.json
+deployments/<env>/evidence-capsule.md
+deployments/<env>/evidence-capsule.json
 deployments/<env>/deployment-summary.md
 ```
+
+The first two files are detailed local evidence. The capsules are allowlist-sanitized human and machine views; review them before sharing and never substitute them for source-specific live assertions.
 
 Fabric-only runs may also write:
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -25,10 +25,12 @@ Normally, do not author that optional token field at all. `verify` and `mcp` acq
 ## 1. Replay The Contract
 
 ```bash
-./liveks try
+./liveks try --evidence-out .deployment/first-run-evidence.json
 ```
 
-Expected: an answer naming Alpine Air, followed by both `MCP Server KS` and `Fabric Ontology KS` evidence. No package install or cloud access is used.
+Expected: an answer naming Alpine Air, both `MCP Server KS` and `Fabric Ontology KS` evidence, and `Contract: PASS (4/4 assertions)`. No package install or cloud access is used.
+
+The ignored `.deployment/first-run-evidence.json` capsule contains only the source revision, runtime, fixture digest, source identities and counts, and assertion statuses. It excludes the answer, query, raw response, and credentials. Pull requests run the same command and retain this capsule as the `first-success-evidence` workflow artifact.
 
 Open the same response visually in the [interactive trace demo](https://microsoft.github.io/azure-ai-search-foundry-iq-live-knowledge-sources/demo/?demo=combined).
 
@@ -204,4 +206,4 @@ Never use `--keep-resources` for a release rehearsal without recording who owns 
 
 ## Evidence Boundary
 
-Keep `.liveks/`, `.deployment/`, `deployments/`, raw responses, tokens, and private screenshots out of git. Public summaries should include only profile, status, sanitized resource/source names, evidence counts, and cleanup result.
+Keep `.liveks/`, `.deployment/`, `deployments/`, raw responses, tokens, and private screenshots out of git. Every `e2e` run writes allowlist-sanitized `evidence-capsule.json` and `evidence-capsule.md` files beside the detailed local reports. Review even sanitized capsules before sharing; public summaries should include only profile, revision, status, source types, assertion names, evidence counts, report digest, and cleanup result.

--- a/scripts/validate-local.sh
+++ b/scripts/validate-local.sh
@@ -17,6 +17,7 @@ Options:
 This script performs local, non-deploying validation:
 - shell syntax
 - LiveKS CLI dependencies and profile schema
+- documented first-success execution contract
 - Python compile
 - Python contract tests
 - notebook JSON parse
@@ -75,7 +76,7 @@ fi
 
 cd "$(git rev-parse --show-toplevel)"
 
-TOTAL=15
+TOTAL=16
 CURRENT=0
 FAILED=false
 SKIPPED=0
@@ -168,6 +169,7 @@ run_required "Python compile" \
     samples/python/build_payloads.py \
     samples/python/inspect_retrieve_response.py \
     src/liveks/runtime.py \
+    src/liveks/evidence.py \
     src/liveks/cli.py
 
 run_required "Python contract tests" \
@@ -209,6 +211,9 @@ run_required "Sample packaging hygiene" \
 
 run_required "Repository size hygiene" \
   python3 scripts/check-repo-size.py
+
+run_required "Documented first-success contract" \
+  ./liveks try --evidence-out .deployment/first-run-evidence.json
 
 run_required "Sample payload generation" \
   bash -c 'python3 samples/python/build_payloads.py >/dev/null'

--- a/src/liveks/cli.py
+++ b/src/liveks/cli.py
@@ -29,6 +29,7 @@ from .config import (
     write_lock,
     write_user_config,
 )
+from .evidence import generated_at, repository_revision, runtime_summary, sha256_file, write_json
 from .runtime import CommandRunner, http_json, http_mcp_json, parse_azd_values, parse_version
 
 
@@ -86,13 +87,138 @@ def _markdown_cell(value: Any) -> str:
     return str(value or "").replace("\n", " ").replace("|", "\\|").strip()
 
 
+def _sanitized_e2e_checks(report: dict[str, Any]) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    for phase_name in ("up", "down"):
+        phase = report.get("phases", {}).get(phase_name)
+        if not isinstance(phase, dict):
+            continue
+        for check in phase.get("checks", []):
+            if not isinstance(check, dict):
+                continue
+            safe_check: dict[str, Any] = {
+                "phase": phase_name,
+                "name": str(check.get("name", "unknown")),
+                "status": str(check.get("status", "unknown")),
+            }
+            source_types = check.get("sourceTypes")
+            if isinstance(source_types, list):
+                safe_check["sourceTypes"] = sorted(
+                    {str(item) for item in source_types if item in {"fabricOntology", "mcpServer"}}
+                )
+            checks.append(safe_check)
+    return checks
+
+
+def _write_e2e_evidence_capsule(
+    config: ResolvedConfig,
+    report: dict[str, Any],
+    *,
+    cleanup_requested: bool,
+    source_report: Path,
+    json_path: Path,
+    markdown_path: Path,
+) -> None:
+    checks = _sanitized_e2e_checks(report)
+    status_counts: dict[str, int] = {}
+    for check in checks:
+        status = str(check["status"])
+        status_counts[status] = status_counts.get(status, 0) + 1
+
+    successful_names = {check["name"] for check in checks if check["status"] == "pass"}
+    source_types: list[str] = []
+    if "fabric-retrieve" in successful_names:
+        source_types.append("fabricOntology")
+    if "mcp-retrieve" in successful_names:
+        source_types.append("mcpServer")
+    mcp_status = next(
+        (str(check["status"]) for check in checks if check["name"] == "knowledge-base-mcp"),
+        "not-run",
+    )
+    combined_status = next(
+        (str(check["status"]) for check in checks if check["name"] == "combined-retrieve"),
+        "not-run",
+    )
+
+    capsule = {
+        "schemaVersion": 1,
+        "kind": "liveks-evidence-capsule",
+        "scope": "live-e2e-sanitized",
+        "status": str(report.get("status", "unknown")),
+        "generatedAt": generated_at(),
+        "repositoryRevision": repository_revision(ROOT),
+        "profile": config.profile,
+        "command": {
+            "entryPoint": "./liveks e2e",
+            "environment": "redacted",
+            "cleanupRequested": cleanup_requested,
+        },
+        "runtime": runtime_summary(),
+        "declaredContracts": {
+            "mcpServerKnowledgeSourceTransport": "remote-https",
+            "knowledgeBaseMcpTransport": "stateless-json-rpc-http",
+            "liveGrounding": "protected-integration",
+        },
+        "observedEvidence": {
+            "sourceTypes": sorted(source_types),
+            "knowledgeBaseMcp": mcp_status,
+            "combinedRouting": combined_status,
+        },
+        "summary": {
+            "checkCount": len(checks),
+            "statusCounts": dict(sorted(status_counts.items())),
+        },
+        "assertions": checks,
+        "sourceReport": {
+            "kind": "e2e-report",
+            "sha256": sha256_file(source_report),
+        },
+        "privacy": {
+            "environmentIncluded": False,
+            "messagesIncluded": False,
+            "resourceIdentifiersIncluded": False,
+            "serviceEndpointsIncluded": False,
+            "rawResponsesIncluded": False,
+            "credentialsIncluded": False,
+        },
+    }
+    write_json(json_path, capsule)
+
+    revision = str(capsule["repositoryRevision"])
+    lines = [
+        "# LiveKS Evidence Capsule",
+        "",
+        "> Ignored, allowlist-sanitized evidence. Review before sharing.",
+        "",
+        f"- Status: `{str(capsule['status']).upper()}`",
+        f"- Profile: `{config.profile}`",
+        f"- Repository revision: `{revision}`",
+        f"- Cleanup requested: `{'yes' if cleanup_requested else 'no'}`",
+        f"- Source types proved: `{', '.join(sorted(source_types)) or 'none'}`",
+        f"- Knowledge Base MCP: `{mcp_status}`",
+        f"- Source report SHA-256: `{capsule['sourceReport']['sha256']}`",
+        "",
+        "| Phase | Status | Assertion |",
+        "| --- | --- | --- |",
+    ]
+    lines.extend(f"| `{check['phase']}` | `{str(check['status']).upper()}` | {check['name']} |" for check in checks)
+    markdown_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 def write_e2e_reports(config: ResolvedConfig, report: dict[str, Any], *, cleanup_requested: bool) -> list[str]:
     """Persist ignored machine and maintainer reports for the complete lifecycle."""
     report_dir = ROOT / "deployments" / config.environment
     report_dir.mkdir(parents=True, exist_ok=True)
     json_path = report_dir / "e2e-report.json"
     markdown_path = report_dir / "test-report.md"
-    artifacts = [_display_path(json_path), _display_path(markdown_path)]
+    capsule_json_path = report_dir / "evidence-capsule.json"
+    capsule_markdown_path = report_dir / "evidence-capsule.md"
+    artifacts = [
+        _display_path(json_path),
+        _display_path(markdown_path),
+        _display_path(capsule_json_path),
+        _display_path(capsule_markdown_path),
+    ]
     report["artifacts"] = list(dict.fromkeys(report.get("artifacts", []) + artifacts))
     json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
@@ -127,6 +253,14 @@ def write_e2e_reports(config: ResolvedConfig, report: dict[str, Any], *, cleanup
     ]
     lines.extend(f"| `{status}` | {name} | {message} |" for status, name, message in checks)
     markdown_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    _write_e2e_evidence_capsule(
+        config,
+        report,
+        cleanup_requested=cleanup_requested,
+        source_report=json_path,
+        json_path=capsule_json_path,
+        markdown_path=capsule_markdown_path,
+    )
     return artifacts
 
 
@@ -1120,6 +1254,7 @@ def build_parser() -> argparse.ArgumentParser:
     try_parser.add_argument("--sample", choices=["mcp", "fabric", "combined"], default="combined")
     try_parser.add_argument("--details", action="store_true")
     try_parser.add_argument("--format", choices=["text", "json"], default="text")
+    try_parser.add_argument("--evidence-out", type=Path)
 
     init_parser = subparsers.add_parser("init", help="Create an ignored YAML environment ledger.")
     init_parser.add_argument("--profile", choices=["mcp-only", "byo-fabric", "full"], required=True)
@@ -1211,6 +1346,8 @@ def main(argv: list[str] | None = None) -> int:
             command = [sys.executable, "tools/try_offline.py", "--sample", args.sample, "--format", args.format]
             if args.details:
                 command.append("--details")
+            if args.evidence_out:
+                command.extend(["--evidence-out", str(args.evidence_out)])
             return subprocess.run(command, cwd=ROOT, check=False).returncode
         if args.command == "init":
             destination = args.config or ROOT / ".liveks" / f"{args.environment}.yaml"

--- a/src/liveks/evidence.py
+++ b/src/liveks/evidence.py
@@ -1,0 +1,63 @@
+"""Small, dependency-free helpers for sanitized execution evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+
+
+def generated_at() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def repository_revision(root: Path) -> str:
+    github_sha = os.environ.get("GITHUB_SHA", "").strip()
+    if COMMIT_SHA_RE.fullmatch(github_sha):
+        return github_sha.lower()
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+            timeout=3,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "unavailable"
+    revision = result.stdout.strip()
+    return revision.lower() if result.returncode == 0 and COMMIT_SHA_RE.fullmatch(revision) else "unavailable"
+
+
+def runtime_summary() -> dict[str, str]:
+    return {
+        "python": platform.python_version(),
+        "os": platform.system().lower() or sys.platform,
+        "architecture": platform.machine().lower() or "unknown",
+    }
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/test_liveks_config.py
+++ b/tests/test_liveks_config.py
@@ -130,7 +130,15 @@ class LiveKsConfigTests(unittest.TestCase):
             "environment": "unit-report",
             "phases": {
                 "up": {"checks": [{"name": "mcp-retrieve", "status": "pass", "message": "live | evidence"}]},
-                "down": {"checks": [{"name": "resource-group-absent", "status": "pass", "message": "absent"}]},
+                "down": {
+                    "checks": [
+                        {
+                            "name": "resource-group-absent",
+                            "status": "pass",
+                            "message": "absent; super-secret-token; https://private-search.example",
+                        }
+                    ]
+                },
             },
             "artifacts": [],
         }
@@ -138,11 +146,19 @@ class LiveKsConfigTests(unittest.TestCase):
             artifacts = cli.write_e2e_reports(config, report, cleanup_requested=True)
             json_report = json.loads((Path(temp_dir) / "deployments/unit-report/e2e-report.json").read_text())
             markdown_report = (Path(temp_dir) / "deployments/unit-report/test-report.md").read_text()
-        self.assertEqual(len(artifacts), 2)
+            capsule = json.loads((Path(temp_dir) / "deployments/unit-report/evidence-capsule.json").read_text())
+            capsule_markdown = (Path(temp_dir) / "deployments/unit-report/evidence-capsule.md").read_text()
+        self.assertEqual(len(artifacts), 4)
         self.assertEqual(json_report["status"], "pass")
         self.assertIn("- Deployment mode: `mcp-only`", markdown_report)
         self.assertIn("| `PASS` | mcp-retrieve | live \\| evidence |", markdown_report)
-        self.assertIn("| `PASS` | resource-group-absent | absent |", markdown_report)
+        self.assertIn("| `PASS` | resource-group-absent | absent; super-secret-token", markdown_report)
+        self.assertEqual(capsule["kind"], "liveks-evidence-capsule")
+        self.assertEqual(capsule["observedEvidence"]["sourceTypes"], ["mcpServer"])
+        self.assertFalse(capsule["privacy"]["messagesIncluded"])
+        self.assertNotIn("unit-report", json.dumps(capsule))
+        self.assertNotIn("super-secret-token", json.dumps(capsule))
+        self.assertNotIn("private-search.example", capsule_markdown)
 
     def test_bicep_parameters_cover_canonical_names(self):
         parameters = json.loads((ROOT / "infra/main.parameters.json").read_text(encoding="utf-8"))["parameters"]

--- a/tests/test_try_offline.py
+++ b/tests/test_try_offline.py
@@ -1,0 +1,67 @@
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import try_offline  # noqa: E402
+
+
+class OfflineFirstSuccessTests(unittest.TestCase):
+    def test_every_packaged_scenario_satisfies_its_contract(self):
+        expected_types = {
+            "mcp": ["mcpServer"],
+            "fabric": ["fabricOntology"],
+            "combined": ["fabricOntology", "mcpServer"],
+        }
+        for sample, source_types in expected_types.items():
+            with self.subTest(sample=sample):
+                report = try_offline.build_report(sample)
+                self.assertEqual(report["status"], "pass")
+                self.assertEqual(report["sourceTypes"], source_types)
+                self.assertTrue(all(check["status"] == "pass" for check in report["checks"]))
+
+    def test_missing_expected_reference_fails_the_first_success_contract(self):
+        original = json.loads(try_offline.SAMPLES["combined"].read_text(encoding="utf-8"))
+        original["references"] = [
+            item for item in original["references"] if item.get("type") != "mcpServer"
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fixture = Path(temp_dir) / "combined.json"
+            fixture.write_text(json.dumps(original), encoding="utf-8")
+            with mock.patch.dict(try_offline.SAMPLES, {"combined": fixture}):
+                report = try_offline.build_report("combined")
+                with redirect_stdout(StringIO()):
+                    exit_code = try_offline.main(["--sample", "combined", "--format", "json"])
+
+        reference_check = next(check for check in report["checks"] if check["name"] == "reference-evidence")
+        self.assertEqual(report["status"], "fail")
+        self.assertEqual(reference_check["status"], "fail")
+        self.assertEqual(exit_code, 1)
+
+    def test_evidence_capsule_omits_answer_query_and_raw_response(self):
+        report = try_offline.build_report("combined")
+        report["answer"] += " super-secret-value"
+        report["response"]["privateQuery"] = "customer private question"
+
+        capsule = try_offline.build_evidence_capsule(report)
+        serialized = json.dumps(capsule)
+
+        self.assertEqual(capsule["kind"], "liveks-evidence-capsule")
+        self.assertEqual(capsule["scope"], "offline-first-success")
+        self.assertEqual(capsule["networkCalls"], 0)
+        self.assertFalse(capsule["privacy"]["rawResponseIncluded"])
+        self.assertNotIn("super-secret-value", serialized)
+        self.assertNotIn("customer private question", serialized)
+        self.assertNotIn("response", capsule)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/try_offline.py
+++ b/tools/try_offline.py
@@ -5,15 +5,38 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from liveks.evidence import generated_at, repository_revision, runtime_summary, sha256_file, write_json  # noqa: E402
+
+
 SAMPLES = {
     "mcp": ROOT / "samples/responses/mcp-retrieve.sample.json",
     "fabric": ROOT / "samples/responses/fabric-airline-ops-retrieve.sample.json",
     "combined": ROOT / "samples/responses/combined-airline-ops-retrieve.sample.json",
+}
+CONTRACTS = {
+    "mcp": {
+        "sourceTypes": {"mcpServer"},
+        "sourceNames": {"microsoft-learn-mcp-ks"},
+        "knownAnswerTerm": "Azure AI Search",
+    },
+    "fabric": {
+        "sourceTypes": {"fabricOntology"},
+        "sourceNames": {"fabric-ontology-ks"},
+        "knownAnswerTerm": "Alpine Air",
+    },
+    "combined": {
+        "sourceTypes": {"fabricOntology", "mcpServer"},
+        "sourceNames": {"fabric-ontology-ks", "microsoft-learn-mcp-ks"},
+        "knownAnswerTerm": "Alpine Air",
+    },
 }
 
 
@@ -34,23 +57,127 @@ def source_names(response: dict[str, Any]) -> list[str]:
     return names
 
 
+def _types(items: list[Any]) -> set[str]:
+    return {
+        str(item["type"])
+        for item in items
+        if isinstance(item, dict) and isinstance(item.get("type"), str)
+    }
+
+
+def build_checks(sample: str, response: dict[str, Any]) -> list[dict[str, Any]]:
+    contract = CONTRACTS[sample]
+    expected_types = set(contract["sourceTypes"])
+    expected_names = set(contract["sourceNames"])
+    activity_types = _types(response.get("activity", []))
+    reference_types = _types(response.get("references", []))
+    observed_names = set(source_names(response))
+    answer = answer_text(response)
+    known_answer = str(contract["knownAnswerTerm"])
+
+    return [
+        {
+            "name": "known-answer",
+            "status": "pass" if known_answer.casefold() in answer.casefold() else "fail",
+            "message": "The packaged answer contains the scenario's known non-sensitive fact.",
+            "expectedTermCount": 1,
+            "matchedExpectedTermCount": 1 if known_answer.casefold() in answer.casefold() else 0,
+        },
+        {
+            "name": "activity-evidence",
+            "status": "pass" if expected_types.issubset(activity_types) else "fail",
+            "message": "Activity contains every source type required by the replay contract.",
+            "expectedSourceTypes": sorted(expected_types),
+            "observedSourceTypes": sorted(activity_types),
+        },
+        {
+            "name": "reference-evidence",
+            "status": "pass" if expected_types.issubset(reference_types) else "fail",
+            "message": "References contain every source type required by the replay contract.",
+            "expectedSourceTypes": sorted(expected_types),
+            "observedSourceTypes": sorted(reference_types),
+        },
+        {
+            "name": "source-identity",
+            "status": "pass" if expected_names.issubset(observed_names) else "fail",
+            "message": "The packaged trace names every Knowledge Source required by the scenario.",
+            "expectedSourceNames": sorted(expected_names),
+            "observedSourceNames": sorted(observed_names),
+        },
+    ]
+
+
 def build_report(sample: str) -> dict[str, Any]:
     response = json.loads(SAMPLES[sample].read_text(encoding="utf-8"))
+    checks = build_checks(sample, response)
+    status = "fail" if any(check["status"] == "fail" for check in checks) else "pass"
     return {
         "schemaVersion": 2,
         "command": "try",
-        "status": "pass",
+        "status": status,
         "mode": "offline-replay",
         "sample": sample,
         "answer": answer_text(response),
         "sources": source_names(response),
+        "sourceTypes": sorted(_types(response.get("activity", [])) | _types(response.get("references", []))),
         "activityCount": len(response.get("activity", [])),
         "referenceCount": len(response.get("references", [])),
+        "checks": checks,
         "response": response,
     }
 
 
-def render_text(report: dict[str, Any], details: bool) -> str:
+def build_evidence_capsule(report: dict[str, Any]) -> dict[str, Any]:
+    sample_path = SAMPLES[str(report["sample"])]
+    safe_check_fields = (
+        "name",
+        "status",
+        "expectedTermCount",
+        "matchedExpectedTermCount",
+        "expectedSourceTypes",
+        "observedSourceTypes",
+        "expectedSourceNames",
+        "observedSourceNames",
+    )
+    assertions = [
+        {key: check[key] for key in safe_check_fields if key in check}
+        for check in report.get("checks", [])
+        if isinstance(check, dict)
+    ]
+    return {
+        "schemaVersion": 1,
+        "kind": "liveks-evidence-capsule",
+        "scope": "offline-first-success",
+        "status": report["status"],
+        "generatedAt": generated_at(),
+        "repositoryRevision": repository_revision(ROOT),
+        "command": f"./liveks try --sample {report['sample']}",
+        "mode": "offline-replay",
+        "networkCalls": 0,
+        "runtime": runtime_summary(),
+        "fixture": {
+            "path": str(sample_path.relative_to(ROOT)),
+            "sha256": sha256_file(sample_path),
+        },
+        "evidence": {
+            "activityCount": report["activityCount"],
+            "referenceCount": report["referenceCount"],
+            "sourceNames": report["sources"],
+            "sourceTypes": report["sourceTypes"],
+        },
+        "assertions": assertions,
+        "privacy": {
+            "answerIncluded": False,
+            "queryIncluded": False,
+            "rawResponseIncluded": False,
+            "credentialsIncluded": False,
+        },
+    }
+
+
+def render_text(report: dict[str, Any], details: bool, evidence_path: Path | None = None) -> str:
+    passed = sum(check.get("status") == "pass" for check in report.get("checks", []))
+    total = len(report.get("checks", []))
     lines = [
         "Answer",
         str(report["answer"]),
@@ -59,24 +186,33 @@ def render_text(report: dict[str, Any], details: bool) -> str:
         ", ".join(report["sources"]) or "No source evidence",
         "",
         f"Trace: {report['activityCount']} activity items, {report['referenceCount']} references (offline replay)",
+        f"Contract: {str(report['status']).upper()} ({passed}/{total} assertions)",
     ]
+    for check in report.get("checks", []):
+        if check.get("status") == "fail":
+            lines.append(f"[FAIL] {check.get('name')}: {check.get('message')}")
+    if evidence_path:
+        lines.append(f"Evidence capsule: {evidence_path}")
     if details:
         lines.extend(["", "Full response", json.dumps(report["response"], indent=2)])
     return "\n".join(lines)
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Inspect a checked-in retrieve trace without cloud resources.")
     parser.add_argument("--sample", choices=sorted(SAMPLES), default="combined")
     parser.add_argument("--details", action="store_true")
     parser.add_argument("--format", choices=["text", "json"], default="text")
-    args = parser.parse_args()
+    parser.add_argument("--evidence-out", type=Path, help="Write a sanitized machine-readable evidence capsule.")
+    args = parser.parse_args(argv)
     report = build_report(args.sample)
+    if args.evidence_out:
+        write_json(args.evidence_out, build_evidence_capsule(report))
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))
     else:
-        print(render_text(report, args.details))
-    return 0
+        print(render_text(report, args.details, args.evidence_out))
+    return 0 if report["status"] == "pass" else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make the documented `./liveks try` path fail when its known-answer, activity, reference, or Knowledge Source identity contract is broken
- add revision-bound, allowlist-sanitized evidence capsules for offline first success and live E2E runs
- execute the same no-cloud entry point in Linux and Windows validation and retain the first-success capsule for 14 days
- record the MemPalace benchmark revision, MIT license, observed paths, independent adaptation, and explicit non-adaptations

## Why

The repository already separates no-credential contract checks from protected live grounding and documents both MCP directions. The remaining gap was that the first command shown to users returned a fixed pass status and Linux CI did not execute that wrapper exactly. This change turns the landing-page promise into an executable contract while keeping live tenant evidence protected and ignored.

## Validation

- `bash scripts/validate-local.sh --no-color` (16/16 passed, 74 tests)
- `python3 -m unittest tests.test_try_offline tests.test_liveks_config`
- `mkdocs build --strict`
- `git diff --check`
- fresh clone of commit `c9e9714`: documented first-success command passed 4/4, wrote a capsule for the same revision, and made zero network calls

No Azure or Fabric resources were created for this pull request. Existing protected live verification, known-fact MCP checks, failure normalization, and cleanup contracts remain unchanged.
