### PR TITLE
Use current artifact action runtime

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,7 +38,7 @@ jobs:
         run: bash scripts/validate-local.sh --no-color
 
       - name: Upload first-success evidence
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: first-success-evidence
           path: .deployment/first-run-evidence.json


### PR DESCRIPTION
## Summary

- Upgrade the official `actions/upload-artifact` action from v4 to v7.
- Preserve the hidden first-success evidence upload and fail-closed artifact contract introduced in #19.
- Remove the Node.js 20 deprecation annotation emitted by the post-merge validation run.

## Validation

- `bash scripts/validate-local.sh --no-color` (16/16 gates, 74 tests)
- `git diff --check`
- Confirmed that `actions/upload-artifact@v7` supports `include-hidden-files` and `if-no-files-found`.