### PR TITLE
Add a stable Search Index knowledge source profile

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 # Generated legacy environment catalog.
 # Source of truth: config/schema.yaml and profiles/*.yaml.
 # Prefer .liveks/<env>.yaml created by ./liveks init.
+# - search-index: wrap an existing Search index with the stable extractive contract.
 # - mcp-only: deploy Azure AI Search with the MCP Server Knowledge Source.
 # - byo-fabric: connect an existing Fabric ontology without taking ownership.
 # - full: create the Fabric sample stack after explicit cost acknowledgement.
@@ -17,8 +18,12 @@ AZURE_HOSTING_MODE=staticwebapp
 AZURE_STATIC_WEB_APP_LOCATION=eastus2
 AZURE_APP_SERVICE_SKU=F1
 AZURE_SEARCH_API_VERSION=2026-05-01-preview
+AZURE_SEARCH_ENDPOINT=''
 AZURE_SEARCH_SKU=basic
-AIRLINE_OPS_INDEX_NAME=airline-ops-regulatory-docs
+SEARCH_INDEX_NAME=airline-ops-regulatory-docs
+SEARCH_SEMANTIC_CONFIGURATION_NAME=''
+SEARCH_INDEX_KNOWLEDGE_SOURCE_NAME=''
+SEARCH_INDEX_KNOWLEDGE_BASE_NAME=''
 MCP_KNOWLEDGE_SOURCE_NAME=microsoft-learn-mcp-ks
 FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME=fabric-ontology-ks
 MCP_ONLY_KNOWLEDGE_BASE_NAME=live-knowledge-sources-mcp-kb

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,6 +13,7 @@ body:
     attributes:
       label: Area
       options:
+        - Search Index Knowledge Source
         - MCP Server Knowledge Source
         - Fabric Ontology Knowledge Source
         - Combined Knowledge Base
@@ -28,6 +29,7 @@ body:
     attributes:
       label: Deployment mode
       options:
+        - search-index
         - mcp-only
         - byo-fabric
         - full
@@ -39,7 +41,7 @@ body:
     id: api-version
     attributes:
       label: Azure AI Search API version
-      placeholder: "2026-05-01-preview"
+      placeholder: "2026-04-01 or 2026-05-01-preview"
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/review_request.yml
+++ b/.github/ISSUE_TEMPLATE/review_request.yml
@@ -16,6 +16,7 @@ body:
       label: Review scope
       options:
         - Azure AI Search terminology and REST shape
+        - Search Index Knowledge Source
         - MCP Server Knowledge Source
         - Fabric Ontology Knowledge Source
         - Deployment modes
@@ -29,6 +30,7 @@ body:
     attributes:
       label: Deployment modes involved
       options:
+        - label: search-index (stable existing-index path)
         - label: mcp-only
         - label: byo-fabric
         - label: full

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@
 
 ## Deployment Mode Impact
 
+- [ ] `search-index` (stable existing-index path)
 - [ ] `mcp-only`
 - [ ] `byo-fabric`
 - [ ] `full`
@@ -37,9 +38,9 @@ Result: PASS / FAIL / SKIP summary
 
 Do not paste raw tokens, tenant IDs, service URLs, customer data, or generated deployment reports into this PR.
 
-## Preview And Security Checklist
+## API And Security Checklist
 
-- [ ] API version remains explicit where preview APIs are used.
+- [ ] API version remains explicit and matches the stable or preview contract used by this change.
 - [ ] No secrets, bearer tokens, API keys, tenant-specific IDs, customer data, or private endpoint details were added.
 - [ ] Generated files remain under ignored paths such as `.deployment/`, `deployments/`, or `scratch/`.
 - [ ] Fabric live claims are backed by live Fabric activity or clearly described as offline replay.
@@ -55,5 +56,5 @@ Suggested reviewer asks:
 - Azure AI Search Knowledge Source terminology and REST shape
 - MCP Server KS request/response shape and trace wording
 - Fabric Ontology KS setup and delegated source authorization wording
-- deployment-mode clarity: `mcp-only`, `byo-fabric`, `full`
+- profile clarity: stable `search-index`; preview `mcp-only`, `byo-fabric`, `full`
 - public-preview caveats

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This public accelerator demonstrates Foundry IQ composition across Azure AI Sear
 Follow this progression unless the user explicitly requests another profile:
 
 ```text
-offline -> mcp-only -> byo-fabric
+offline -> search-index (when an agentic-ready index exists) -> mcp-only -> byo-fabric
 ```
 
 `full` is a greenfield demo profile. It creates a billable Fabric F2 capacity and generated Fabric assets, so it requires explicit user intent and `--accept-fabric-capacity`.
@@ -31,7 +31,7 @@ Do not create cloud resources merely because credentials are available. `try`, `
 ## Configuration Authority
 
 - `config/schema.yaml` defines supported fields, validation, azd projection, secrets, and legacy mappings.
-- `profiles/offline.yaml`, `mcp-only.yaml`, `byo-fabric.yaml`, and `full.yaml` define executable defaults, resources, cost, and success criteria.
+- `profiles/offline.yaml`, `search-index.yaml`, `mcp-only.yaml`, `byo-fabric.yaml`, and `full.yaml` define executable defaults, resources, cost, and success criteria.
 - `.liveks/<environment>.yaml` is the ignored human-authored ledger.
 - `.liveks/<environment>.lock.json` is the ignored redacted resolution and ownership record.
 - `azd env` is generated deployment state, not the v2 authoring source.
@@ -40,6 +40,20 @@ Do not create cloud resources merely because credentials are available. `try`, `
 Unknown YAML fields fail closed. Secret fields must use `{env: VARIABLE_NAME}` and must never contain raw values.
 
 ## Live Lifecycle
+
+Stable existing-index lane:
+
+```bash
+./liveks init --profile search-index --env liveks-index
+# Fill the existing endpoint, index, semantic configuration, and optional field lists.
+./liveks doctor --env liveks-index
+./liveks plan --env liveks-index
+./liveks up --env liveks-index --query "<question>" --expect-term "<known term>"
+./liveks verify --env liveks-index --query "<question>" --expect-term "<known term>"
+./liveks down --env liveks-index
+```
+
+Preview deployment lane:
 
 ```bash
 ./liveks init --profile mcp-only --env liveks-mcp
@@ -62,6 +76,7 @@ Rules:
 
 ## Ownership Rules
 
+- `search-index`: Search service and index are reused and must be preserved; only a matching lock can authorize deletion of the generated KS and KB.
 - `mcp-only`: generated Azure assets may be deleted; no Fabric assets are owned.
 - `byo-fabric`: generated Azure assets may be deleted; Fabric capacity, workspace, and ontology must be preserved.
 - `full`: generated Azure and Fabric assets may be deleted.
@@ -78,6 +93,8 @@ Use the evidence that matches the claim:
 | --- | --- |
 | Repository is internally consistent | `bash scripts/validate-local.sh` |
 | Offline response shape | `./liveks try --details` |
+| Stable Search Index path is live | `liveks verify` reports `search-index-retrieve=pass`; use `--expect-term` for content acceptance |
+| Existing Search index survived cleanup | `liveks down` reports `search-index-preserved=pass` |
 | Deployment is ready | Passing `liveks doctor` and `liveks plan` |
 | MCP path is live | MCP activity or references from `liveks verify` |
 | Fabric path is live | `fabricOntology` evidence in live mode with delegated authorization |
@@ -104,6 +121,6 @@ The supported Fabric pattern is native Fabric Ontology Knowledge Source. The che
 
 ## Source Of Truth
 
-Azure AI Search Knowledge Source APIs are public preview and pinned here to `2026-05-01-preview`. Keep the official Microsoft Learn articles for MCP Server KS, Fabric Ontology KS, Knowledge Base creation, and retrieve behavior as the API source of truth.
+The Search Index lane is generally available and pinned to `2026-04-01`. MCP Server and Fabric Ontology lanes are public preview and pinned to `2026-05-01-preview`. Keep the official Microsoft Learn articles for Search Index KS, MCP Server KS, Fabric Ontology KS, Knowledge Base creation, and retrieve behavior as the API source of truth.
 
 When live behavior differs from replay, state that replay demonstrates response shape only. Summarize live evidence using sanitized status, source names, counts, and cleanup outcome.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this accelerator are documented here.
 
 ### Added
 
+- A generally available `search-index` profile for existing agentic-ready Azure AI Search indexes, with keyless doctor checks, stable payload planning, extractive retrieve verification, expected-term assertions, collision protection, lock-proved KS/KB ownership, and preserved-index cleanup evidence.
+- A source-backed Search Index execution manual that records the required YAML inputs, success and failure messages, stable API boundary, and official Microsoft Learn contracts.
 - A Codespaces and Dev Container first-live path with pinned Python, Node.js, Azure CLI, Bicep, and Azure Developer CLI tooling, plus a validation rule that prevents automatic cloud mutation during container creation.
 - A source-backed, identifier-free MCP-only live evidence sample and visual that distinguish a controlled live E2E pass from the canonical offline replay.
 - A stable-versus-preview API compatibility matrix covering source kinds, retrieve inputs, reasoning behavior, authentication, source authorization, and supported profiles.
@@ -30,7 +32,8 @@ All notable changes to this accelerator are documented here.
 
 ### Changed
 
-- README, manual home, and trace demo now lead with `30-second replay -> mcp-only first live -> Fabric expansion`; replay status and fixture badges explicitly say that no Azure call occurred.
+- README and runbook profile selection now place the stable existing-index lane between offline replay and preview MCP/Fabric deployment, while keeping the two API contracts fail-closed and separate.
+- README and manual home now lead with `30-second replay -> stable existing-index live -> preview MCP-only -> Fabric expansion`; replay status and fixture badges explicitly say that no Azure call occurred.
 - `search.api_version` and direct postprovision validation now fail closed on anything except the repository's tested `2026-05-01-preview` contract.
 - Local and Windows validation now execute the documented first-success command; a damaged known-answer, activity, reference, or source-identity fixture fails the same entry point shown to users.
 - The MCP Server guide now uses one payload-to-cleanup execution contract that distinguishes representative JSON, the resolved deployment dry-run, live retrieve evidence, and native Knowledge Base MCP content proof.
@@ -56,9 +59,10 @@ All notable changes to this accelerator are documented here.
 
 ### Compatibility
 
+- Search Index KS uses generally available `2026-04-01`, `intents`, and minimal extractive retrieval; MCP Server and Fabric Ontology profiles remain on `2026-05-01-preview` with `messages` and answer synthesis.
 - The Knowledge Base MCP tool accepts its documented `queries` input only; retrieve-only source-forcing parameters are not sent through MCP, so independent source proof uses the corresponding single-source Knowledge Base.
 - The checked-in Airline Ops terms are synthetic sample evidence and are not assumed to exist in an arbitrary BYO Fabric ontology; live assertions must match the connected ontology's own sanitized facts.
-- Azure AI Search Knowledge Source API remains pinned to `2026-05-01-preview`.
+- MCP Server and Fabric Ontology Knowledge Source APIs remain pinned to `2026-05-01-preview`; the Search Index profile is pinned separately to stable `2026-04-01`.
 - Python 3.11+, Azure Developer CLI 1.27.0+, and Node.js 22+ are required for live profiles.
 - Legacy dotenv input remains supported through `--env-file` and one-time `init --from-env` migration.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Foundry IQ Live Knowledge Sources Accelerator
 
-> Go from clone to a proved live Azure AI Search MCP Server Knowledge Source, then extend the same guarded lifecycle to a governed Fabric Ontology.
+> Go from clone to a proved stable Search Index Knowledge Source, then extend the same guarded lifecycle to preview MCP Server and governed Fabric Ontology sources.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Validate](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/actions/workflows/validate.yml/badge.svg)](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/actions/workflows/validate.yml)
-![Azure AI Search](https://img.shields.io/badge/Azure%20AI%20Search-2026--05--01--preview-orange)
+![Stable API](https://img.shields.io/badge/Search%20Index%20KS-2026--04--01-blue)
+![Preview API](https://img.shields.io/badge/MCP%20%2B%20Fabric-2026--05--01--preview-orange)
 ![Python](https://img.shields.io/badge/Python-3.11%2B-blue)
 ![Node.js](https://img.shields.io/badge/Node.js-22%2B-green)
 
@@ -15,20 +16,21 @@
 <p align="center">
   <img
     src="assets/clone-to-grounded-proof.svg"
-    alt="Three stages from clone to proof: a 30-second offline replay, the MCP-only first live Azure path, and advanced Fabric expansion."
+    alt="Three stages from clone to proof: a 30-second offline replay, a choice between stable Search Index and preview MCP live paths, and advanced Fabric expansion."
     width="1600"
   />
 </p>
 
-This accelerator is for three successive jobs:
+This accelerator is for four successive jobs:
 
 | You are here | Finish this | Path |
 | --- | --- | --- |
 | **Evaluator** | Inspect the answer, activity, references, and source identities without cloud access. | `./liveks try` |
-| **Azure implementer** | Deploy and prove one live MCP Server KS without Fabric. | `mcp-only` |
+| **Search implementer** | Wrap and prove an existing agentic-ready Search index without transferring ownership. | `search-index` |
+| **Azure implementer** | Deploy and prove one preview MCP Server KS without Fabric. | `mcp-only` |
 | **Fabric implementer** | Add an existing or greenfield ontology and prove both source paths. | `byo-fabric` or `full` |
 
-The repository is a reusable accelerator, not a production reference architecture. Coding-agent behavior is specified separately in [AGENTS.md](AGENTS.md); human onboarding stays focused on the three outcomes above.
+The repository is a reusable accelerator, not a production reference architecture. Coding-agent behavior is specified separately in [AGENTS.md](AGENTS.md); human onboarding stays focused on the outcomes above.
 
 ## 30-Second Replay
 
@@ -46,7 +48,37 @@ Python 3.11 or newer is the only requirement. Require `Contract: PASS (4/4 asser
 
 The ignored capsule records repository revision, runtime, fixture digest, source counts, and assertion status without query, answer, raw response, or credentials. Pull-request validation runs the same command and retains the capsule as a short-lived workflow artifact.
 
-## First Actual Live: MCP-Only
+## Lowest-Risk Live: Existing Search Index
+
+When an agentic-ready Azure AI Search index already exists, use the generally available `2026-04-01` lane before preview-only sources:
+
+```bash
+./liveks bootstrap
+./liveks init --profile search-index --env liveks-index
+# Fill endpoint, index_name, semantic_configuration_name, and optional field lists.
+./liveks doctor --env liveks-index
+./liveks plan --env liveks-index
+./liveks up \
+  --env liveks-index \
+  --query "<question answerable from the index>" \
+  --expect-term "<known non-sensitive term>"
+```
+
+`doctor` reads the index definition with a transient Microsoft Entra token. `plan` checks stable payloads and name collisions without writes. `up` creates only a Search Index KS and minimal extractive Knowledge Base, then applies the supplied content assertion; the Search service and index remain BYO assets.
+
+Prove a real call with a known non-sensitive term, then clean up:
+
+```bash
+./liveks verify \
+  --env liveks-index \
+  --query "<question answerable from the index>" \
+  --expect-term "<known term>"
+./liveks down --env liveks-index
+```
+
+Require `search-index-retrieve=pass`, `grounding-content=pass`, and `search-index-preserved=pass`. Read the [stable Search Index execution contract](docs/23-search-index-ks.md).
+
+## First Preview Live: MCP-Only
 
 Use the checked-in Codespaces environment to avoid installing Python, Node.js, Azure CLI, Bicep, and Azure Developer CLI yourself. Container creation runs only replay, dependency bootstrap, profile listing, and offline doctor; it never signs in or creates cloud resources.
 
@@ -129,6 +161,7 @@ BYO Fabric typically takes 10-25 minutes after its IDs and delegated authorizati
 
 | Component | What it does | Proof to inspect |
 | --- | --- | --- |
+| **Search Index Knowledge Source** | Wraps an existing agentic-ready Search index for stable extractive retrieval. | `searchIndex` activity or references, expected content, and preserved-index cleanup proof. |
 | **MCP Server Knowledge Source** | Calls an allowed tool on a remote HTTPS MCP server during Knowledge Base retrieval. | `mcpServer` activity or references and the invoked tool name. |
 | **Fabric Ontology Knowledge Source** | Grounds a business question in governed Fabric entities and relationships. | `fabricOntology` activity or references plus Fabric source data. |
 | **Foundry IQ Knowledge Base** | Plans retrieval across attached sources and produces one grounded result. | Answer content, `activity`, `references`, and `sourceData`. |
@@ -156,6 +189,7 @@ The verifier checks each source independently before combined planner routing:
 
 | Profile | Required source proof |
 | --- | --- |
+| `search-index` | Stable retrieve returns extracted text and `searchIndex` activity or references; optional expected terms match. |
 | `mcp-only` | `mcpServer` activity or references from the MCP-only Knowledge Base. |
 | `byo-fabric` | MCP evidence plus `fabricOntology` evidence from the Fabric-only Knowledge Base. |
 | `full` | Both source checks, generated Fabric readiness, app status, and ownership evidence. |
@@ -203,6 +237,8 @@ Omitting `--expect-term` proves the MCP protocol surface only and leaves groundi
 
 Read [Call the Knowledge Base Through MCP](docs/22-knowledge-base-mcp.md) for authentication, delegated Fabric authorization, and controlled failure handling.
 
+The native `liveks mcp` client currently targets the preview deployment profiles. The stable `search-index` profile uses its documented REST retrieve assertion; MCP plus Search Index composition is tracked as a separate preview expansion.
+
 ## Configuration And Compatibility
 
 `.liveks/<environment>.yaml` is the canonical human-authored ledger. `azd env` is generated deployment state. Secret fields use `{env: VARIABLE_NAME}` references; raw values never belong in YAML.
@@ -210,11 +246,12 @@ Read [Call the Knowledge Base Through MCP](docs/22-knowledge-base-mcp.md) for au
 | Profile | Cloud mutation | Required configuration |
 | --- | --- | --- |
 | `offline` | None | None |
+| `search-index` | Generated KS and KB only; service and index reused | Existing endpoint, index, semantic configuration, and Search permissions |
 | `mcp-only` | Generated Azure resources | Azure sign-in; profile defaults are otherwise runnable |
 | `byo-fabric` | Generated Azure resources only | Existing Fabric workspace and ontology IDs |
 | `full` | Generated Azure and Fabric resources | Fabric quota and explicit capacity acceptance |
 
-The live profiles are pinned to `2026-05-01-preview`. LiveKS rejects `2026-04-01` stable because MCP Server KS, Fabric Ontology KS, message input, answer synthesis, and configurable reasoning are preview-dependent in this implementation. The stable API remains valid for its generally available sources and minimal, extractive retrieval; this repository does not yet implement that separate lane.
+The `search-index` profile is pinned to generally available `2026-04-01` and uses `intents` plus minimal extractive retrieval. The MCP and Fabric profiles are pinned to `2026-05-01-preview` because their source kinds, `messages`, answer synthesis, and configurable reasoning are preview-dependent. LiveKS rejects cross-lane API overrides.
 
 Read the [stable vs preview compatibility matrix](docs/14-api-compatibility.md).
 
@@ -244,13 +281,13 @@ The answer is printed first, followed by MCP Server KS and Fabric Ontology KS ev
 
 ## Verify And Clean Up
 
-Before cleanup, open the App URL in `deployments/<environment>/deployment-summary.md` and complete the [Guided Live Demo](docs/16-demo-walkthrough.md).
+Before cleanup for a preview deployment, open the App URL in `deployments/<environment>/deployment-summary.md` and complete the [Guided Live Demo](docs/16-demo-walkthrough.md). The stable data-plane profile has no app; run its documented `verify --query --expect-term` assertion instead.
 
 ```bash
 ./liveks down --env <environment>
 ```
 
-Require `resource-group-absent=pass`. A `full` run that generated Fabric capacity must also report `fabric-capacity-absent`, plus either `fabric-capacity-resource-group-absent` for a generated group or `fabric-capacity-resource-group-preserved` for a pre-existing group.
+For `search-index`, require `search-index-preserved=pass`. For preview deployments, require `resource-group-absent=pass`. A `full` run that generated Fabric capacity must also report `fabric-capacity-absent`, plus either `fabric-capacity-resource-group-absent` for a generated group or `fabric-capacity-resource-group-preserved` for a pre-existing group.
 
 For a controlled end-to-end rehearsal:
 
@@ -304,6 +341,7 @@ The gate checks configuration and CLI contracts, safe dev container behavior, no
 
 - [Agentic retrieval overview](https://learn.microsoft.com/azure/search/search-agentic-retrieval-concept)
 - [What is a Knowledge Source?](https://learn.microsoft.com/azure/search/agentic-knowledge-source-overview)
+- [Create a Search Index knowledge source](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-search-index)
 - [Create an MCP Server knowledge source](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-mcp-server)
 - [Create a Fabric Ontology knowledge source](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-fabric-ontology)
 - [Create a Knowledge Base](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-create-knowledge-base)

--- a/assets/clone-to-grounded-proof.svg
+++ b/assets/clone-to-grounded-proof.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="760" viewBox="0 0 1600 760" role="img" aria-labelledby="title desc">
-  <title id="title">From clone to the first live Foundry IQ proof</title>
-  <desc id="desc">Three stages: inspect a 30-second offline replay, run the MCP-only profile as the first actual Azure deployment, then expand to an existing or greenfield Fabric ontology.</desc>
+  <title id="title">From clone to a live Foundry IQ proof</title>
+  <desc id="desc">Three stages: inspect a 30-second offline replay, choose a stable Search Index or preview MCP Server live path, then expand to an existing or greenfield Fabric ontology.</desc>
 
   <rect width="1600" height="760" fill="#F7F9FC"/>
   <rect x="0" y="0" width="14" height="760" fill="#0F6CBD"/>
 
   <text x="58" y="58" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#0F6CBD">FROM CLONE TO FIRST LIVE PROOF</text>
   <text x="58" y="112" font-family="Segoe UI, Arial, sans-serif" font-size="44" font-weight="700" fill="#111827">See the contract. Prove one live source. Expand when ready.</text>
-  <text x="60" y="154" font-family="Segoe UI, Arial, sans-serif" font-size="21" fill="#475569">The shortest supported path preserves doctor, plan, ARM preview, explicit confirmation, source evidence, and cleanup.</text>
+  <text x="60" y="154" font-family="Segoe UI, Arial, sans-serif" font-size="21" fill="#475569">The guarded lifecycle preserves doctor, plan, explicit confirmation, source evidence, and ownership-safe cleanup.</text>
 
   <rect x="1310" y="40" width="234" height="42" rx="8" fill="#E8F3FC" stroke="#8DC8E8" stroke-width="2"/>
   <text x="1340" y="67" font-family="Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#0F548C">CODESPACES READY</text>
@@ -31,15 +31,16 @@
     <rect x="500" y="192" width="600" height="370" rx="8" fill="#102A43" stroke="#0F6CBD" stroke-width="3"/>
     <rect x="500" y="192" width="600" height="10" fill="#2E90FA"/>
     <rect x="848" y="222" width="220" height="38" rx="6" fill="#DFF6E9" stroke="#68C78A"/>
-    <text x="888" y="247" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#116B3A">FIRST ACTUAL LIVE</text>
-    <text x="532" y="250" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#90CDF4">2 | AZURE IMPLEMENTER</text>
-    <text x="532" y="304" font-family="Segoe UI, Arial, sans-serif" font-size="36" font-weight="700" fill="#FFFFFF">MCP-only</text>
-    <text x="532" y="341" font-family="Segoe UI, Arial, sans-serif" font-size="19" fill="#D7E3F0">No Fabric workspace or ontology required.</text>
+    <text x="864" y="247" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#116B3A">CHOOSE FIRST LIVE LANE</text>
+    <text x="532" y="250" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#90CDF4">2 | SEARCH OR AZURE IMPLEMENTER</text>
+    <text x="532" y="304" font-family="Segoe UI, Arial, sans-serif" font-size="36" font-weight="700" fill="#FFFFFF">Prove one source</text>
+    <text x="532" y="341" font-family="Segoe UI, Arial, sans-serif" font-size="19" fill="#D7E3F0">Reuse an index or deploy the preview MCP path.</text>
     <rect x="532" y="374" width="536" height="64" rx="6" fill="#0B1F33" stroke="#486581"/>
-    <text x="558" y="414" font-family="Consolas, monospace" font-size="21" font-weight="700" fill="#BEE3F8">doctor -&gt; plan -&gt; up -&gt; verify</text>
-    <text x="532" y="474" font-family="Segoe UI, Arial, sans-serif" font-size="17" fill="#E6EEF7">Azure AI Search calls the public Microsoft Learn MCP tool.</text>
+    <text x="558" y="400" font-family="Consolas, monospace" font-size="18" font-weight="700" fill="#BEE3F8">search-index | 2026-04-01 GA</text>
+    <text x="558" y="425" font-family="Consolas, monospace" font-size="18" font-weight="700" fill="#BEE3F8">mcp-only    | 2026-05-01-preview</text>
+    <text x="532" y="474" font-family="Segoe UI, Arial, sans-serif" font-size="17" fill="#E6EEF7">doctor -&gt; plan -&gt; up -&gt; verify -&gt; down</text>
     <rect x="532" y="500" width="172" height="34" rx="6" fill="#163D5C"/>
-    <text x="553" y="523" font-family="Segoe UI, Arial, sans-serif" font-size="14" font-weight="700" fill="#D9F0FF">ARM PREVIEW FIRST</text>
+    <text x="553" y="523" font-family="Segoe UI, Arial, sans-serif" font-size="14" font-weight="700" fill="#D9F0FF">REUSE OR DEPLOY</text>
     <rect x="718" y="500" width="184" height="34" rx="6" fill="#163D5C"/>
     <text x="739" y="523" font-family="Segoe UI, Arial, sans-serif" font-size="14" font-weight="700" fill="#D9F0FF">EXPLICIT CONFIRM</text>
     <rect x="916" y="500" width="152" height="34" rx="6" fill="#175C3B"/>
@@ -64,20 +65,20 @@
   </g>
 
   <rect x="58" y="604" width="1486" height="104" rx="8" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
-  <text x="84" y="640" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#475569">A LIVE PASS REQUIRES ALL THREE</text>
+  <text x="84" y="640" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#475569">A LIVE PASS REQUIRES ALL FOUR</text>
 
   <circle cx="102" cy="672" r="14" fill="#17805C"/>
   <path d="M95 672 L100 677 L110 666" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="128" y="679" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#111827">live status</text>
+  <text x="128" y="679" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#111827">readiness contract</text>
 
   <circle cx="418" cy="672" r="14" fill="#17805C"/>
   <path d="M411 672 L416 677 L426 666" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="444" y="679" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#111827">mcpServer activity or reference</text>
+  <text x="444" y="679" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#111827">source activity or reference</text>
 
   <circle cx="918" cy="672" r="14" fill="#17805C"/>
   <path d="M911 672 L916 677 L926 666" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="944" y="679" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#111827">microsoft_docs_search identity</text>
+  <text x="944" y="679" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#111827">content assertion</text>
 
   <rect x="1294" y="648" width="222" height="46" rx="6" fill="#E7F7F0" stroke="#79B8A4"/>
-  <text x="1336" y="677" font-family="Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#116B4A">THEN CLEAN UP</text>
+  <text x="1336" y="677" font-family="Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#116B4A">SAFE CLEANUP</text>
 </svg>

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -4,7 +4,7 @@ environment_pattern: '^[A-Za-z][A-Za-z0-9-]{2,62}$'
 fields:
   deployment.mode:
     type: enum
-    values: [offline, mcp-only, byo-fabric, full]
+    values: [offline, search-index, mcp-only, byo-fabric, full]
     azd: DEPLOYMENT_MODE
   azure.location:
     type: string
@@ -46,8 +46,11 @@ fields:
     azd: AZURE_APP_SERVICE_SKU
   search.api_version:
     type: enum
-    values: [2026-05-01-preview]
+    values: ['2026-04-01', 2026-05-01-preview]
     azd: AZURE_SEARCH_API_VERSION
+  search.endpoint:
+    type: azure_search_url
+    optional: true
   search.sku:
     type: enum
     values: [basic, standard]
@@ -55,6 +58,21 @@ fields:
   search.index_name:
     type: string
     azd: AIRLINE_OPS_INDEX_NAME
+  search.semantic_configuration_name:
+    type: string
+    optional: true
+  search.search_fields:
+    type: string_list
+    optional: true
+  search.source_data_fields:
+    type: string_list
+    optional: true
+  search.index_knowledge_source_name:
+    type: string
+    optional: true
+  search.index_knowledge_base_name:
+    type: string
+    optional: true
   search.mcp_knowledge_source_name:
     type: string
     azd: MCP_KNOWLEDGE_SOURCE_NAME
@@ -154,8 +172,14 @@ legacy_env:
   AZURE_APP_SERVICE_SKU: azure.app_service_sku
   AZURE_SEARCH_API_VERSION: search.api_version
   SEARCH_API_VERSION: search.api_version
+  AZURE_SEARCH_ENDPOINT: search.endpoint
+  SEARCH_ENDPOINT: search.endpoint
   AZURE_SEARCH_SKU: search.sku
+  SEARCH_INDEX_NAME: search.index_name
   AIRLINE_OPS_INDEX_NAME: search.index_name
+  SEARCH_SEMANTIC_CONFIGURATION_NAME: search.semantic_configuration_name
+  SEARCH_INDEX_KNOWLEDGE_SOURCE_NAME: search.index_knowledge_source_name
+  SEARCH_INDEX_KNOWLEDGE_BASE_NAME: search.index_knowledge_base_name
   MCP_KNOWLEDGE_SOURCE_NAME: search.mcp_knowledge_source_name
   FABRIC_ONTOLOGY_KNOWLEDGE_SOURCE_NAME: search.fabric_knowledge_source_name
   MCP_ONLY_KNOWLEDGE_BASE_NAME: search.mcp_knowledge_base_name

--- a/docs/02-choose-a-pattern.md
+++ b/docs/02-choose-a-pattern.md
@@ -7,19 +7,27 @@ Start with offline replay, then choose the smallest live profile that proves the
 | Profile | Use when | Main risk or prerequisite | Success signal |
 | --- | --- | --- | --- |
 | `offline` | You need to inspect the response contract immediately. | It proves shape, not live retrieval. | Answer plus MCP and Fabric trace evidence. |
-| `mcp-only` | You want the lowest-friction live path. | Azure AI Search preview and model availability. | `microsoft_docs_search` appears in activity or references. |
+| `search-index` | An agentic-ready Search index already exists and you want the lowest-risk live path. | Search data-plane permissions and a semantic configuration. | Stable retrieve returns extracted text and `searchIndex` evidence; cleanup preserves the index. |
+| `mcp-only` | You want the first preview live path without Fabric. | Azure AI Search preview and model availability. | `microsoft_docs_search` appears in activity or references. |
 | `byo-fabric` | Existing governed Fabric semantics should ground retrieval. | Workspace/ontology IDs and delegated user authorization. | Separate checks prove both KS paths; the combined KB shows planner-selected routing. |
 | `full` | A greenfield platform demo must create everything. | Billable Fabric F2 quota, longer duration, tenant settings, cleanup. | Fabric GraphModel, both KS paths, app, and teardown pass. |
 
 ## Decision
 
-Use `mcp-only` unless the answer to one of these is yes:
+Use `search-index` when an agentic-ready index already exists. Otherwise use `mcp-only` unless the answer to one of these is yes:
 
 - Existing Fabric workspace and ontology IDs are ready: use `byo-fabric`.
 - The audience must see Fabric sample creation from zero and quota is confirmed: use `full`.
 - No cloud mutation should occur: remain on `offline`.
 
 ## Command Shapes
+
+```bash
+./liveks init --profile search-index --env liveks-index
+# Add the existing endpoint, index, semantic configuration, and optional field lists.
+./liveks plan --env liveks-index
+./liveks up --env liveks-index
+```
 
 ```bash
 ./liveks init --profile mcp-only --env liveks-mcp
@@ -44,6 +52,7 @@ Use `mcp-only` unless the answer to one of these is yes:
 
 | Knowledge Source pattern | Sample entry point |
 | --- | --- |
+| Search Index KS | [Stable Search Index Knowledge Source](23-search-index-ks.md) |
 | MCP Server KS | `samples/rest/01-create-mcp-server-ks.http` |
 | Fabric Ontology KS | `samples/rest/04-create-fabric-ontology-ks.http` |
 | Combined Knowledge Base | `samples/rest/05-create-combined-kb.http` |

--- a/docs/14-api-compatibility.md
+++ b/docs/14-api-compatibility.md
@@ -1,28 +1,28 @@
 # API Compatibility
 
-The live profiles in this accelerator are intentionally pinned to Azure AI Search `2026-05-01-preview`. They use two preview-only Knowledge Source kinds and the full retrieval behavior. Changing only `search.api_version` does not convert those payloads into a stable API workload.
+LiveKS has two deliberately separate API lanes. `search-index` uses generally available Azure AI Search `2026-04-01` with an existing index and minimal extractive retrieval. `mcp-only`, `byo-fabric`, and `full` remain pinned to `2026-05-01-preview` because they use preview-only source kinds and full retrieval behavior.
 
-LiveKS therefore rejects any other API version during configuration resolution, before `plan` or provisioning. A future stable lane needs a separate profile and payload contract; it must not silently weaken the current source evidence.
+Changing only `search.api_version` never converts one lane into the other. Configuration resolution rejects a profile/version mismatch before `plan` or any data-plane write.
 
 ## Stable And Preview Matrix
 
 | Contract | `2026-04-01` stable | `2026-05-01-preview` | This accelerator |
 | --- | --- | --- | --- |
-| Release status | Generally available data-plane API. | Preview API; behavior and schema can change. | Pinned preview lane only. |
-| Knowledge Source kinds | Search index, Azure Blob, indexed OneLake, and Web. | Stable kinds plus preview kinds, including MCP Server and Fabric Ontology. | MCP Server and Fabric Ontology are first-class; the uploaded sample index is not yet wrapped as a Knowledge Source. |
-| Retrieve input | `intents`. | `intents` and `messages`. | Uses the preview `messages` contract. |
-| Retrieval behavior | Minimal, extractive retrieval. | Query planning, answer synthesis, and configurable reasoning effort. | Uses answer synthesis and `low` reasoning effort. |
+| Release status | Generally available data-plane API. | Preview API; behavior and schema can change. | Separate stable and preview profiles. |
+| Knowledge Source kinds | Search index, Azure Blob, indexed OneLake, and Web. | Stable kinds plus preview kinds, including MCP Server and Fabric Ontology. | `search-index` wraps a BYO index; other live profiles use MCP Server and optional Fabric Ontology. |
+| Retrieve input | `intents`. | `intents` and `messages`. | `search-index` uses `intents`; preview profiles use `messages`. |
+| Retrieval behavior | Minimal, extractive retrieval. | Query planning, answer synthesis, and configurable reasoning effort. | Stable lane is extractive; preview lane uses answer synthesis and `low` reasoning effort. |
 | MCP Server KS | Not accepted. | Supported in preview. | Required by `mcp-only`, `byo-fabric`, and `full`. |
 | Fabric Ontology KS | Not accepted. | Supported in preview. | Required by `byo-fabric` and `full`; intentionally absent from `mcp-only`. |
-| Search authentication | API key or Microsoft Entra bearer token. | API key or Microsoft Entra bearer token. | Sample default reads an admin key transiently; bearer with **Search Index Data Reader** is the managed-client path. |
+| Search authentication | API key or Microsoft Entra bearer token. | API key or Microsoft Entra bearer token. | `search-index` uses a transient bearer token; preview sample deployments read their generated admin key transiently. |
 | Source authorization | Depends on the selected generally available source. | Fabric calls additionally require delegated `x-ms-query-source-authorization`. | Fabric verification acquires and passes the raw delegated Search token transiently. |
-| Supported LiveKS profiles | None. | `mcp-only`, `byo-fabric`, and `full`. | Stable plus MCP/Fabric fails closed during YAML validation. |
+| Supported LiveKS profiles | `search-index`. | `mcp-only`, `byo-fabric`, and `full`. | Every profile/version pairing fails closed during YAML validation. |
 
 ## What The Pin Protects
 
-The repository's builders create `mcpServer` and `fabricOntology` payloads. Its Knowledge Bases request `answerSynthesis`, use configurable reasoning effort, and its retrieve requests expect the preview evidence envelope. Substituting `2026-04-01` would mix incompatible source kinds and retrieval behavior.
+The preview builders create `mcpServer` and `fabricOntology` payloads. Their Knowledge Bases request `answerSynthesis`, use configurable reasoning effort, and send `messages`. Substituting `2026-04-01` would mix incompatible source kinds and retrieval behavior.
 
-This fail-closed rule is narrower than claiming the stable API is unsupported by Azure AI Search. The stable API is valid for its generally available source kinds and minimal, extractive behavior; this repository simply does not implement that separate lane yet.
+The stable builder creates `searchIndex`, requires a semantic configuration, omits models and preview-only Knowledge Base properties, and sends `intents`. It also treats the Search service and index as reused assets. Substituting the preview API would silently change the lane's availability and evidence contract, so LiveKS rejects it.
 
 ## Upgrade Checklist
 
@@ -30,7 +30,7 @@ Before changing the pinned version:
 
 1. Compare the migration guide and REST schemas for every Knowledge Source and Knowledge Base payload.
 2. Confirm MCP Server and Fabric Ontology remain available in the target version.
-3. Re-run local builder tests, all three live profile rehearsals, source-specific retrieve checks, native MCP checks, and cleanup checks.
+3. Re-run local builder tests, the stable and preview live profile rehearsals, source-specific retrieve checks, native MCP checks where applicable, and cleanup checks.
 4. Update the profile defaults, schema enum, REST samples, notebooks, app API, badges, and this matrix in one change.
 5. Keep public PR validation offline; run cloud drift checks only in an approved protected environment.
 
@@ -41,3 +41,4 @@ Before changing the pinned version:
 - [Upgrade Azure AI Search REST API versions](https://learn.microsoft.com/azure/search/search-api-migration)
 - [Azure AI Search What's New](https://learn.microsoft.com/azure/search/whats-new)
 - [Knowledge Source overview](https://learn.microsoft.com/azure/search/agentic-knowledge-source-overview)
+- [Create a Search Index Knowledge Source](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-search-index)

--- a/docs/20-liveks-cli.md
+++ b/docs/20-liveks-cli.md
@@ -29,16 +29,32 @@ PowerShell equivalents replace `./liveks` with `./liveks.ps1`.
 | `try` | None | Print a checked-in answer and evidence trace. |
 | `init` | None | Write an ignored YAML environment ledger. |
 | `doctor` | None | Check tools, versions, sign-in, providers, and required fields. |
-| `plan` | None | Run doctor, build Bicep, dry-run payloads, build the app, and write a redacted lock. |
-| `up` | Yes, after confirmation | Sync the selected `azd` environment, preview ARM changes, provision, deploy, and verify. |
-| `verify` | Read/call only | Check the resource group, app API, and source evidence. |
+| `plan` | None | Validate the selected profile's payload and ownership contract; preview profiles also build Bicep and the app. |
+| `up` | Yes, after confirmation | Create only the selected profile's owned objects, then verify. |
+| `verify` | Read/call only | Check deployed or reused objects and source evidence. |
 | `mcp` | Read/call only | Discover and call `knowledge_base_retrieve` on the deployed Knowledge Base MCP endpoint. |
 | `down` | Yes, after confirmation | Delete only assets owned by the environment. |
 | `e2e` | Yes | Run `up` and either clean up or explicitly retain resources. |
 
 `doctor` can issue read-only Azure CLI calls for live profiles. In `byo-fabric`, it also acquires a transient Fabric API token and confirms that the configured workspace and ontology are readable. The token is not serialized. `plan` writes local build and lock artifacts under ignored directories, but it does not run `azd env set`, `azd up`, or Fabric provisioning.
 
+For `search-index`, `doctor` reads the existing index definition with an Azure AI Search bearer token. `plan` checks stable payloads and generated-name collisions without Bicep, `azd`, npm, `PUT`, or `DELETE`.
+
 ## Standard Run
+
+Existing Search index, generally available lane:
+
+```bash
+./liveks init --profile search-index --env liveks-index
+# Fill the existing Search values in .liveks/liveks-index.yaml.
+./liveks doctor --env liveks-index
+./liveks plan --env liveks-index
+./liveks up --env liveks-index --query "<question>" --expect-term "<known term>"
+./liveks verify --env liveks-index --query "<question>" --expect-term "<known term>"
+./liveks down --env liveks-index
+```
+
+Preview MCP Server lane:
 
 ```bash
 ./liveks init --profile mcp-only --env liveks-mcp
@@ -58,7 +74,7 @@ Use JSON output when cleanup evidence will be reviewed:
 ./liveks down --env liveks-full --yes --format json
 ```
 
-Every live profile must report `resource-group-absent=pass`. A `full` run that created capacity must additionally report `fabric-capacity-absent=pass`. It must also report `fabric-capacity-resource-group-absent=pass` when the same run created that dedicated group, or `fabric-capacity-resource-group-preserved=pass` when the group predated the run. A missing summary or unresolved ownership produces partial cleanup instead of a deletion claim.
+Every preview deployment profile must report `resource-group-absent=pass`. The data-plane-only `search-index` profile instead requires `search-index-preserved=pass`. A `full` run that created capacity must additionally report `fabric-capacity-absent=pass`. It must also report `fabric-capacity-resource-group-absent=pass` when the same run created that dedicated group, or `fabric-capacity-resource-group-preserved=pass` when the group predated the run. A missing summary or unresolved ownership produces partial cleanup instead of a deletion claim.
 
 For `byo-fabric` and `full`, `mcp` attaches delegated source authorization by default. It records text-block and expected-term counts but never persists the endpoint, query, response content, key, or token. A call without `--expect-term` can pass protocol checks but reports `grounding-content=warn`; use a known non-sensitive fact for source-content acceptance. See [Call the Knowledge Base Through MCP](22-knowledge-base-mcp.md).
 

--- a/docs/21-configuration.md
+++ b/docs/21-configuration.md
@@ -5,12 +5,32 @@ LiveKS v2 uses one ignored YAML file as the human-managed deployment ledger. Pro
 ## Create A Ledger
 
 ```bash
+./liveks init --profile search-index --env liveks-index
 ./liveks init --profile mcp-only --env liveks-mcp
 ./liveks init --profile byo-fabric --env liveks-byo
 ./liveks init --profile full --env liveks-full
 ```
 
 The default location is `.liveks/<environment>.yaml`. The directory is ignored by git and files are written with owner-only permissions where the operating system supports them.
+
+## Search Index Example
+
+```yaml
+version: 2
+profile: search-index
+environment: liveks-index
+search:
+  endpoint: https://<search-service>.search.windows.net
+  index_name: <existing-index-name>
+  semantic_configuration_name: <semantic-configuration-name>
+  search_fields:
+    - content
+  source_data_fields:
+    - id
+    - title
+```
+
+This stable lane uses Microsoft Entra bearer authentication from Azure CLI. It reuses the Search service and index, derives unique KS and KB names from the environment, and never stores an API key. Field lists are optional, but any supplied values must exist and satisfy the required searchable or retrievable capability.
 
 ## MCP-only Example
 
@@ -89,7 +109,7 @@ The complete machine-readable contract is [`config/schema.yaml`](https://github.
 | --- | --- |
 | `deployment` | `mode` |
 | `azure` | location, subscription, tenant, resource group, hosting mode |
-| `search` | API version, SKU, index, KS, and KB names |
+| `search` | API version, endpoint, SKU, index and semantic configuration, optional field lists, KS, and KB names |
 | `mcp` | HTTPS server URL and allowed tool name |
 | `openai` | deployment, model name/version, capacity |
 | `fabric` | create/BYO mode, location, capacity, workspace, ontology, secret reference |
@@ -105,13 +125,13 @@ Lowest to highest precedence:
 2. Optional legacy dotenv values supplied with `--env-file`.
 3. Authored YAML values.
 4. Hidden v1 compatibility flags such as `--location`.
-5. Derived resource group, name salt, and generated Fabric names when absent.
+5. Derived resource group, name salt, Search Index KS/KB names, and generated Fabric names when absent.
 
 The final redacted result and the source of each value are written to `.liveks/<environment>.lock.json` by `plan` and later lifecycle commands.
 
-`azd env` is a deployment projection, not the authored source of truth. `up` selects or creates the named `azd` environment and writes resolved non-secret values immediately before preview and provisioning.
+`azd env` is a deployment projection, not the authored source of truth. Preview deployment profiles select or create the named `azd` environment and write resolved non-secret values immediately before preview and provisioning. The stable `search-index` profile is data-plane-only and does not create or read an `azd` environment.
 
-`search.api_version` is a fail-closed enum pinned to `2026-05-01-preview`. The current source kinds and full retrieval behavior are not compatible with the `2026-04-01` stable contract. See [API Compatibility](14-api-compatibility.md).
+`search.api_version` fails closed by profile: `search-index` requires generally available `2026-04-01`, while `mcp-only`, `byo-fabric`, and `full` require `2026-05-01-preview`. Source kinds and retrieve shapes cannot be mixed across those contracts. See [API Compatibility](14-api-compatibility.md).
 
 ## Legacy Dotenv Migration
 
@@ -141,6 +161,8 @@ Authentication is acquired at call time:
 The generated MCP report contains counts and normalized statuses only. It does not contain the endpoint, query, expected terms, response content, key, or token.
 
 `--query` and repeatable `--expect-term` values are runtime acceptance inputs, not deployment configuration. Supply a known non-sensitive fact when validating Fabric-backed MCP content. Without an expected term, the command validates protocol execution and reports grounding as unverified.
+
+The same runtime inputs are accepted by `liveks verify` for `search-index`. Its report records only match counts and normalized status, not the query, terms, or extracted content.
 
 ## Safe Review
 

--- a/docs/23-search-index-ks.md
+++ b/docs/23-search-index-ks.md
@@ -1,0 +1,193 @@
+# Stable Search Index Knowledge Source
+
+Use this profile when an Azure AI Search service already contains an index that is ready for agentic retrieval. LiveKS reuses that service and index, creates only a Search Index Knowledge Source and a minimal extractive Knowledge Base, proves a real retrieve call, and then deletes only those two generated objects.
+
+This lane uses the generally available `2026-04-01` REST contract. It does not deploy the demo app, Azure OpenAI, MCP Server KS, Fabric Ontology KS, or any Azure resource group.
+
+## 1. Check The Existing Index
+
+The index must:
+
+- be on the Search service where the Knowledge Source and Knowledge Base will be created,
+- contain searchable text or vector content,
+- have a semantic configuration,
+- expose every configured `search_fields` field as searchable,
+- expose every configured `source_data_fields` field as retrievable.
+
+The signed-in identity needs **Search Service Contributor** to inspect and create the Knowledge Source and Knowledge Base, plus **Search Index Data Reader** to run retrieve. LiveKS follows Microsoft's keyless path, acquires a short-lived Azure AI Search bearer token from Azure CLI, and never asks for, prints, or persists an admin key or bearer token.
+
+Agentic retrieval is usage-billed. Search services start on the free plan with a monthly allowance; after that allowance is consumed, requests that require paid usage can return a payment-required error. An Owner or Contributor can deliberately select the Standard knowledge retrieval plan under **Settings > Premium features**. LiveKS reports the failure but never changes this management-plane billing setting.
+
+## 2. Create The Ledger
+
+```bash
+./liveks bootstrap
+./liveks init --profile search-index --env liveks-index
+```
+
+Edit the ignored `.liveks/liveks-index.yaml`:
+
+```yaml
+version: 2
+profile: search-index
+environment: liveks-index
+search:
+  endpoint: https://<search-service>.search.windows.net
+  index_name: <existing-index-name>
+  semantic_configuration_name: <semantic-configuration-name>
+  search_fields:
+    - content
+  source_data_fields:
+    - id
+    - title
+```
+
+`search_fields` and `source_data_fields` can be empty when the Knowledge Source should use the index defaults. Unknown fields, duplicate list values, an HTTP endpoint, a preview API override, or a missing required value fails before any write.
+
+The generated object names are derived from the environment:
+
+```text
+liveks-index-search-index-ks
+liveks-index-search-index-kb
+```
+
+Override `search.index_knowledge_source_name` or `search.index_knowledge_base_name` only when a deliberate naming convention requires it. LiveKS refuses to overwrite an object with the same name unless the matching environment lock already proves ownership.
+
+## 3. Sign In And Inspect
+
+```bash
+az login --tenant <tenant-guid>
+./liveks doctor --env liveks-index
+```
+
+Expected checks include:
+
+```text
+[PASS] azure-login: Azure CLI account is active
+[PASS] search-auth: A transient Azure AI Search bearer token was acquired.
+[PASS] search-index: The existing Search index is readable.
+[PASS] semantic-configuration: Configured semantic configuration exists.
+[PASS] search-fields: Configured search fields exist and are searchable.
+[PASS] source-data-fields: Configured source-data fields exist and are retrievable.
+```
+
+Representative failures are explicit:
+
+```text
+[FAIL] semantic-configuration: Configured semantic configuration was not found on the index.
+[FAIL] search-fields: One or more configured search fields are missing or not searchable.
+```
+
+No endpoint, token, raw index definition, or document content is included in these messages.
+
+An HTTP `402` during retrieve means the free agentic retrieval allowance is unavailable or exhausted and the service hasn't opted into Standard knowledge retrieval billing. Review the billing plan with the service owner; do not treat it as a payload or index failure.
+
+## 4. Plan Without Mutation
+
+```bash
+./liveks plan --env liveks-index
+```
+
+The plan:
+
+1. reruns the read-only index checks,
+2. serializes the stable `searchIndex` Knowledge Source payload,
+3. serializes a Knowledge Base without models, answer synthesis, or configurable reasoning,
+4. serializes the stable `intents` retrieve request,
+5. checks generated names for unowned collisions,
+6. writes ignored plan and ownership artifacts.
+
+It does not run Bicep, `azd`, app builds, `PUT`, or `DELETE`.
+
+## 5. Create And Verify
+
+```bash
+./liveks up \
+  --env liveks-index \
+  --query "<question answerable from the existing index>" \
+  --expect-term "<known non-sensitive term>"
+```
+
+Review the two generated objects and the reuse ownership statement, then type:
+
+```text
+create liveks-index
+```
+
+`up` creates the Knowledge Source first, records ownership immediately, creates the Knowledge Base, and runs a stable extractive retrieve with the supplied content assertion. A partial failure leaves the successfully created object in the ignored lock so `down` can remove it safely.
+
+Repeat verification with a non-sensitive query and known fact from the index:
+
+```bash
+./liveks verify \
+  --env liveks-index \
+  --query "<question answerable from the existing index>" \
+  --expect-term "<known non-sensitive term>" \
+  --format json
+```
+
+Acceptance requires:
+
+- the existing index, generated Knowledge Source, and generated Knowledge Base are readable,
+- the Knowledge Source still names the configured index and semantic configuration,
+- the Knowledge Base references the generated source and contains no preview-only properties,
+- retrieve returns extracted text plus `searchIndex` activity or references,
+- every supplied expected term is found.
+
+The ignored verify report stores only normalized messages and expected-term counts. It does not store the query, expected terms, extracted content, endpoint, or bearer token.
+
+## 6. Reproduce A Controlled Failure
+
+Use an expected term that is known to be absent:
+
+```bash
+./liveks verify \
+  --env liveks-index \
+  --query "<same non-sensitive question>" \
+  --expect-term "term-that-is-not-present"
+```
+
+Expected result:
+
+```text
+[FAIL] grounding-content: Extracted content matched 0/1 expected term(s).
+```
+
+This proves that a transport success cannot be mistaken for content acceptance.
+
+## 7. Clean Up Without Deleting The Index
+
+```bash
+./liveks down --env liveks-index
+```
+
+Type `delete liveks-index`. Cleanup deletes the recorded Knowledge Base first and the recorded Knowledge Source second. It never sends a delete request for the Search service or index, and it finishes by requiring:
+
+```text
+[PASS] search-index-preserved: The existing Search index remains readable after cleanup.
+```
+
+If the lock is missing, mismatched, or invalid, cleanup returns `cleanup-incomplete` and preserves all named objects for manual review.
+
+## Stable Boundary
+
+The stable lane intentionally uses:
+
+- `2026-04-01`,
+- `kind: searchIndex`,
+- `intents` input,
+- minimal extractive retrieval,
+- Microsoft Entra bearer authentication,
+- BYO ownership for the Search service and index.
+
+Use `mcp-only`, `byo-fabric`, or `full` when you need preview `messages`, query planning, answer synthesis, MCP Server KS, or Fabric Ontology KS. Those profiles remain pinned to `2026-05-01-preview` and use a separate deployment contract.
+
+## Microsoft Sources Of Truth
+
+- [Create a Search Index Knowledge Source](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-search-index)
+- [Create a Knowledge Base](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-create-knowledge-base)
+- [Query a Knowledge Base](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-retrieve)
+- [Create an index for agentic retrieval](https://learn.microsoft.com/azure/search/search-agentic-retrieval-how-to-index)
+- [Use role-based access in Azure AI Search](https://learn.microsoft.com/azure/search/search-security-rbac)
+- [Enable or disable agentic retrieval billing](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-enable-disable)
+- [Migrate agentic retrieval code to the latest version](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-migrate)

--- a/docs/assets/clone-to-grounded-proof.svg
+++ b/docs/assets/clone-to-grounded-proof.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="760" viewBox="0 0 1600 760" role="img" aria-labelledby="title desc">
-  <title id="title">From clone to the first live Foundry IQ proof</title>
-  <desc id="desc">Three stages: inspect a 30-second offline replay, run the MCP-only profile as the first actual Azure deployment, then expand to an existing or greenfield Fabric ontology.</desc>
+  <title id="title">From clone to a live Foundry IQ proof</title>
+  <desc id="desc">Three stages: inspect a 30-second offline replay, choose a stable Search Index or preview MCP Server live path, then expand to an existing or greenfield Fabric ontology.</desc>
 
   <rect width="1600" height="760" fill="#F7F9FC"/>
   <rect x="0" y="0" width="14" height="760" fill="#0F6CBD"/>
 
   <text x="58" y="58" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#0F6CBD">FROM CLONE TO FIRST LIVE PROOF</text>
   <text x="58" y="112" font-family="Segoe UI, Arial, sans-serif" font-size="44" font-weight="700" fill="#111827">See the contract. Prove one live source. Expand when ready.</text>
-  <text x="60" y="154" font-family="Segoe UI, Arial, sans-serif" font-size="21" fill="#475569">The shortest supported path preserves doctor, plan, ARM preview, explicit confirmation, source evidence, and cleanup.</text>
+  <text x="60" y="154" font-family="Segoe UI, Arial, sans-serif" font-size="21" fill="#475569">The guarded lifecycle preserves doctor, plan, explicit confirmation, source evidence, and ownership-safe cleanup.</text>
 
   <rect x="1310" y="40" width="234" height="42" rx="8" fill="#E8F3FC" stroke="#8DC8E8" stroke-width="2"/>
   <text x="1340" y="67" font-family="Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#0F548C">CODESPACES READY</text>
@@ -31,15 +31,16 @@
     <rect x="500" y="192" width="600" height="370" rx="8" fill="#102A43" stroke="#0F6CBD" stroke-width="3"/>
     <rect x="500" y="192" width="600" height="10" fill="#2E90FA"/>
     <rect x="848" y="222" width="220" height="38" rx="6" fill="#DFF6E9" stroke="#68C78A"/>
-    <text x="888" y="247" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#116B3A">FIRST ACTUAL LIVE</text>
-    <text x="532" y="250" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#90CDF4">2 | AZURE IMPLEMENTER</text>
-    <text x="532" y="304" font-family="Segoe UI, Arial, sans-serif" font-size="36" font-weight="700" fill="#FFFFFF">MCP-only</text>
-    <text x="532" y="341" font-family="Segoe UI, Arial, sans-serif" font-size="19" fill="#D7E3F0">No Fabric workspace or ontology required.</text>
+    <text x="864" y="247" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#116B3A">CHOOSE FIRST LIVE LANE</text>
+    <text x="532" y="250" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#90CDF4">2 | SEARCH OR AZURE IMPLEMENTER</text>
+    <text x="532" y="304" font-family="Segoe UI, Arial, sans-serif" font-size="36" font-weight="700" fill="#FFFFFF">Prove one source</text>
+    <text x="532" y="341" font-family="Segoe UI, Arial, sans-serif" font-size="19" fill="#D7E3F0">Reuse an index or deploy the preview MCP path.</text>
     <rect x="532" y="374" width="536" height="64" rx="6" fill="#0B1F33" stroke="#486581"/>
-    <text x="558" y="414" font-family="Consolas, monospace" font-size="21" font-weight="700" fill="#BEE3F8">doctor -&gt; plan -&gt; up -&gt; verify</text>
-    <text x="532" y="474" font-family="Segoe UI, Arial, sans-serif" font-size="17" fill="#E6EEF7">Azure AI Search calls the public Microsoft Learn MCP tool.</text>
+    <text x="558" y="400" font-family="Consolas, monospace" font-size="18" font-weight="700" fill="#BEE3F8">search-index | 2026-04-01 GA</text>
+    <text x="558" y="425" font-family="Consolas, monospace" font-size="18" font-weight="700" fill="#BEE3F8">mcp-only    | 2026-05-01-preview</text>
+    <text x="532" y="474" font-family="Segoe UI, Arial, sans-serif" font-size="17" fill="#E6EEF7">doctor -&gt; plan -&gt; up -&gt; verify -&gt; down</text>
     <rect x="532" y="500" width="172" height="34" rx="6" fill="#163D5C"/>
-    <text x="553" y="523" font-family="Segoe UI, Arial, sans-serif" font-size="14" font-weight="700" fill="#D9F0FF">ARM PREVIEW FIRST</text>
+    <text x="553" y="523" font-family="Segoe UI, Arial, sans-serif" font-size="14" font-weight="700" fill="#D9F0FF">REUSE OR DEPLOY</text>
     <rect x="718" y="500" width="184" height="34" rx="6" fill="#163D5C"/>
     <text x="739" y="523" font-family="Segoe UI, Arial, sans-serif" font-size="14" font-weight="700" fill="#D9F0FF">EXPLICIT CONFIRM</text>
     <rect x="916" y="500" width="152" height="34" rx="6" fill="#175C3B"/>
@@ -64,20 +65,20 @@
   </g>
 
   <rect x="58" y="604" width="1486" height="104" rx="8" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="2"/>
-  <text x="84" y="640" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#475569">A LIVE PASS REQUIRES ALL THREE</text>
+  <text x="84" y="640" font-family="Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#475569">A LIVE PASS REQUIRES ALL FOUR</text>
 
   <circle cx="102" cy="672" r="14" fill="#17805C"/>
   <path d="M95 672 L100 677 L110 666" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="128" y="679" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#111827">live status</text>
+  <text x="128" y="679" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#111827">readiness contract</text>
 
   <circle cx="418" cy="672" r="14" fill="#17805C"/>
   <path d="M411 672 L416 677 L426 666" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="444" y="679" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#111827">mcpServer activity or reference</text>
+  <text x="444" y="679" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#111827">source activity or reference</text>
 
   <circle cx="918" cy="672" r="14" fill="#17805C"/>
   <path d="M911 672 L916 677 L926 666" fill="none" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-  <text x="944" y="679" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#111827">microsoft_docs_search identity</text>
+  <text x="944" y="679" font-family="Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#111827">content assertion</text>
 
   <rect x="1294" y="648" width="222" height="46" rx="6" fill="#E7F7F0" stroke="#79B8A4"/>
-  <text x="1336" y="677" font-family="Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#116B4A">THEN CLEAN UP</text>
+  <text x="1336" y="677" font-family="Segoe UI, Arial, sans-serif" font-size="16" font-weight="700" fill="#116B4A">SAFE CLEANUP</text>
 </svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
 # Foundry IQ Live Knowledge Sources
 
-Deploy and prove one live Azure AI Search MCP Server Knowledge Source, then extend the same guarded lifecycle to a governed Fabric Ontology.
+Wrap and prove an existing Azure AI Search index with the stable API, then extend the same guarded lifecycle to preview MCP Server and governed Fabric Ontology sources.
 
-[Start the first live path](15-codespaces-first-live.md){ .md-button .md-button--primary }
+[Start the stable live path](23-search-index-ks.md){ .md-button .md-button--primary }
 [Inspect the no-cloud replay](09-offline-replay.md){ .md-button }
 
 <figure class="manual-hero">
   <img
     src="assets/clone-to-grounded-proof.svg"
-    alt="Three stages from clone to proof: a 30-second offline replay, the MCP-only first live Azure path, and advanced Fabric expansion."
+    alt="Three stages from clone to proof: a 30-second offline replay, a choice between stable Search Index and preview MCP live paths, and advanced Fabric expansion."
     width="1600"
     height="760"
     loading="eager"
@@ -21,7 +21,8 @@ Deploy and prove one live Azure AI Search MCP Server Knowledge Source, then exte
 | Role | Finish line | Start here |
 | --- | --- | --- |
 | **Evaluator** | Inspect the packaged answer and trace contract with no cloud access. | `./liveks try` |
-| **Azure implementer** | Prove Microsoft Learn MCP runs live through Foundry IQ. | [Codespaces First Live](15-codespaces-first-live.md) |
+| **Search implementer** | Prove an existing agentic-ready index through the GA data plane. | [Stable Search Index KS](23-search-index-ks.md) |
+| **Azure implementer** | Prove Microsoft Learn MCP runs live through the preview Foundry IQ path. | [Codespaces First Live](15-codespaces-first-live.md) |
 | **Fabric implementer** | Add governed entities and relationships after the Azure path works. | [Fabric Live BYO Validation](11-fabric-live-byo-validation.md) |
 
 The accelerator is not a production reference architecture. It keeps the human path narrow while [AGENTS.md](https://github.com/microsoft/azure-ai-search-foundry-iq-live-knowledge-sources/blob/main/AGENTS.md) defines the separate execution contract for coding agents.
@@ -39,7 +40,23 @@ Require `Contract: PASS (4/4 assertions)`. Python 3.11 or newer is the only depe
 
 The ignored evidence capsule retains revision, fixture digest, source identities, counts, and assertion status. It excludes query, answer, raw response, endpoints, and credentials. Pull-request validation executes the same entry point.
 
-## First Actual Live: MCP-Only
+## Lowest-Risk Live: Existing Search Index
+
+```bash
+./liveks init --profile search-index --env liveks-index
+# Fill the existing endpoint, index, semantic configuration, and optional fields.
+az login --use-device-code --tenant <tenant-guid>
+./liveks doctor --env liveks-index
+./liveks plan --env liveks-index
+./liveks up --env liveks-index
+./liveks verify --env liveks-index --query "<question>" --expect-term "<known term>"
+```
+
+This generally available `2026-04-01` lane creates only a Search Index KS and minimal extractive Knowledge Base. The Search service and index remain reused assets, and cleanup must finish with `search-index-preserved=pass`.
+
+[Follow the stable execution contract](23-search-index-ks.md){ .md-button .md-button--primary }
+
+## First Preview Live: MCP-Only
 
 The checked-in Codespaces environment supplies Python 3.11, Node.js 22, Azure CLI, Bicep, and Azure Developer CLI. Container creation runs only safe local checks.
 
@@ -101,6 +118,7 @@ BYO cleanup preserves the existing Fabric assets. Full cleanup deletes only asse
 
 | Component | Role | Acceptance evidence |
 | --- | --- | --- |
+| Search Index KS | Wraps an existing index for stable extractive retrieval. | `searchIndex` evidence, expected content, and preserved-index cleanup proof. |
 | MCP Server KS | Calls an explicitly allowed remote HTTPS MCP tool. | `mcpServer` activity or references and tool identity. |
 | Fabric Ontology KS | Resolves governed business entities and relationships. | `fabricOntology` activity or references plus source data. |
 | Foundry IQ Knowledge Base | Selects sources and returns grounded output. | Answer, `activity`, `references`, and `sourceData`. |
@@ -120,23 +138,24 @@ Fabric Ontology is a native Knowledge Source and is not routed through the exter
 
 The ignored `.liveks/<environment>.yaml` file is the authoring ledger. `azd env` is generated state. Secrets are environment references, never raw YAML values.
 
-All live profiles are pinned to `2026-05-01-preview`. The repository rejects `2026-04-01` because this implementation uses preview-only MCP Server and Fabric Ontology source kinds, message input, query planning, answer synthesis, and configurable reasoning effort.
+`search-index` is pinned to generally available `2026-04-01`, `intents`, and minimal extractive retrieval. `mcp-only`, `byo-fabric`, and `full` are pinned to `2026-05-01-preview` because their source kinds and full retrieval behavior are preview-dependent. Cross-lane API overrides fail closed.
 
 [Compare stable and preview support](14-api-compatibility.md){ .md-button }
 
 ## Finish With Cleanup
 
 ```bash
-./liveks down --env liveks-mcp
+./liveks down --env <environment>
 ```
 
-Require `resource-group-absent=pass`. For `full`, also require the capacity and its generated or preserved resource-group outcome. A deletion request without an absence check is incomplete.
+For `search-index`, require `search-index-preserved=pass`. For preview deployment profiles, require `resource-group-absent=pass`. For `full`, also require the capacity and its generated or preserved resource-group outcome. A deletion request without an absence check is incomplete.
 
 ## Manual Map
 
 | Need | Manual |
 | --- | --- |
 | Shortest complete sequence | [Execution Runbook](runbook.md) |
+| Stable existing-index path | [Stable Search Index KS](23-search-index-ks.md) |
 | Every first-live Codespaces step | [Codespaces First Live](15-codespaces-first-live.md) |
 | MCP payload and source contract | [MCP Server Knowledge Source](03-mcp-server-ks.md) |
 | Fabric source contract | [Fabric Ontology Knowledge Source](04-fabric-ontology-ks.md) |
@@ -151,6 +170,7 @@ Require `resource-group-absent=pass`. For `full`, also require the capacity and 
 
 - [Agentic retrieval overview](https://learn.microsoft.com/azure/search/search-agentic-retrieval-concept)
 - [Knowledge Source overview](https://learn.microsoft.com/azure/search/agentic-knowledge-source-overview)
+- [Create a Search Index knowledge source](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-search-index)
 - [Create an MCP Server knowledge source](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-mcp-server)
 - [Create a Fabric Ontology knowledge source](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-fabric-ontology)
 - [Query a Knowledge Base using retrieve or MCP](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-retrieve)

--- a/docs/maintainers/private-review-workflow.md
+++ b/docs/maintainers/private-review-workflow.md
@@ -158,15 +158,16 @@ Hi team,
 I have a private-review candidate for the Azure AI Search Foundry IQ Live Knowledge Sources sample accelerator.
 
 Scope:
+- One stable existing-index path: Search Index KS
 - Two public preview Knowledge Source paths: MCP Server KS and Fabric Ontology KS
-- Three deployment modes: mcp-only, byo-fabric, full
+- Three preview deployment modes: mcp-only, byo-fabric, full
 - Demo app, notebooks, REST samples, synthetic Airline Ops data, offline replay, and validation workflow
 
 Current evidence:
 - Commit: <commit>
 - Local validation: PASS
 - GitHub Actions Validate: PASS
-- Deployment mode reviewed: <mcp-only | byo-fabric | full>
+- Deployment mode reviewed: <search-index | mcp-only | byo-fabric | full>
 - E2E summary: <PASS / SKIP / not run, with reason>
 
 Reviewer asks:

--- a/docs/maintainers/reviewer-evidence.md
+++ b/docs/maintainers/reviewer-evidence.md
@@ -176,7 +176,7 @@ Use that summary as the source for private review notes. Keep the generated summ
 Review scope:
 - Repo/branch:
 - Commit:
-- Deployment mode reviewed: mcp-only | byo-fabric | full
+- Deployment mode reviewed: search-index | mcp-only | byo-fabric | full
 - Review intent: private review | workshop rehearsal | blog validation | official sample preparation
 
 Validation:
@@ -203,7 +203,7 @@ Known caveats:
 Reviewer asks:
 - Azure AI Search KS terminology and REST shape
 - Fabric Ontology KS setup and delegated source authorization wording
-- Deployment-mode clarity: mcp-only, byo-fabric, full
+- Profile clarity: stable search-index; preview mcp-only, byo-fabric, full
 - Public-preview caveats and safe claims
 - Security posture for generated outputs and tokens
 ```
@@ -216,6 +216,7 @@ Use these proof points to decide whether a run supports a claim.
 
 | Claim | Minimum evidence |
 | --- | --- |
+| Search Index KS works | Stable `2026-04-01` retrieve returns extracted content plus `searchIndex` evidence, and cleanup proves the reused index remains readable. |
 | MCP Server KS works | `microsoft-learn-mcp-ks` exists, MCP-only KB exists, retrieve returns MCP activity or Microsoft Learn references. |
 | Fabric Ontology KS works | Fabric KS and Fabric-only KB exist, live retrieve with delegated source authorization returns Fabric activity or Fabric source data. |
 | Combined routing works | Combined KB includes both source names and retrieve output contains recognized live evidence from the source or sources selected for the query. Separate checks prove MCP and Fabric independently. |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -10,6 +10,7 @@ The canonical input is an ignored `.liveks/<environment>.yaml` ledger. It is not
 
 | Profile | Required authored values | Runtime credential | What it creates |
 | --- | --- | --- | --- |
+| `search-index` | Existing Search endpoint, index name, and semantic configuration; optional field lists. | Azure CLI sign-in with Search data-plane permissions. | Search Index KS and minimal extractive KB; the existing service and index are preserved. |
 | `mcp-only` | None beyond the generated profile and environment. | Azure CLI and Azure Developer CLI sign-in. | Azure resources, MCP Server KS, MCP-only KB, and app. |
 | `byo-fabric` | `fabric.workspace_id` and `fabric.ontology_id`. | Azure sign-in plus a transient delegated Search token during Fabric calls. | Generated Azure resources and a Fabric-only validation KB; the existing Fabric assets are preserved. |
 | `full` | No existing Fabric IDs; optional Fabric location and SKU overrides. | Azure and Fabric access, available quota, and `--accept-fabric-capacity`. | Generated Azure resources and a billable Fabric F2 sample stack. |
@@ -52,44 +53,48 @@ Expected: profile metadata prints, offline doctor passes, and the repository gat
 Choose the smallest live profile that matches the tenant:
 
 ```bash
-./liveks init --profile mcp-only --env liveks-mcp
+./liveks init --profile search-index --env liveks-index
 ```
 
 Other choices:
 
 ```bash
+./liveks init --profile mcp-only --env liveks-mcp
 ./liveks init --profile byo-fabric --env liveks-byo
 ./liveks init --profile full --env liveks-full
 ```
 
-Review `.liveks/<environment>.yaml`. For `byo-fabric`, replace the blank Fabric workspace and ontology IDs. For external tenants, add `azure.tenant_id`, `azure.subscription_id`, and `azure.cli_config_dir`. See [Configuration](21-configuration.md).
+Review `.liveks/<environment>.yaml`. For `search-index`, add the existing Search endpoint, index, semantic configuration, and optional field lists. For `byo-fabric`, replace the blank Fabric workspace and ontology IDs. For external tenants, add `azure.tenant_id`, `azure.subscription_id`, and `azure.cli_config_dir`. See [Configuration](21-configuration.md).
 
 ## 4. Sign In
 
 ```bash
 az login --tenant <tenant-guid>
-azd auth login
 ```
 
-Use the same target tenant and subscription for both tools. `doctor` fails on a configured tenant or subscription mismatch.
+For `mcp-only`, `byo-fabric`, and `full`, also run `azd auth login`. Use the same target tenant and subscription for both tools. `doctor` fails on a configured tenant or subscription mismatch.
 
 ## 5. Doctor
 
 ```bash
-./liveks doctor --env liveks-mcp
+./liveks doctor --env liveks-index
 ```
 
 Resolve all failures. Warnings about Search preview availability or unknown Fabric quota require human review but do not claim that a deployment will fail.
+
+For `search-index`, doctor reads the existing index and verifies the semantic configuration and requested field capabilities with a transient bearer token. It does not read documents or mutate Search objects.
 
 Minimum versions are Python 3.11, Azure Developer CLI 1.27.0, and Node.js 22. Azure CLI is also required.
 
 ## 6. Plan Without Provisioning
 
 ```bash
-./liveks plan --env liveks-mcp
+./liveks plan --env liveks-index
 ```
 
-The plan:
+For `search-index`, the plan serializes the stable KS, extractive KB, and `intents` retrieve payloads and checks names for unowned collisions. It does not run Bicep, `azd`, npm, or any data-plane write.
+
+For preview deployment profiles, use their environment name instead. The plan:
 
 1. reruns doctor,
 2. compiles Bicep,
@@ -102,10 +107,15 @@ It does not set `azd` values, create Fabric assets, or run `azd up`.
 ## 7. Deploy And Verify
 
 ```bash
-./liveks up --env liveks-mcp
+./liveks up \
+  --env liveks-index \
+  --query "<question answerable from the existing index>" \
+  --expect-term "<known non-sensitive term>"
 ```
 
-Review the ARM preview and cost statement, then type `create liveks-mcp`. LiveKS provisions, deploys, and runs verification in the same lifecycle.
+Review the reuse ownership and cost statement, then type `create liveks-index`. LiveKS creates only the Search Index KS and minimal extractive KB, records each owned object, and runs the supplied content acceptance check. Follow [Stable Search Index Knowledge Source](23-search-index-ks.md) for the exact ledger and expected failures.
+
+For a preview MCP-only deployment, run `./liveks up --env liveks-mcp`, review the ARM preview, and type `create liveks-mcp`.
 
 For full greenfield:
 
@@ -117,13 +127,23 @@ Expected evidence:
 
 | Profile | Required evidence |
 | --- | --- |
+| `search-index` | Existing index remains readable; stable retrieve includes `searchIndex` activity or references and extracted text. |
 | `mcp-only` | Resource group and app exist; MCP retrieve includes MCP activity or references. |
 | `byo-fabric` | MCP evidence plus live Fabric and combined evidence using delegated Search authorization. |
 | `full` | Generated Fabric GraphModel is ready, separate checks prove both sources, and all Azure assets pass. |
 
 ### Run The Manual Acceptance Test
 
-Do not stop at a successful deployment message. Open the **App URL** from:
+The `search-index` lane has no deployed app. Run its content assertion directly:
+
+```bash
+./liveks verify \
+  --env liveks-index \
+  --query "<question answerable from the existing index>" \
+  --expect-term "<known non-sensitive term>"
+```
+
+For preview deployment profiles, do not stop at a successful deployment message. Open the **App URL** from:
 
 ```text
 deployments/<environment>/deployment-summary.md
@@ -168,21 +188,24 @@ For an Airline Ops `byo-fabric` or `full` environment:
 
 Expected: `tools/list` publishes `knowledge_base_retrieve`, `tools/call` returns at least one text block, and `grounding-content` matches every expected term. The command keeps raw MCP content in memory and records only sanitized counts. Without `--expect-term`, protocol checks can pass but grounding remains a warning.
 
+This command currently applies to the preview deployment profiles. The stable `search-index` profile proves its source through the documented REST retrieve contract; native MCP composition with Search Index KS is the next preview expansion path.
+
 Use [Call the Knowledge Base Through MCP](22-knowledge-base-mcp.md) for bearer authentication, a controlled missing-authorization failure, and the complete acceptance contract.
 
 ## 9. Clean Up
 
 ```bash
-./liveks down --env liveks-mcp
+./liveks down --env <environment>
 ```
 
-Type `delete liveks-mcp`. The command verifies the generated deployment resource group is absent afterward. For a generated `full` capacity, it also confirms that the exact ARM capacity is absent. When the run created the dedicated capacity resource group, it waits for that group to disappear as well.
+Type `delete <environment>`. For `search-index`, the command deletes only the recorded KS and KB, then proves the reused index remains. For a preview deployment, it verifies the generated resource group is absent afterward. A generated `full` capacity also requires the exact ARM capacity to be absent, with its dedicated capacity group deleted or preserved according to ownership.
 
 - `mcp-only` deletes generated Azure resources.
+- `search-index` deletes only the lock-owned Knowledge Base and Knowledge Source, then proves the reused index remains readable.
 - `byo-fabric` deletes generated Azure resources and preserves the existing Fabric workspace and ontology.
 - `full` deletes generated Fabric assets first, continues with Azure cleanup if Fabric reports a partial failure, and returns a nonzero partial-cleanup status.
 
-Do not close a rehearsal until `resource-group-absent` passes. For generated `full`, also require `fabric-capacity-absent`; require `fabric-capacity-resource-group-absent` for a generated group or `fabric-capacity-resource-group-preserved` for a pre-existing group. Treat a missing summary or unresolved create-mode ownership as partial cleanup.
+Do not close a stable rehearsal until `search-index-preserved` passes. Do not close a preview rehearsal until `resource-group-absent` passes. For generated `full`, also require `fabric-capacity-absent`; require `fabric-capacity-resource-group-absent` for a generated group or `fabric-capacity-resource-group-preserved` for a pre-existing group. Treat a missing summary or unresolved create-mode ownership as partial cleanup.
 
 The YAML and redacted lock must both identify Fabric assets as generated before Fabric deletion is allowed.
 
@@ -191,6 +214,12 @@ The YAML and redacted lock must both identify Fabric assets as generated before 
 For CI or a controlled test tenant:
 
 ```bash
+./liveks e2e \
+  --env liveks-index \
+  --query "<question answerable from the existing index>" \
+  --expect-term "<known non-sensitive term>" \
+  --cleanup \
+  --yes
 ./liveks e2e --env liveks-mcp --cleanup --yes
 ```
 

--- a/env/search-index.env.example
+++ b/env/search-index.env.example
@@ -1,0 +1,14 @@
+# Generated legacy compatibility example for search-index.
+# Source of truth: config/schema.yaml and profiles/*.yaml.
+# Prefer: ./liveks init --profile search-index --env <environment>
+
+DEPLOYMENT_MODE=search-index
+AZURE_SEARCH_API_VERSION=2026-04-01
+SEARCH_ENDPOINT=''
+SEARCH_INDEX_NAME=''
+SEARCH_SEMANTIC_CONFIGURATION_NAME=''
+SEARCH_INDEX_KNOWLEDGE_SOURCE_NAME=''
+SEARCH_INDEX_KNOWLEDGE_BASE_NAME=''
+FABRIC_CAPACITY_MODE=skip
+NEXT_TELEMETRY_DISABLED=1
+RUN_LIVE_CALLS=false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - Offline Replay: 09-offline-replay.md
   - Live Paths:
       - Architecture: 01-architecture.md
+      - Stable Search Index KS: 23-search-index-ks.md
       - MCP Server KS: 03-mcp-server-ks.md
       - Fabric Ontology KS: 04-fabric-ontology-ks.md
       - Fabric Prerequisites: fabric-ontology-prerequisites.md

--- a/profiles/search-index.yaml
+++ b/profiles/search-index.yaml
@@ -1,0 +1,39 @@
+schema_version: 2
+profile: search-index
+kind: deployment
+purpose: Wrap an existing Azure AI Search index with the generally available Search Index Knowledge Source contract.
+default: false
+required_tools: [python3, az]
+estimated_duration: 5-10 minutes
+cost: Uses an existing Azure AI Search service and index; retrieval can consume that service's existing billable capacity.
+defaults:
+  deployment:
+    mode: search-index
+  search:
+    api_version: '2026-04-01'
+    endpoint: ''
+    index_name: ''
+    semantic_configuration_name: ''
+    search_fields: []
+    source_data_fields: []
+    index_knowledge_source_name: ''
+    index_knowledge_base_name: ''
+  fabric:
+    mode: skip
+  runtime:
+    telemetry_disabled: true
+    run_live_calls: false
+required:
+  - search.endpoint
+  - search.index_name
+  - search.semantic_configuration_name
+resources:
+  - Existing Azure AI Search service (reused)
+  - Existing Azure AI Search index (reused)
+  - Search Index Knowledge Source (generated)
+  - Minimal extractive Knowledge Base (generated)
+success_criteria:
+  - The existing index and semantic configuration pass the read-only doctor checks.
+  - Stable retrieve returns searchIndex activity or reference evidence.
+  - Cleanup deletes only the generated Knowledge Base and Knowledge Source and proves the existing index remains.
+cleanup: Delete the generated Knowledge Base and Knowledge Source only; preserve the existing Search service and index.

--- a/scripts/check-sample-hygiene.py
+++ b/scripts/check-sample-hygiene.py
@@ -88,7 +88,7 @@ ZERO_GUID_KEYS = (
     "EXTERNAL_TENANT_ID",
 )
 
-EXPECTED_DEPLOYMENT_MODES = {"mcp-only", "byo-fabric", "full"}
+EXPECTED_DEPLOYMENT_MODES = {"search-index", "mcp-only", "byo-fabric", "full"}
 LIVE_PROOF_PATH = Path("samples/evidence/mcp-only-live-proof.sample.json")
 
 

--- a/scripts/generate_env_examples.py
+++ b/scripts/generate_env_examples.py
@@ -18,6 +18,7 @@ from liveks.config import flatten, load_yaml  # noqa: E402
 
 PROFILE_TARGETS = {
     "offline": ROOT / "env/offline.env.example",
+    "search-index": ROOT / "env/search-index.env.example",
     "mcp-only": ROOT / "env/mcp-only.env.example",
     "byo-fabric": ROOT / "env/byo-fabric.env.example",
     "full": ROOT / "env/full.env.example",
@@ -51,6 +52,8 @@ def profile_values(name: str) -> tuple[dict[str, Any], dict[str, Any]]:
 def render_profile(name: str) -> str:
     schema, values = profile_values(name)
     reverse = {path: env_name for env_name, path in schema["legacy_env"].items() if env_name not in {"SEARCH_API_VERSION"}}
+    if name == "search-index":
+        reverse["search.index_name"] = "SEARCH_INDEX_NAME"
     lines = [
         f"# Generated legacy compatibility example for {name}.",
         "# Source of truth: config/schema.yaml and profiles/*.yaml.",
@@ -74,6 +77,7 @@ def render_catalog() -> str:
         "# Generated legacy environment catalog.",
         "# Source of truth: config/schema.yaml and profiles/*.yaml.",
         "# Prefer .liveks/<env>.yaml created by ./liveks init.",
+        "# - search-index: wrap an existing Search index with the stable extractive contract.",
         "# - mcp-only: deploy Azure AI Search with the MCP Server Knowledge Source.",
         "# - byo-fabric: connect an existing Fabric ontology without taking ownership.",
         "# - full: create the Fabric sample stack after explicit cost acknowledgement.",

--- a/scripts/maintainers/create-promotion-note.sh
+++ b/scripts/maintainers/create-promotion-note.sh
@@ -208,8 +208,9 @@ Hi team,
 I have a private-review candidate for the Azure AI Search Foundry IQ Live Knowledge Sources sample accelerator.
 
 Scope:
+- One stable existing-index path: Search Index KS
 - Two public preview Knowledge Source paths: MCP Server KS and Fabric Ontology KS
-- Three deployment modes: mcp-only, byo-fabric, full
+- Three preview deployment modes: mcp-only, byo-fabric, full
 - Demo app, notebooks, REST samples, synthetic Airline Ops data, offline replay, validation workflow, and E2E evidence workflow
 
 Current evidence:
@@ -223,7 +224,7 @@ Reviewer asks:
 - Azure AI Search Knowledge Source terminology and REST shape
 - MCP Server KS request/response shape and trace wording
 - Fabric Ontology KS setup and delegated source authorization wording
-- Deployment-mode clarity: mcp-only, byo-fabric, full
+- Profile clarity: stable search-index; preview mcp-only, byo-fabric, full
 - Public-preview caveats and safe claims
 - Security posture for generated outputs and tokens
 

--- a/scripts/maintainers/create-review-packet.sh
+++ b/scripts/maintainers/create-review-packet.sh
@@ -17,7 +17,7 @@ Usage:
 
 Options:
   --mode <mode>          Deployment mode reviewed.
-                         Values: mcp-only, byo-fabric, full
+                         Values: search-index, mcp-only, byo-fabric, full
   --intent <text>        Review intent. Default: private review
   --e2e-report <path>    Ignored local E2E report path to reference.
                          The script records only the path, not report contents.
@@ -80,10 +80,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$MODE" in
-  ""|mcp-only|byo-fabric|full)
+  ""|search-index|mcp-only|byo-fabric|full)
     ;;
   *)
-    echo "Invalid --mode: $MODE. Allowed values: mcp-only, byo-fabric, full." >&2
+    echo "Invalid --mode: $MODE. Allowed values: search-index, mcp-only, byo-fabric, full." >&2
     exit 2
     ;;
 esac
@@ -252,7 +252,7 @@ ${evidence_summary_block}
 - Azure AI Search Knowledge Source terminology and REST shape
 - MCP Server KS request/response shape and trace wording
 - Fabric Ontology KS setup and delegated source authorization wording
-- Deployment-mode clarity: \`mcp-only\`, \`byo-fabric\`, \`full\`
+- Profile clarity: stable \`search-index\`; preview \`mcp-only\`, \`byo-fabric\`, \`full\`
 - Public-preview caveats and safe claims
 - Security posture for generated outputs and tokens
 

--- a/src/ks_factory/__init__.py
+++ b/src/ks_factory/__init__.py
@@ -1,12 +1,14 @@
 """Payload builders for Azure AI Search live Knowledge Sources."""
 
 from .fabric_ontology import create_fabric_ontology_knowledge_source
-from .knowledge_base import create_knowledge_base
+from .knowledge_base import create_extracting_knowledge_base, create_knowledge_base
 from .mcp_server import create_mcp_server_knowledge_source
+from .search_index import create_search_index_knowledge_source
 
 __all__ = [
     "create_fabric_ontology_knowledge_source",
+    "create_extracting_knowledge_base",
     "create_knowledge_base",
     "create_mcp_server_knowledge_source",
+    "create_search_index_knowledge_source",
 ]
-

--- a/src/ks_factory/knowledge_base.py
+++ b/src/ks_factory/knowledge_base.py
@@ -49,3 +49,17 @@ def create_knowledge_base(
         ]
 
     return payload
+
+
+def create_extracting_knowledge_base(
+    *,
+    name: str,
+    knowledge_source_names: list[str],
+    description: str = "Knowledge Base for minimal extractive retrieval.",
+) -> dict[str, Any]:
+    """Build the narrow Knowledge Base payload accepted by the stable API."""
+    return {
+        "name": name,
+        "description": description,
+        "knowledgeSources": [{"name": source_name} for source_name in knowledge_source_names],
+    }

--- a/src/ks_factory/search_index.py
+++ b/src/ks_factory/search_index.py
@@ -1,0 +1,42 @@
+"""Search Index Knowledge Source payload helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+
+def _field_references(names: Iterable[str]) -> list[dict[str, str]]:
+    return [{"name": name} for name in names if name]
+
+
+def create_search_index_knowledge_source(
+    *,
+    name: str,
+    search_index_name: str,
+    semantic_configuration_name: str,
+    search_fields: Iterable[str] = (),
+    source_data_fields: Iterable[str] = (),
+    description: str = "Knowledge Source over an existing Azure AI Search index.",
+) -> dict[str, Any]:
+    """Build the generally available Search Index Knowledge Source payload."""
+    if not name or not search_index_name or not semantic_configuration_name:
+        raise ValueError("name, search_index_name, and semantic_configuration_name are required")
+
+    parameters: dict[str, Any] = {
+        "searchIndexName": search_index_name,
+        "semanticConfigurationName": semantic_configuration_name,
+    }
+    search_field_references = _field_references(search_fields)
+    source_data_field_references = _field_references(source_data_fields)
+    if search_field_references:
+        parameters["searchFields"] = search_field_references
+    if source_data_field_references:
+        parameters["sourceDataFields"] = source_data_field_references
+
+    return {
+        "name": name,
+        "kind": "searchIndex",
+        "description": description,
+        "searchIndexParameters": parameters,
+    }

--- a/src/liveks/cli.py
+++ b/src/liveks/cli.py
@@ -31,10 +31,18 @@ from .config import (
 )
 from .evidence import generated_at, repository_revision, runtime_summary, sha256_file, write_json
 from .runtime import CommandRunner, http_json, http_mcp_json, parse_azd_values, parse_version
+from .search_index import (
+    acquire_bearer_token as acquire_search_bearer_token,
+    build_payloads as build_search_index_payloads,
+    inspect_index,
+    object_path as search_object_path,
+    request as search_index_request,
+    response_text as search_index_response_text,
+)
 
 
 ROOT = Path(__file__).resolve().parents[2]
-LIVE_PROFILES = {"mcp-only", "byo-fabric", "full"}
+LIVE_PROFILES = {"search-index", "mcp-only", "byo-fabric", "full"}
 GENERATED_FABRIC_AZD_KEYS = (
     "FABRIC_CAPACITY_ID",
     "FABRIC_CAPACITY_ARM_ID",
@@ -104,7 +112,7 @@ def _sanitized_e2e_checks(report: dict[str, Any]) -> list[dict[str, Any]]:
             source_types = check.get("sourceTypes")
             if isinstance(source_types, list):
                 safe_check["sourceTypes"] = sorted(
-                    {str(item) for item in source_types if item in {"fabricOntology", "mcpServer"}}
+                    {str(item) for item in source_types if item in {"fabricOntology", "mcpServer", "searchIndex"}}
                 )
             checks.append(safe_check)
     return checks
@@ -131,6 +139,8 @@ def _write_e2e_evidence_capsule(
         source_types.append("fabricOntology")
     if "mcp-retrieve" in successful_names:
         source_types.append("mcpServer")
+    if "search-index-retrieve" in successful_names:
+        source_types.append("searchIndex")
     mcp_status = next(
         (str(check["status"]) for check in checks if check["name"] == "knowledge-base-mcp"),
         "not-run",
@@ -154,11 +164,19 @@ def _write_e2e_evidence_capsule(
             "cleanupRequested": cleanup_requested,
         },
         "runtime": runtime_summary(),
-        "declaredContracts": {
-            "mcpServerKnowledgeSourceTransport": "remote-https",
-            "knowledgeBaseMcpTransport": "stateless-json-rpc-http",
-            "liveGrounding": "protected-integration",
-        },
+        "declaredContracts": (
+            {
+                "searchIndexKnowledgeSource": "2026-04-01-stable",
+                "retrieval": "minimal-extractive",
+                "existingIndexOwnership": "reuse",
+            }
+            if config.profile == "search-index"
+            else {
+                "mcpServerKnowledgeSourceTransport": "remote-https",
+                "knowledgeBaseMcpTransport": "stateless-json-rpc-http",
+                "liveGrounding": "protected-integration",
+            }
+        ),
         "observedEvidence": {
             "sourceTypes": sorted(source_types),
             "knowledgeBaseMcp": mcp_status,
@@ -269,6 +287,66 @@ def _command_version(command: list[str], config: ResolvedConfig) -> tuple[int, s
     return result.returncode, result.stdout.strip()
 
 
+def _search_index_doctor_checks(config: ResolvedConfig) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    if not shutil.which("az"):
+        return checks
+    runner = CommandRunner(root=ROOT, env=config.child_env(), quiet=True)
+    account = runner.run(["az", "account", "show", "-o", "json"])
+    account_data: dict[str, Any] = {}
+    if account.returncode == 0:
+        try:
+            account_data = json.loads(account.stdout)
+        except json.JSONDecodeError:
+            pass
+    checks.append(
+        _check(
+            "azure-login",
+            "pass" if account_data.get("id") else "fail",
+            "Azure CLI account is active" if account_data.get("id") else "Run az login for the target tenant",
+        )
+    )
+
+    configured_tenant = str(config.get("azure.tenant_id", ""))
+    configured_subscription = str(config.get("azure.subscription_id", ""))
+    if configured_tenant:
+        matches = configured_tenant == str(account_data.get("tenantId", ""))
+        checks.append(_check("tenant-match", "pass" if matches else "fail", "Configured tenant matches Azure CLI" if matches else "Configured tenant differs from Azure CLI"))
+    if configured_subscription:
+        matches = configured_subscription == str(account_data.get("id", ""))
+        checks.append(_check("subscription-match", "pass" if matches else "fail", "Configured subscription matches Azure CLI" if matches else "Configured subscription differs from Azure CLI"))
+    if not account_data.get("id"):
+        return checks
+
+    try:
+        token = acquire_search_bearer_token(runner)
+        checks.append(_check("search-auth", "pass", "A transient Azure AI Search bearer token was acquired."))
+        status_code, index = search_index_request(
+            config,
+            token,
+            method="GET",
+            path=search_object_path("indexes", str(config.get("search.index_name"))),
+            timeout=30,
+        )
+    except Exception:
+        checks.append(_check("search-index", "fail", "The configured Search index could not be read with the current identity."))
+        return checks
+
+    index_ready = status_code == 200
+    checks.append(
+        _check(
+            "search-index",
+            "pass" if index_ready else "fail",
+            "The existing Search index is readable."
+            if index_ready
+            else f"Azure AI Search returned HTTP {status_code} for the configured index.",
+        )
+    )
+    if index_ready:
+        checks.extend(_check(name, status, message) for name, status, message in inspect_index(index, config))
+    return checks
+
+
 def doctor_report(config: ResolvedConfig, *, cloud: bool = True) -> dict[str, Any]:
     checks: list[dict[str, Any]] = []
     required_tools = list(config.manifest.get("required_tools", []))
@@ -290,7 +368,9 @@ def doctor_report(config: ResolvedConfig, *, cloud: bool = True) -> dict[str, An
         ready = code == 0 and parse_version(output) >= (22, 0, 0)
         checks.append(_check("node-version", "pass" if ready else "fail", f"{output} (requires 22+)"))
 
-    if config.profile in LIVE_PROFILES and cloud:
+    if config.profile == "search-index" and cloud:
+        checks.extend(_search_index_doctor_checks(config))
+    elif config.profile in LIVE_PROFILES and cloud:
         runner = CommandRunner(root=ROOT, env=config.child_env(), quiet=True)
         account = runner.run(["az", "account", "show", "-o", "json"])
         account_data: dict[str, Any] = {}
@@ -372,6 +452,143 @@ def doctor_report(config: ResolvedConfig, *, cloud: bool = True) -> dict[str, An
     )
 
 
+def _search_index_lock_state(config: ResolvedConfig) -> tuple[dict[str, str], bool, str]:
+    try:
+        lock = _load_lock(config.environment)
+    except ConfigError as error:
+        return {}, False, f"invalid environment lock: {error}"
+    if lock is None:
+        return {}, True, "environment lock is not present"
+
+    managed = lock.get("managedObjects")
+    managed_objects = {
+        str(key): str(value)
+        for key, value in managed.items()
+        if isinstance(managed, dict) and key in {"knowledgeSource", "knowledgeBase"} and value
+    } if isinstance(managed, dict) else {}
+    matches = (
+        lock.get("profile") == config.profile
+        and lock.get("environment") == config.environment
+        and lock.get("configDigest") == config.config_digest
+    )
+    return managed_objects, matches, "matching environment lock" if matches else "environment lock does not match the resolved configuration"
+
+
+def _search_index_plan_report(config: ResolvedConfig, checks: list[dict[str, Any]]) -> dict[str, Any]:
+    managed, lock_matches, lock_message = _search_index_lock_state(config)
+    if managed and not lock_matches:
+        checks.append(
+            _check(
+                "environment-lock",
+                "fail",
+                "A different configuration owns generated Search objects; use its original ledger for cleanup before planning again.",
+            )
+        )
+        return envelope(
+            "plan",
+            "fail",
+            profile=config.profile,
+            environment=config.environment,
+            checks=checks,
+            resources=config.manifest.get("resources", []),
+            nextActions=["Restore the original environment ledger and run liveks down."],
+        )
+    checks.append(_check("environment-lock", "pass", lock_message))
+
+    payloads = build_search_index_payloads(
+        config,
+        query="What information is available in this index?",
+    )
+    knowledge_source = payloads["knowledgeSource"]
+    knowledge_base = payloads["knowledgeBase"]
+    retrieve = payloads["retrieve"]
+    payload_ready = (
+        knowledge_source.get("kind") == "searchIndex"
+        and "searchIndexParameters" in knowledge_source
+        and not {"models", "outputMode", "retrievalReasoningEffort"}.intersection(knowledge_base)
+        and "intents" in retrieve
+        and "messages" not in retrieve
+    )
+    checks.append(
+        _check(
+            "stable-payload-contract",
+            "pass" if payload_ready else "fail",
+            "Search Index KS, extractive Knowledge Base, and intents retrieve payloads match the stable lane."
+            if payload_ready
+            else "The stable payload contract is internally inconsistent.",
+        )
+    )
+
+    runner = CommandRunner(root=ROOT, env=config.child_env(), quiet=True)
+    try:
+        token = acquire_search_bearer_token(runner)
+        names = {
+            "knowledgeSource": ("knowledgesources", str(config.get("search.index_knowledge_source_name"))),
+            "knowledgeBase": ("knowledgebases", str(config.get("search.index_knowledge_base_name"))),
+        }
+        for label, (kind, name) in names.items():
+            status_code, _ = search_index_request(
+                config,
+                token,
+                method="GET",
+                path=search_object_path(kind, name),
+                timeout=30,
+            )
+            collision = status_code == 200 and managed.get(label) != name
+            ready = status_code == 404 or (status_code == 200 and not collision)
+            checks.append(
+                _check(
+                    f"{label}-name",
+                    "pass" if ready else "fail",
+                    "Name is available."
+                    if status_code == 404
+                    else "Existing object is owned by this environment."
+                    if ready
+                    else "An existing unowned object uses this name; choose another environment or explicit name.",
+                )
+            )
+    except Exception:
+        checks.append(_check("search-object-collision-check", "fail", "Existing Search object names could not be checked."))
+
+    output_dir = ROOT / ".deployment" / config.environment
+    output_dir.mkdir(parents=True, exist_ok=True)
+    payload_path = output_dir / "search-index-plan.json"
+    write_json(
+        payload_path,
+        {
+            "schemaVersion": 1,
+            "apiVersion": config.get("search.api_version"),
+            "payloads": payloads,
+            "ownership": config.ownership(),
+        },
+    )
+    status = "fail" if any(check["status"] == "fail" for check in checks) else "warn" if any(check["status"] in {"warn", "unknown"} for check in checks) else "pass"
+    lock = write_lock(
+        config,
+        status="planned" if status != "fail" else "plan-failed",
+        extra={
+            "checks": checks,
+            "resources": config.manifest.get("resources", []),
+            "estimatedDuration": config.manifest.get("estimated_duration"),
+            "cost": config.manifest.get("cost"),
+            "managedObjects": managed,
+        },
+    )
+    return envelope(
+        "plan",
+        status,
+        profile=config.profile,
+        environment=config.environment,
+        checks=checks,
+        resources=config.manifest.get("resources", []),
+        cost=config.manifest.get("cost"),
+        estimatedDuration=config.manifest.get("estimated_duration"),
+        ownership=config.ownership(),
+        artifacts=[_display_path(lock), _display_path(payload_path)],
+        nextActions=[f"Run ./liveks up --env {config.environment}" if status != "fail" else "Fix plan failures before creating Search objects"],
+    )
+
+
 def plan_report(
     config: ResolvedConfig,
     *,
@@ -387,6 +604,9 @@ def plan_report(
     if config.profile == "offline":
         lock = write_lock(config, status="planned", extra={"checks": checks})
         return envelope("plan", "pass", profile=config.profile, environment=config.environment, checks=checks, resources=[], cost=config.manifest.get("cost"), estimatedDuration=config.manifest.get("estimated_duration"), artifacts=[_display_path(lock)], nextActions=["Run ./liveks try"])
+
+    if config.profile == "search-index":
+        return _search_index_plan_report(config, checks)
 
     output_dir = ROOT / ".deployment" / config.environment
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -464,6 +684,126 @@ def _confirm_up(config: ResolvedConfig, *, yes: bool, accept_fabric_capacity: bo
         raise PermissionError("Provisioning confirmation was not provided.")
 
 
+def _search_index_up_report(
+    config: ResolvedConfig,
+    *,
+    yes: bool,
+    quiet: bool,
+    query: str | None,
+    expected_terms: list[str] | None,
+) -> dict[str, Any]:
+    plan = plan_report(config, quiet=True)
+    if plan["status"] == "fail":
+        return {**plan, "command": "up"}
+
+    checks = list(plan.get("checks", []))
+    managed, lock_matches, _ = _search_index_lock_state(config)
+    if not lock_matches:
+        return envelope(
+            "up",
+            "fail",
+            profile=config.profile,
+            environment=config.environment,
+            checks=checks + [_check("environment-lock", "fail", "The planned lock no longer matches the resolved configuration.")],
+        )
+    runner = CommandRunner(root=ROOT, env=config.child_env(), quiet=quiet)
+    payloads = build_search_index_payloads(config, query="What information is available in this index?")
+    try:
+        _confirm_up(config, yes=yes, accept_fabric_capacity=False, creates_capacity=False)
+        token = acquire_search_bearer_token(runner)
+        objects = [
+            (
+                "knowledgeSource",
+                "knowledgesources",
+                str(config.get("search.index_knowledge_source_name")),
+                payloads["knowledgeSource"],
+            ),
+            (
+                "knowledgeBase",
+                "knowledgebases",
+                str(config.get("search.index_knowledge_base_name")),
+                payloads["knowledgeBase"],
+            ),
+        ]
+        for label, kind, name, body in objects:
+            existing_code, _ = search_index_request(
+                config,
+                token,
+                method="GET",
+                path=search_object_path(kind, name),
+                timeout=30,
+            )
+            if existing_code == 200 and managed.get(label) != name:
+                raise RuntimeError(f"Refusing to overwrite an unowned {label}.")
+            if existing_code not in {200, 404}:
+                raise RuntimeError(f"Unable to check the target {label} name (HTTP {existing_code}).")
+            status_code, _ = search_index_request(
+                config,
+                token,
+                method="PUT",
+                path=search_object_path(kind, name),
+                body=body,
+            )
+            if status_code not in {200, 201}:
+                raise RuntimeError(f"Creating {label} failed (HTTP {status_code}).")
+            managed[label] = name
+            checks.append(_check(f"create-{label}", "pass", f"Generated {label} is ready."))
+            write_lock(
+                config,
+                status="deployment-in-progress",
+                extra={"checks": checks, "managedObjects": managed},
+            )
+
+        verified = verify_report(
+            config,
+            quiet=True,
+            query=query,
+            expected_terms=expected_terms,
+        )
+        checks.extend(verified.get("checks", []))
+        status = "pass" if verified.get("status") == "pass" else "fail"
+        lock = write_lock(
+            config,
+            status="deployed" if status == "pass" else "verification-failed",
+            extra={"checks": checks, "managedObjects": managed},
+        )
+        return envelope(
+            "up",
+            status,
+            profile=config.profile,
+            environment=config.environment,
+            checks=checks,
+            ownership=config.ownership(),
+            artifacts=[_display_path(lock)],
+            nextActions=[f"Run ./liveks down --env {config.environment} when finished"],
+        )
+    except PermissionError as error:
+        return envelope(
+            "up",
+            "confirmation-required",
+            profile=config.profile,
+            environment=config.environment,
+            checks=checks + [_check("confirmation", "fail", str(error))],
+            nextActions=["Review the plan and provide confirmation."],
+        )
+    except Exception as error:
+        lock = write_lock(
+            config,
+            status="deployment-failed",
+            extra={"checks": checks, "managedObjects": managed, "error": str(error)},
+        )
+        return envelope(
+            "up",
+            "fail",
+            profile=config.profile,
+            environment=config.environment,
+            checks=checks + [_check("deployment", "fail", str(error))],
+            ownership=config.ownership(),
+            artifacts=[_display_path(lock)],
+            nextActions=[f"Run ./liveks down --env {config.environment} --yes to remove only recorded generated objects"],
+        )
+
+
 def up_report(
     config: ResolvedConfig,
     *,
@@ -473,7 +813,17 @@ def up_report(
     skip_app_build: bool = False,
     skip_dry_run: bool = False,
     postprovision_only: bool = False,
+    query: str | None = None,
+    expected_terms: list[str] | None = None,
 ) -> dict[str, Any]:
+    if config.profile == "search-index":
+        return _search_index_up_report(
+            config,
+            yes=yes,
+            quiet=quiet,
+            query=query,
+            expected_terms=expected_terms,
+        )
     plan = plan_report(config, quiet=True, skip_app_build=skip_app_build, skip_dry_run=skip_dry_run)
     if plan["status"] == "fail":
         return {**plan, "command": "up"}
@@ -617,6 +967,23 @@ def mcp_report(
             profile=config.profile,
             environment=config.environment,
             checks=[_check("deployment", "fail", "A deployed live profile is required for an MCP call.")],
+        )
+        if persist:
+            _persist_mcp_report(config, report)
+        return report
+    if config.profile == "search-index":
+        report = envelope(
+            "mcp",
+            "fail",
+            profile=config.profile,
+            environment=config.environment,
+            checks=[
+                _check(
+                    "profile-contract",
+                    "fail",
+                    "The stable search-index profile validates the REST retrieve path; use liveks verify. MCP is available in the preview deployment profiles.",
+                )
+            ],
         )
         if persist:
             _persist_mcp_report(config, report)
@@ -820,10 +1187,163 @@ def mcp_report(
     return report
 
 
-def verify_report(config: ResolvedConfig, *, quiet: bool = False) -> dict[str, Any]:
+def _search_index_verify_report(
+    config: ResolvedConfig,
+    *,
+    quiet: bool,
+    query: str | None,
+    expected_terms: list[str] | None,
+) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+    runner = CommandRunner(root=ROOT, env=config.child_env(), quiet=quiet)
+    try:
+        token = acquire_search_bearer_token(runner)
+    except Exception:
+        return envelope(
+            "verify",
+            "fail",
+            profile=config.profile,
+            environment=config.environment,
+            checks=[_check("search-auth", "fail", "Unable to acquire a transient Azure AI Search bearer token.")],
+        )
+
+    object_contracts = [
+        ("search-index", "indexes", str(config.get("search.index_name"))),
+        ("search-index-knowledge-source", "knowledgesources", str(config.get("search.index_knowledge_source_name"))),
+        ("search-index-knowledge-base", "knowledgebases", str(config.get("search.index_knowledge_base_name"))),
+    ]
+    objects: dict[str, Any] = {}
+    for label, kind, name in object_contracts:
+        try:
+            status_code, payload = search_index_request(
+                config,
+                token,
+                method="GET",
+                path=search_object_path(kind, name),
+                timeout=30,
+            )
+        except Exception:
+            status_code, payload = 0, {}
+        objects[label] = payload
+        checks.append(
+            _check(
+                label,
+                "pass" if status_code == 200 else "fail",
+                "Object is readable." if status_code == 200 else f"Object read failed (HTTP {status_code or 'unavailable'}).",
+            )
+        )
+
+    knowledge_source = objects.get("search-index-knowledge-source")
+    source_parameters = knowledge_source.get("searchIndexParameters", {}) if isinstance(knowledge_source, dict) else {}
+    source_matches = (
+        isinstance(knowledge_source, dict)
+        and knowledge_source.get("kind") == "searchIndex"
+        and source_parameters.get("searchIndexName") == config.get("search.index_name")
+        and source_parameters.get("semanticConfigurationName") == config.get("search.semantic_configuration_name")
+    )
+    checks.append(
+        _check(
+            "knowledge-source-contract",
+            "pass" if source_matches else "fail",
+            "Knowledge Source references the configured existing index and semantic configuration."
+            if source_matches
+            else "Knowledge Source definition does not match the configured index contract.",
+        )
+    )
+
+    knowledge_base = objects.get("search-index-knowledge-base")
+    source_names = {
+        str(item.get("name"))
+        for item in knowledge_base.get("knowledgeSources", [])
+        if isinstance(knowledge_base, dict) and isinstance(item, dict) and item.get("name")
+    } if isinstance(knowledge_base, dict) else set()
+    stable_kb = (
+        config.get("search.index_knowledge_source_name") in source_names
+        and not {"models", "outputMode", "retrievalReasoningEffort"}.intersection(knowledge_base or {})
+    )
+    checks.append(
+        _check(
+            "knowledge-base-contract",
+            "pass" if stable_kb else "fail",
+            "Knowledge Base uses the generated source without preview-only properties."
+            if stable_kb
+            else "Knowledge Base definition does not match the stable extractive contract.",
+        )
+    )
+
+    effective_query = query or "What information is available in this index?"
+    payloads = build_search_index_payloads(config, query=effective_query)
+    try:
+        retrieve_code, retrieve_payload = search_index_request(
+            config,
+            token,
+            method="POST",
+            path=f"{search_object_path('knowledgebases', str(config.get('search.index_knowledge_base_name')))}/retrieve",
+            body=payloads["retrieve"],
+            attempts=2,
+        )
+    except Exception:
+        retrieve_code, retrieve_payload = 0, {}
+    text_content = search_index_response_text(retrieve_payload)
+    retrieve_ok = retrieve_code == 200 and bool(text_content) and _response_has_evidence(retrieve_payload, "searchIndex")
+    checks.append(
+        _check(
+            "search-index-retrieve",
+            "pass" if retrieve_ok else "fail",
+            "Stable retrieve returned extracted content and searchIndex activity or reference evidence."
+            if retrieve_ok
+            else f"Stable retrieve did not return the required evidence (HTTP {retrieve_code or 'unavailable'}).",
+        )
+    )
+
+    terms = expected_terms or []
+    if terms:
+        folded = text_content.casefold()
+        matched = sum(1 for term in terms if term.casefold() in folded)
+        checks.append(
+            _check(
+                "grounding-content",
+                "pass" if matched == len(terms) else "fail",
+                f"Extracted content matched {matched}/{len(terms)} expected term(s).",
+                expectedTermCount=len(terms),
+                matchedExpectedTermCount=matched,
+            )
+        )
+
+    status = "fail" if any(check["status"] == "fail" for check in checks) else "pass"
+    report = envelope(
+        "verify",
+        status,
+        profile=config.profile,
+        environment=config.environment,
+        checks=checks,
+        nextActions=[f"Run ./liveks down --env {config.environment} when finished"],
+    )
+    report_dir = ROOT / "deployments" / config.environment
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = report_dir / "verify-report.json"
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    report["artifacts"] = [_display_path(report_path)]
+    return report
+
+
+def verify_report(
+    config: ResolvedConfig,
+    *,
+    quiet: bool = False,
+    query: str | None = None,
+    expected_terms: list[str] | None = None,
+) -> dict[str, Any]:
     if config.profile == "offline":
         result = subprocess.run([sys.executable, "tools/try_offline.py", "--format", "json"], cwd=ROOT, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False)
         return envelope("verify", "pass" if result.returncode == 0 else "fail", profile=config.profile, environment=config.environment, checks=[_check("offline-replay", "pass" if result.returncode == 0 else "fail", "combined trace inspected" if result.returncode == 0 else result.stdout)])
+    if config.profile == "search-index":
+        return _search_index_verify_report(
+            config,
+            quiet=quiet,
+            query=query,
+            expected_terms=expected_terms,
+        )
 
     runner = CommandRunner(root=ROOT, env=config.child_env(), quiet=quiet)
     checks: list[dict[str, Any]] = []
@@ -989,7 +1509,121 @@ def _cleanup_ownership(config: ResolvedConfig) -> tuple[dict[str, str], str]:
     return effective, "resolved configuration + environment lock"
 
 
+def _search_index_down_report(config: ResolvedConfig, *, yes: bool, quiet: bool) -> dict[str, Any]:
+    if not yes:
+        expected = f"delete {config.environment}"
+        answer = input(f"Type '{expected}' to delete generated resources: ").strip()
+        if answer != expected:
+            return envelope(
+                "down",
+                "confirmation-required",
+                profile=config.profile,
+                environment=config.environment,
+                checks=[_check("confirmation", "fail", "Cleanup cancelled")],
+            )
+
+    managed, lock_matches, lock_message = _search_index_lock_state(config)
+    if not lock_matches or lock_message != "matching environment lock":
+        return envelope(
+            "down",
+            "cleanup-incomplete",
+            profile=config.profile,
+            environment=config.environment,
+            checks=[
+                _check(
+                    "ownership",
+                    "warn",
+                    "Generated Search object ownership cannot be proven; the existing service, index, and all named objects were preserved.",
+                )
+            ],
+            ownership=config.ownership(),
+            nextActions=["Restore the matching environment lock before cleanup."],
+        )
+
+    checks = [_check("ownership", "pass", "Matching configuration and lock prove the generated object names.")]
+    runner = CommandRunner(root=ROOT, env=config.child_env(), quiet=quiet)
+    try:
+        token = acquire_search_bearer_token(runner)
+    except Exception:
+        return envelope(
+            "down",
+            "cleanup-incomplete",
+            profile=config.profile,
+            environment=config.environment,
+            checks=checks + [_check("search-auth", "fail", "Unable to acquire a transient Azure AI Search bearer token.")],
+            ownership=config.ownership(),
+        )
+
+    remaining = dict(managed)
+    for label, kind in (("knowledgeBase", "knowledgebases"), ("knowledgeSource", "knowledgesources")):
+        name = managed.get(label)
+        if not name:
+            checks.append(_check(f"delete-{label}", "pass", "No generated object is recorded."))
+            continue
+        try:
+            status_code, _ = search_index_request(
+                config,
+                token,
+                method="DELETE",
+                path=search_object_path(kind, name),
+                timeout=60,
+            )
+        except Exception:
+            status_code = 0
+        deleted = status_code in {200, 202, 204, 404}
+        checks.append(
+            _check(
+                f"delete-{label}",
+                "pass" if deleted else "fail",
+                "Generated object is absent."
+                if deleted
+                else f"Generated object deletion failed (HTTP {status_code or 'unavailable'}).",
+            )
+        )
+        if deleted:
+            remaining.pop(label, None)
+
+    try:
+        index_code, _ = search_index_request(
+            config,
+            token,
+            method="GET",
+            path=search_object_path("indexes", str(config.get("search.index_name"))),
+            timeout=30,
+        )
+    except Exception:
+        index_code = 0
+    checks.append(
+        _check(
+            "search-index-preserved",
+            "pass" if index_code == 200 else "fail",
+            "The existing Search index remains readable after cleanup."
+            if index_code == 200
+            else f"The existing Search index could not be confirmed after cleanup (HTTP {index_code or 'unavailable'}).",
+        )
+    )
+
+    status = "pass" if not remaining and all(check["status"] != "fail" for check in checks) else "cleanup-incomplete"
+    lock = write_lock(
+        config,
+        status="cleaned" if status == "pass" else "cleanup-incomplete",
+        extra={"checks": checks, "managedObjects": remaining},
+    )
+    return envelope(
+        "down",
+        status,
+        profile=config.profile,
+        environment=config.environment,
+        checks=checks,
+        ownership=config.ownership(),
+        artifacts=[_display_path(lock)],
+        nextActions=[] if status == "pass" else ["Retry cleanup after resolving the failed generated-object deletion."],
+    )
+
+
 def down_report(config: ResolvedConfig, *, yes: bool, quiet: bool = False) -> dict[str, Any]:
+    if config.profile == "search-index":
+        return _search_index_down_report(config, yes=yes, quiet=quiet)
     checks: list[dict[str, Any]] = []
     if not yes:
         expected = f"delete {config.environment}"
@@ -1257,7 +1891,7 @@ def build_parser() -> argparse.ArgumentParser:
     try_parser.add_argument("--evidence-out", type=Path)
 
     init_parser = subparsers.add_parser("init", help="Create an ignored YAML environment ledger.")
-    init_parser.add_argument("--profile", choices=["mcp-only", "byo-fabric", "full"], required=True)
+    init_parser.add_argument("--profile", choices=["search-index", "mcp-only", "byo-fabric", "full"], required=True)
     init_parser.add_argument("--env", dest="environment", required=True)
     init_parser.add_argument("--config", type=Path)
     init_parser.add_argument("--from-env", type=Path)
@@ -1274,8 +1908,12 @@ def build_parser() -> argparse.ArgumentParser:
     up_parser.add_argument("--skip-app-build", action="store_true", help=argparse.SUPPRESS)
     up_parser.add_argument("--skip-dry-run", action="store_true", help=argparse.SUPPRESS)
     up_parser.add_argument("--postprovision-only", action="store_true", help=argparse.SUPPRESS)
+    up_parser.add_argument("--query", help="Runtime acceptance query for the search-index profile.")
+    up_parser.add_argument("--expect-term", action="append", default=[], help="Expected non-sensitive term for search-index content acceptance; repeatable.")
     verify_parser = subparsers.add_parser("verify", help="Verify deployed resources and retrieve evidence.")
     _common_config_args(verify_parser, require_env=False)
+    verify_parser.add_argument("--query")
+    verify_parser.add_argument("--expect-term", action="append", default=[])
     mcp_parser = subparsers.add_parser("mcp", help="Call a deployed Knowledge Base through its MCP endpoint.")
     _common_config_args(mcp_parser, require_env=True)
     mcp_parser.add_argument("--query")
@@ -1293,6 +1931,8 @@ def build_parser() -> argparse.ArgumentParser:
     e2e_parser.add_argument("--keep-resources", action="store_true")
     e2e_parser.add_argument("--yes", action="store_true")
     e2e_parser.add_argument("--accept-fabric-capacity", action="store_true")
+    e2e_parser.add_argument("--query", help="Runtime acceptance query for the search-index profile.")
+    e2e_parser.add_argument("--expect-term", action="append", default=[], help="Expected non-sensitive term for search-index content acceptance; repeatable.")
     return parser
 
 
@@ -1355,7 +1995,15 @@ def main(argv: list[str] | None = None) -> int:
                 _init_from_legacy(args.from_env, args.profile, args.environment, destination)
             else:
                 write_user_config(destination, profile=args.profile, environment=args.environment)
-            report = envelope("init", "pass", profile=args.profile, environment=args.environment, artifacts=[str(destination.relative_to(ROOT))], nextActions=[f"Review {destination.relative_to(ROOT)}, then run ./liveks doctor --env {args.environment}"])
+            display_destination = _display_path(destination)
+            report = envelope(
+                "init",
+                "pass",
+                profile=args.profile,
+                environment=args.environment,
+                artifacts=[display_destination],
+                nextActions=[f"Review {display_destination}, then run ./liveks doctor --env {args.environment}"],
+            )
             emit(report, args.format)
             return 0
 
@@ -1373,9 +2021,16 @@ def main(argv: list[str] | None = None) -> int:
                 skip_app_build=args.skip_app_build,
                 skip_dry_run=args.skip_dry_run,
                 postprovision_only=args.postprovision_only,
+                query=args.query,
+                expected_terms=args.expect_term,
             )
         elif args.command == "verify":
-            report = verify_report(config, quiet=args.format == "json")
+            report = verify_report(
+                config,
+                quiet=args.format == "json",
+                query=args.query,
+                expected_terms=args.expect_term,
+            )
         elif args.command == "mcp":
             report = mcp_report(
                 config,
@@ -1391,7 +2046,14 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "e2e":
             if args.cleanup == args.keep_resources:
                 raise ConfigError("Choose exactly one of --cleanup or --keep-resources.")
-            up = up_report(config, yes=args.yes, accept_fabric_capacity=args.accept_fabric_capacity, quiet=args.format == "json")
+            up = up_report(
+                config,
+                yes=args.yes,
+                accept_fabric_capacity=args.accept_fabric_capacity,
+                quiet=args.format == "json",
+                query=args.query,
+                expected_terms=args.expect_term,
+            )
             cleanup: dict[str, Any] | None = None
             if args.cleanup:
                 cleanup = down_report(config, yes=True, quiet=args.format == "json")

--- a/src/liveks/config.py
+++ b/src/liveks/config.py
@@ -107,6 +107,12 @@ def _validate_field(path: str, value: Any, spec: dict[str, Any]) -> Any:
         if not isinstance(value, str):
             raise ConfigError(f"{path} must be a string.")
         return value
+    if field_type == "string_list":
+        if not isinstance(value, list) or any(not isinstance(item, str) or not item.strip() for item in value):
+            raise ConfigError(f"{path} must be a list of non-empty strings.")
+        if len(value) != len(set(value)):
+            raise ConfigError(f"{path} must not contain duplicate values.")
+        return value
     if field_type == "guid":
         if not isinstance(value, str) or not GUID_RE.fullmatch(value):
             raise ConfigError(f"{path} must be a GUID.")
@@ -117,6 +123,29 @@ def _validate_field(path: str, value: Any, spec: dict[str, Any]) -> Any:
         parsed = urlparse(value)
         if parsed.scheme != "https" or not parsed.netloc:
             raise ConfigError(f"{path} must be an absolute HTTPS URL.")
+        return value.rstrip("/")
+    if field_type == "azure_search_url":
+        if not isinstance(value, str):
+            raise ConfigError(f"{path} must be an Azure AI Search HTTPS endpoint.")
+        parsed = urlparse(value)
+        hostname = (parsed.hostname or "").lower()
+        trusted_suffix = ".search.windows.net"
+        try:
+            port = parsed.port
+        except ValueError as error:
+            raise ConfigError(f"{path} must be a trusted Azure AI Search service endpoint.") from error
+        if (
+            parsed.scheme != "https"
+            or not hostname.endswith(trusted_suffix)
+            or parsed.username
+            or parsed.password
+            or port not in {None, 443}
+            or parsed.path not in {"", "/"}
+            or parsed.params
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ConfigError(f"{path} must be a trusted Azure AI Search service endpoint.")
         return value.rstrip("/")
     if field_type == "enum":
         if value not in spec.get("values", []):
@@ -228,12 +257,23 @@ class ResolvedConfig:
 
     def ownership(self) -> dict[str, str]:
         fabric_mode = self.get("fabric.mode")
-        return {
+        ownership = {
             "azure": "none" if self.profile == "offline" else "create",
             "fabricCapacity": "create" if fabric_mode == "create" else "reuse" if fabric_mode == "byo" else "none",
             "fabricWorkspace": "create" if fabric_mode == "create" else "reuse" if fabric_mode == "byo" else "none",
             "fabricOntology": "create" if fabric_mode == "create" else "reuse" if fabric_mode == "byo" else "none",
         }
+        if self.profile == "search-index":
+            ownership.update(
+                {
+                    "azure": "reuse",
+                    "searchService": "reuse",
+                    "searchIndex": "reuse",
+                    "knowledgeSources": "create",
+                    "knowledgeBases": "create",
+                }
+            )
+        return ownership
 
 
 def available_profiles() -> list[str]:
@@ -242,7 +282,7 @@ def available_profiles() -> list[str]:
         data = load_yaml(path)
         if data.get("kind", "deployment") == "deployment":
             names.append(str(data.get("profile", path.stem)))
-    preferred = ["offline", "mcp-only", "byo-fabric", "full"]
+    preferred = ["offline", "search-index", "mcp-only", "byo-fabric", "full"]
     return [name for name in preferred if name in names] + sorted(set(names) - set(preferred))
 
 
@@ -323,6 +363,13 @@ def resolve_config(
         values.setdefault("fabric.capacity_resource_group", f"rg-{environment}-fabric")
         sources.setdefault("fabric.capacity_name", "derived")
         sources.setdefault("fabric.capacity_resource_group", "derived")
+    if profile == "search-index":
+        if is_placeholder(values.get("search.index_knowledge_source_name")):
+            values["search.index_knowledge_source_name"] = f"{environment.lower()}-search-index-ks"
+            sources["search.index_knowledge_source_name"] = "derived"
+        if is_placeholder(values.get("search.index_knowledge_base_name")):
+            values["search.index_knowledge_base_name"] = f"{environment.lower()}-search-index-kb"
+            sources["search.index_knowledge_base_name"] = "derived"
 
     unknown = sorted(set(values) - set(fields))
     if unknown:
@@ -335,6 +382,11 @@ def resolve_config(
     mode = values.get("deployment.mode")
     if mode != profile:
         raise ConfigError(f"deployment.mode={mode!r} does not match profile={profile!r}.")
+    api_version = values.get("search.api_version")
+    if profile == "search-index" and api_version != "2026-04-01":
+        raise ConfigError("search-index profile requires the generally available 2026-04-01 API contract.")
+    if profile in {"mcp-only", "byo-fabric", "full"} and api_version != "2026-05-01-preview":
+        raise ConfigError(f"{profile} profile requires the 2026-05-01-preview API contract.")
     if profile == "full" and (values.get("fabric.workspace_id") or values.get("fabric.ontology_id")):
         raise ConfigError("full profile must not include BYO Fabric IDs; use byo-fabric instead.")
 
@@ -360,6 +412,14 @@ def write_user_config(path: Path, *, profile: str, environment: str) -> None:
         data["fabric"] = {"mode": "create", "location": "westus3"}
     elif profile == "mcp-only":
         data["azure"] = {"location": "eastus"}
+    elif profile == "search-index":
+        data["search"] = {
+            "endpoint": "",
+            "index_name": "",
+            "semantic_configuration_name": "",
+            "search_fields": [],
+            "source_data_fields": [],
+        }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
     path.chmod(0o600)

--- a/src/liveks/runtime.py
+++ b/src/liveks/runtime.py
@@ -44,6 +44,7 @@ class CommandRunner:
         check: bool = False,
         cwd: Path | None = None,
         timeout: int | None = None,
+        sensitive_output: bool = False,
     ) -> CommandResult:
         args = [str(part) for part in command]
         self.history.append(args)
@@ -57,7 +58,7 @@ class CommandRunner:
             timeout=timeout,
             check=False,
         )
-        if not self.quiet and result.stdout:
+        if not self.quiet and not sensitive_output and result.stdout:
             print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
         wrapped = CommandResult(args, result.returncode, result.stdout)
         if check and result.returncode != 0:

--- a/src/liveks/search_index.py
+++ b/src/liveks/search_index.py
@@ -1,0 +1,163 @@
+"""Stable Search Index Knowledge Source data-plane contract."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote
+
+from ks_factory import create_extracting_knowledge_base, create_search_index_knowledge_source
+
+from .config import ResolvedConfig
+from .runtime import CommandRunner, http_json
+
+
+def acquire_bearer_token(runner: CommandRunner) -> str:
+    """Acquire an Azure AI Search token without printing or persisting it."""
+    result = runner.run(
+        [
+            "az",
+            "account",
+            "get-access-token",
+            "--scope",
+            "https://search.azure.com/.default",
+            "--query",
+            "accessToken",
+            "-o",
+            "tsv",
+        ],
+        sensitive_output=True,
+    )
+    token = result.stdout.strip()
+    if result.returncode != 0 or not token:
+        raise RuntimeError("Unable to acquire an Azure AI Search bearer token.")
+    return token
+
+
+def request(
+    config: ResolvedConfig,
+    token: str,
+    *,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None = None,
+    attempts: int = 1,
+    timeout: int = 120,
+) -> tuple[int, Any]:
+    endpoint = str(config.get("search.endpoint")).rstrip("/")
+    api_version = quote(str(config.get("search.api_version")), safe="")
+    try:
+        return http_json(
+            f"{endpoint}{path}?api-version={api_version}",
+            method=method,
+            body=body,
+            headers={"Authorization": f"Bearer {token}"},
+            attempts=attempts,
+            delay_seconds=2,
+            timeout=timeout,
+        )
+    except Exception as error:
+        raise RuntimeError("Azure AI Search request could not be completed.") from error
+
+
+def object_path(kind: str, name: str) -> str:
+    if kind not in {"indexes", "knowledgesources", "knowledgebases"}:
+        raise ValueError(f"Unsupported Search object kind: {kind}")
+    return f"/{kind}/{quote(name, safe='')}"
+
+
+def build_payloads(config: ResolvedConfig, *, query: str) -> dict[str, dict[str, Any]]:
+    knowledge_source_name = str(config.get("search.index_knowledge_source_name"))
+    knowledge_base_name = str(config.get("search.index_knowledge_base_name"))
+    knowledge_source = create_search_index_knowledge_source(
+        name=knowledge_source_name,
+        search_index_name=str(config.get("search.index_name")),
+        semantic_configuration_name=str(config.get("search.semantic_configuration_name")),
+        search_fields=list(config.get("search.search_fields", [])),
+        source_data_fields=list(config.get("search.source_data_fields", [])),
+        description="Stable Knowledge Source over an existing Azure AI Search index.",
+    )
+    knowledge_base = create_extracting_knowledge_base(
+        name=knowledge_base_name,
+        knowledge_source_names=[knowledge_source_name],
+        description="Stable Knowledge Base for extractive retrieval from an existing search index.",
+    )
+    retrieve = {
+        "intents": [{"type": "semantic", "search": query}],
+        "knowledgeSourceParams": [
+            {
+                "knowledgeSourceName": knowledge_source_name,
+                "kind": "searchIndex",
+            }
+        ],
+    }
+    return {"knowledgeSource": knowledge_source, "knowledgeBase": knowledge_base, "retrieve": retrieve}
+
+
+def inspect_index(index: Any, config: ResolvedConfig) -> list[tuple[str, str, str]]:
+    """Return credential-free assertions for the existing index definition."""
+    if not isinstance(index, dict):
+        return [("search-index-definition", "fail", "The index definition was not a JSON object.")]
+
+    fields = {
+        str(field.get("name")): field
+        for field in index.get("fields", [])
+        if isinstance(field, dict) and field.get("name")
+    }
+    semantic = index.get("semantic") if isinstance(index.get("semantic"), dict) else {}
+    configurations = {
+        str(item.get("name"))
+        for item in semantic.get("configurations", [])
+        if isinstance(item, dict) and item.get("name")
+    }
+    semantic_name = str(config.get("search.semantic_configuration_name"))
+    checks: list[tuple[str, str, str]] = [
+        (
+            "semantic-configuration",
+            "pass" if semantic_name in configurations else "fail",
+            "Configured semantic configuration exists."
+            if semantic_name in configurations
+            else "Configured semantic configuration was not found on the index.",
+        )
+    ]
+
+    requested_search_fields = list(config.get("search.search_fields", []))
+    missing_search = [name for name in requested_search_fields if name not in fields]
+    nonsearchable = [name for name in requested_search_fields if name in fields and not fields[name].get("searchable")]
+    search_ok = not missing_search and not nonsearchable
+    checks.append(
+        (
+            "search-fields",
+            "pass" if search_ok else "fail",
+            "Configured search fields exist and are searchable."
+            if search_ok
+            else "One or more configured search fields are missing or not searchable.",
+        )
+    )
+
+    requested_source_fields = list(config.get("search.source_data_fields", []))
+    missing_source = [name for name in requested_source_fields if name not in fields]
+    nonretrievable = [name for name in requested_source_fields if name in fields and fields[name].get("retrievable") is False]
+    source_ok = not missing_source and not nonretrievable
+    checks.append(
+        (
+            "source-data-fields",
+            "pass" if source_ok else "fail",
+            "Configured source-data fields exist and are retrievable."
+            if source_ok
+            else "One or more configured source-data fields are missing or not retrievable.",
+        )
+    )
+    return checks
+
+
+def response_text(payload: Any) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    blocks: list[str] = []
+    for message in payload.get("response", []):
+        if not isinstance(message, dict):
+            continue
+        for item in message.get("content", []):
+            if isinstance(item, dict) and item.get("type") == "text":
+                blocks.append(str(item.get("text", "")))
+    return "\n".join(blocks)

--- a/tests/test_ks_factory.py
+++ b/tests/test_ks_factory.py
@@ -7,13 +7,46 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
 from ks_factory import (  # noqa: E402
+    create_extracting_knowledge_base,
     create_fabric_ontology_knowledge_source,
     create_knowledge_base,
     create_mcp_server_knowledge_source,
+    create_search_index_knowledge_source,
 )
 
 
 class KnowledgeSourceFactoryTests(unittest.TestCase):
+    def test_search_index_knowledge_source_payload_shape(self):
+        payload = create_search_index_knowledge_source(
+            name="existing-docs-ks",
+            search_index_name="existing-docs",
+            semantic_configuration_name="default-semantic",
+            search_fields=["content"],
+            source_data_fields=["id", "title"],
+        )
+
+        self.assertEqual(payload["kind"], "searchIndex")
+        self.assertEqual(
+            payload["searchIndexParameters"],
+            {
+                "searchIndexName": "existing-docs",
+                "semanticConfigurationName": "default-semantic",
+                "searchFields": [{"name": "content"}],
+                "sourceDataFields": [{"name": "id"}, {"name": "title"}],
+            },
+        )
+
+    def test_extracting_knowledge_base_omits_preview_properties(self):
+        payload = create_extracting_knowledge_base(
+            name="existing-docs-kb",
+            knowledge_source_names=["existing-docs-ks"],
+        )
+
+        self.assertEqual(payload["knowledgeSources"], [{"name": "existing-docs-ks"}])
+        self.assertNotIn("models", payload)
+        self.assertNotIn("outputMode", payload)
+        self.assertNotIn("retrievalReasoningEffort", payload)
+
     def test_mcp_server_knowledge_source_payload_shape(self):
         payload = create_mcp_server_knowledge_source(
             name="microsoft-learn-mcp-ks",

--- a/tests/test_liveks_config.py
+++ b/tests/test_liveks_config.py
@@ -17,7 +17,7 @@ from liveks.runtime import CommandResult  # noqa: E402
 
 class LiveKsConfigTests(unittest.TestCase):
     def test_profiles_are_ordered_and_include_full(self):
-        self.assertEqual(available_profiles(), ["offline", "mcp-only", "byo-fabric", "full"])
+        self.assertEqual(available_profiles(), ["offline", "search-index", "mcp-only", "byo-fabric", "full"])
 
     def test_mcp_profile_resolves_to_azd_values(self):
         config = resolve_config(profile="mcp-only", environment="unit-mcp")

--- a/tests/test_search_index_profile.py
+++ b/tests/test_search_index_profile.py
@@ -1,0 +1,317 @@
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from liveks import cli  # noqa: E402
+from liveks.config import ConfigError, resolve_config  # noqa: E402
+from liveks.runtime import CommandRunner  # noqa: E402
+from liveks.search_index import acquire_bearer_token, build_payloads, inspect_index  # noqa: E402
+
+
+def authored_config(root: Path, *, api_version: str = "2026-04-01"):
+    path = root / "search-index.yaml"
+    path.write_text(
+        "\n".join(
+            [
+                "version: 2",
+                "profile: search-index",
+                "environment: unit-search",
+                "search:",
+                f"  api_version: '{api_version}'",
+                "  endpoint: https://example.search.windows.net",
+                "  index_name: existing-docs",
+                "  semantic_configuration_name: default-semantic",
+                "  search_fields: [content]",
+                "  source_data_fields: [id, title]",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return resolve_config(profile=None, environment=None, config_path=path)
+
+
+class SearchIndexConfigurationTests(unittest.TestCase):
+    def test_profile_requires_existing_index_inputs(self):
+        with self.assertRaisesRegex(ConfigError, "search.endpoint, search.index_name, search.semantic_configuration_name"):
+            resolve_config(profile="search-index", environment="unit-search")
+
+    def test_profile_resolves_stable_contract_and_reuse_ownership(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = authored_config(Path(temp_dir))
+
+        self.assertEqual(config.get("search.api_version"), "2026-04-01")
+        self.assertEqual(config.get("search.index_knowledge_source_name"), "unit-search-search-index-ks")
+        self.assertEqual(config.get("search.index_knowledge_base_name"), "unit-search-search-index-kb")
+        self.assertEqual(config.ownership()["searchIndex"], "reuse")
+        self.assertEqual(config.ownership()["knowledgeSources"], "create")
+
+    def test_profile_rejects_preview_api(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(ConfigError, "generally available 2026-04-01"):
+                authored_config(Path(temp_dir), api_version="2026-05-01-preview")
+
+    def test_profile_rejects_untrusted_https_endpoint(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "search-index.yaml"
+            path.write_text(
+                "version: 2\n"
+                "profile: search-index\n"
+                "environment: unit-search\n"
+                "search:\n"
+                "  endpoint: https://token-collector.example\n"
+                "  index_name: existing-docs\n"
+                "  semantic_configuration_name: default-semantic\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ConfigError, "trusted Azure AI Search"):
+                resolve_config(profile=None, environment=None, config_path=path)
+
+    def test_init_accepts_explicit_config_path_outside_repository(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            destination = Path(temp_dir) / "external-search-index.yaml"
+            with mock.patch("sys.stdout"):
+                result = cli.main(
+                    [
+                        "init",
+                        "--profile",
+                        "search-index",
+                        "--env",
+                        "external-index",
+                        "--config",
+                        str(destination),
+                        "--format",
+                        "json",
+                    ]
+                )
+            self.assertEqual(result, 0)
+            self.assertTrue(destination.exists())
+
+    def test_payloads_use_intents_and_no_preview_kb_properties(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = authored_config(Path(temp_dir))
+        payloads = build_payloads(config, query="What is indexed?")
+
+        self.assertEqual(payloads["knowledgeSource"]["kind"], "searchIndex")
+        self.assertEqual(payloads["retrieve"]["intents"][0]["search"], "What is indexed?")
+        self.assertNotIn("messages", payloads["retrieve"])
+        self.assertFalse(
+            {"models", "outputMode", "retrievalReasoningEffort"}.intersection(payloads["knowledgeBase"])
+        )
+
+    def test_bearer_token_command_marks_stdout_as_sensitive(self):
+        runner = mock.Mock()
+        runner.run.return_value = mock.Mock(returncode=0, stdout="sensitive-token\n")
+
+        self.assertEqual(acquire_bearer_token(runner), "sensitive-token")
+        self.assertTrue(runner.run.call_args.kwargs["sensitive_output"])
+
+    def test_sensitive_command_output_is_not_printed(self):
+        completed = mock.Mock(returncode=0, stdout="sensitive-token\n")
+        with (
+            mock.patch("liveks.runtime.subprocess.run", return_value=completed),
+            mock.patch("sys.stdout", new_callable=io.StringIO) as output,
+        ):
+            runner = CommandRunner(root=ROOT, env={}, quiet=False)
+            runner.run(["az", "account", "get-access-token"], sensitive_output=True)
+
+        self.assertEqual(output.getvalue(), "")
+
+    def test_index_contract_checks_semantic_and_field_capabilities(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = authored_config(Path(temp_dir))
+        index = {
+            "fields": [
+                {"name": "id", "retrievable": True},
+                {"name": "title", "retrievable": True},
+                {"name": "content", "searchable": True, "retrievable": True},
+            ],
+            "semantic": {"configurations": [{"name": "default-semantic"}]},
+        }
+
+        self.assertTrue(all(status == "pass" for _, status, _ in inspect_index(index, config)))
+
+
+class SearchIndexLifecycleTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.config = authored_config(self.root)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_plan_checks_names_without_mutation(self):
+        passing_doctor = {"status": "pass", "checks": [{"name": "doctor", "status": "pass", "message": "ok"}]}
+        request_calls = []
+
+        def fake_request(config, token, *, method, path, **kwargs):
+            request_calls.append((method, path))
+            return 404, {}
+
+        with (
+            mock.patch.object(cli, "ROOT", self.root),
+            mock.patch.object(cli, "doctor_report", return_value=passing_doctor),
+            mock.patch.object(cli, "_load_lock", return_value=None),
+            mock.patch.object(cli, "acquire_search_bearer_token", return_value="token"),
+            mock.patch.object(cli, "search_index_request", side_effect=fake_request),
+            mock.patch.object(cli, "write_lock", return_value=self.root / ".liveks/unit-search.lock.json"),
+        ):
+            report = cli.plan_report(self.config)
+
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual([method for method, _ in request_calls], ["GET", "GET"])
+        plan = json.loads((self.root / ".deployment/unit-search/search-index-plan.json").read_text())
+        self.assertEqual(plan["apiVersion"], "2026-04-01")
+
+    def test_up_records_only_created_knowledge_objects(self):
+        responses = iter([(404, {}), (201, {}), (404, {}), (201, {})])
+        locks = []
+
+        def fake_write_lock(config, *, status, extra=None):
+            locks.append((status, dict((extra or {}).get("managedObjects", {}))))
+            return self.root / ".liveks/unit-search.lock.json"
+
+        with (
+            mock.patch.object(cli, "plan_report", return_value={"status": "pass", "checks": []}),
+            mock.patch.object(cli, "_search_index_lock_state", return_value=({}, True, "matching environment lock")),
+            mock.patch.object(cli, "_confirm_up"),
+            mock.patch.object(cli, "acquire_search_bearer_token", return_value="token"),
+            mock.patch.object(cli, "search_index_request", side_effect=lambda *args, **kwargs: next(responses)),
+            mock.patch.object(cli, "verify_report", return_value={"status": "pass", "checks": []}) as verify_mock,
+            mock.patch.object(cli, "write_lock", side_effect=fake_write_lock),
+        ):
+            report = cli.up_report(
+                self.config,
+                yes=True,
+                accept_fabric_capacity=False,
+                query="What is the policy?",
+                expected_terms=["retention"],
+            )
+
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual(
+            locks[-1][1],
+            {
+                "knowledgeSource": "unit-search-search-index-ks",
+                "knowledgeBase": "unit-search-search-index-kb",
+            },
+        )
+        verify_mock.assert_called_once_with(
+            self.config,
+            quiet=True,
+            query="What is the policy?",
+            expected_terms=["retention"],
+        )
+
+    def test_down_deletes_recorded_objects_and_preserves_index(self):
+        managed = {
+            "knowledgeSource": "unit-search-search-index-ks",
+            "knowledgeBase": "unit-search-search-index-kb",
+        }
+        request_calls = []
+        responses = iter([(204, {}), (204, {}), (200, {"name": "existing-docs"})])
+
+        def fake_request(config, token, *, method, path, **kwargs):
+            request_calls.append((method, path))
+            return next(responses)
+
+        with (
+            mock.patch.object(cli, "_search_index_lock_state", return_value=(managed, True, "matching environment lock")),
+            mock.patch.object(cli, "acquire_search_bearer_token", return_value="token"),
+            mock.patch.object(cli, "search_index_request", side_effect=fake_request),
+            mock.patch.object(cli, "write_lock", return_value=self.root / ".liveks/unit-search.lock.json"),
+        ):
+            report = cli.down_report(self.config, yes=True)
+
+        self.assertEqual(report["status"], "pass")
+        self.assertEqual([method for method, _ in request_calls], ["DELETE", "DELETE", "GET"])
+        self.assertTrue(request_calls[-1][1].endswith("/indexes/existing-docs"))
+        self.assertEqual(next(check for check in report["checks"] if check["name"] == "search-index-preserved")["status"], "pass")
+
+    def test_down_preserves_everything_without_matching_lock(self):
+        with (
+            mock.patch.object(cli, "_search_index_lock_state", return_value=({}, False, "mismatch")),
+            mock.patch.object(cli, "search_index_request") as request_mock,
+        ):
+            report = cli.down_report(self.config, yes=True)
+
+        self.assertEqual(report["status"], "cleanup-incomplete")
+        request_mock.assert_not_called()
+
+    def test_verify_calls_search_index_and_persists_only_sanitized_counts(self):
+        responses = iter(
+            [
+                (200, {"name": "existing-docs"}),
+                (
+                    200,
+                    {
+                        "name": "unit-search-search-index-ks",
+                        "kind": "searchIndex",
+                        "searchIndexParameters": {
+                            "searchIndexName": "existing-docs",
+                            "semanticConfigurationName": "default-semantic",
+                        },
+                    },
+                ),
+                (
+                    200,
+                    {
+                        "name": "unit-search-search-index-kb",
+                        "knowledgeSources": [{"name": "unit-search-search-index-ks"}],
+                    },
+                ),
+                (
+                    200,
+                    {
+                        "response": [
+                            {
+                                "role": "assistant",
+                                "content": [{"type": "text", "text": "The private-known-term is grounded."}],
+                            }
+                        ],
+                        "activity": [{"type": "searchIndex", "knowledgeSourceName": "unit-search-search-index-ks"}],
+                        "references": [],
+                    },
+                ),
+            ]
+        )
+        with (
+            mock.patch.object(cli, "ROOT", self.root),
+            mock.patch.object(cli, "acquire_search_bearer_token", return_value="token"),
+            mock.patch.object(cli, "search_index_request", side_effect=lambda *args, **kwargs: next(responses)),
+        ):
+            report = cli.verify_report(
+                self.config,
+                query="private validation question",
+                expected_terms=["private-known-term"],
+            )
+
+        self.assertEqual(report["status"], "pass")
+        persisted = (self.root / "deployments/unit-search/verify-report.json").read_text(encoding="utf-8")
+        self.assertNotIn("private validation question", persisted)
+        self.assertNotIn("private-known-term", persisted)
+        self.assertNotIn("example.search.windows.net", persisted)
+        grounding = next(check for check in report["checks"] if check["name"] == "grounding-content")
+        self.assertEqual(grounding["matchedExpectedTermCount"], 1)
+
+    def test_mcp_command_explains_stable_profile_boundary_without_azd(self):
+        with mock.patch.object(cli, "CommandRunner") as runner:
+            report = cli.mcp_report(self.config, persist=False)
+
+        self.assertEqual(report["status"], "fail")
+        self.assertEqual(report["checks"][0]["name"], "profile-contract")
+        self.assertIn("use liveks verify", report["checks"][0]["message"])
+        runner.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a `search-index` profile for the generally available Azure AI Search `2026-04-01` contract
- reuse an existing Search service and agentic-ready index while creating only a Search Index Knowledge Source and minimal extractive Knowledge Base
- add read-only doctor and plan checks, stable `intents` retrieval, runtime query/expected-term acceptance, lock-proved cleanup, and preserved-index evidence
- suppress bearer-token stdout and keep query, terms, content, endpoints, and credentials out of persisted verification reports
- update the execution manual, API matrix, configuration examples, issue/PR templates, and clone-to-proof hero to distinguish the stable path from preview MCP and Fabric paths

## Safety

- `plan` performs only read operations against the existing Search service and writes ignored local artifacts
- generated object names cannot overwrite unowned Knowledge Sources or Knowledge Bases
- `down` requires a matching configuration lock, deletes the Knowledge Base before the Knowledge Source, and verifies that the existing index remains readable
- no cloud resources were created or mutated during this local validation

## Validation

- `bash scripts/validate-local.sh --no-color` (17/17 gates pass)
- `python3 -m unittest discover -s tests` (95 tests pass)
- `python3 tools/validate.py --profile offline --format json`
- `mkdocs build --strict --site-dir /tmp/liveks-search-index-site`
- `python3 scripts/generate_env_examples.py --check`
- `git diff --check`

## API sources

- [Create a Search Index Knowledge Source](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-search-index)
- [Create a Knowledge Base](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-create-knowledge-base)
- [Query a Knowledge Base](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-retrieve)
- [Migrate agentic retrieval code](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-migrate)
- [Enable or disable agentic retrieval billing](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-enable-disable)