### PR TITLE
Add protected lifecycle canary

### DIFF
--- a/.github/workflows/protected-mcp-search-index.yml
+++ b/.github/workflows/protected-mcp-search-index.yml
@@ -1,18 +1,39 @@
-name: Protected MCP and Search Index contract
+name: Protected MCP and Search Index lifecycle canary
+run-name: Protected lifecycle canary ${{ github.run_id }}.${{ github.run_attempt }}
 
 on:
   workflow_dispatch:
+    inputs:
+      confirmation:
+        description: Run the protected lifecycle and delete generated objects
+        required: true
+        type: choice
+        default: not-approved
+        options:
+          - not-approved
+          - run-with-cleanup
 
 permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: protected-mcp-search-index-live
+  cancel-in-progress: false
+
 jobs:
-  live-contract:
-    name: Independent sources then combined routing
+  live-canary:
+    name: Guarded lifecycle, cleanup, and sanitized evidence
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.repository_owner == 'microsoft' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.confirmation == 'run-with-cleanup'
     runs-on: ubuntu-latest
     environment: mcp-search-index-live
-    timeout-minutes: 15
+    timeout-minutes: 35
+    env:
+      LIVEKS_CANARY_ENVIRONMENT: canary-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Check out repository
@@ -23,64 +44,96 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Sign in to Azure with OIDC
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Install LiveKS dependencies
         run: python -m pip install --disable-pip-version-check -r requirements-liveks.txt
 
-      - name: Create ignored protected ledger
+      - name: Preflight protected configuration
+        id: preflight
         env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           SEARCH_ENDPOINT: ${{ secrets.SEARCH_ENDPOINT }}
           SEARCH_INDEX_NAME: ${{ secrets.SEARCH_INDEX_NAME }}
           SEARCH_SEMANTIC_CONFIGURATION_NAME: ${{ secrets.SEARCH_SEMANTIC_CONFIGURATION_NAME }}
           AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           AZURE_OPENAI_DEPLOYMENT_ID: ${{ secrets.AZURE_OPENAI_DEPLOYMENT_ID }}
           AZURE_OPENAI_MODEL_NAME: ${{ secrets.AZURE_OPENAI_MODEL_NAME }}
-          SEARCH_INDEX_KNOWLEDGE_SOURCE_NAME: ${{ secrets.SEARCH_INDEX_KNOWLEDGE_SOURCE_NAME }}
-          MCP_KNOWLEDGE_SOURCE_NAME: ${{ secrets.MCP_KNOWLEDGE_SOURCE_NAME }}
-          KNOWLEDGE_BASE_NAME: ${{ secrets.KNOWLEDGE_BASE_NAME }}
-        run: |
-          python - <<'PY'
-          import os
-          from pathlib import Path
-
-          import yaml
-
-          data = {
-              "version": 2,
-              "profile": "mcp-search-index",
-              "environment": "protected-combined",
-              "search": {
-                  "endpoint": os.environ["SEARCH_ENDPOINT"],
-                  "index_name": os.environ["SEARCH_INDEX_NAME"],
-                  "semantic_configuration_name": os.environ["SEARCH_SEMANTIC_CONFIGURATION_NAME"],
-                  "index_knowledge_source_name": os.environ["SEARCH_INDEX_KNOWLEDGE_SOURCE_NAME"],
-                  "mcp_knowledge_source_name": os.environ["MCP_KNOWLEDGE_SOURCE_NAME"],
-                  "combined_knowledge_base_name": os.environ["KNOWLEDGE_BASE_NAME"],
-              },
-              "openai": {
-                  "endpoint": os.environ["AZURE_OPENAI_ENDPOINT"],
-                  "deployment_name": os.environ["AZURE_OPENAI_DEPLOYMENT_ID"],
-                  "model_name": os.environ["AZURE_OPENAI_MODEL_NAME"],
-              },
-          }
-          path = Path(".liveks/protected-mcp-search-index.yaml")
-          path.parent.mkdir(parents=True, exist_ok=True)
-          path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
-          path.chmod(0o600)
-          PY
-
-      - name: Prove sources independently before combined routing
-        env:
-          LIVEKS_RUN_PROTECTED_MCP_SEARCH_INDEX: "1"
-          LIVEKS_PROTECTED_CONFIG: .liveks/protected-mcp-search-index.yaml
           LIVEKS_INDEX_QUERY: ${{ secrets.LIVEKS_INDEX_QUERY }}
           LIVEKS_INDEX_EXPECT_TERM: ${{ secrets.LIVEKS_INDEX_EXPECT_TERM }}
           LIVEKS_MCP_QUERY: ${{ secrets.LIVEKS_MCP_QUERY }}
           LIVEKS_COMBINED_QUERY: ${{ secrets.LIVEKS_COMBINED_QUERY }}
-        run: python -m unittest tests.test_mcp_search_index_live_contract
+        run: >-
+          python scripts/protected_canary.py preflight
+          --environment "$LIVEKS_CANARY_ENVIRONMENT"
+
+      - name: Sign in to Azure with OIDC
+        id: azure_login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Run guarded lifecycle with cleanup
+        id: lifecycle
+        continue-on-error: true
+        env:
+          LIVEKS_RUN_PROTECTED_MCP_SEARCH_INDEX_LIFECYCLE: "1"
+          LIVEKS_PROTECTED_CONFIG: .liveks/${{ env.LIVEKS_CANARY_ENVIRONMENT }}.yaml
+          LIVEKS_INDEX_QUERY: ${{ secrets.LIVEKS_INDEX_QUERY }}
+          LIVEKS_INDEX_EXPECT_TERM: ${{ secrets.LIVEKS_INDEX_EXPECT_TERM }}
+          LIVEKS_MCP_QUERY: ${{ secrets.LIVEKS_MCP_QUERY }}
+          LIVEKS_COMBINED_QUERY: ${{ secrets.LIVEKS_COMBINED_QUERY }}
+        run: >-
+          timeout --signal=INT --kill-after=30s 1200s
+          python -m unittest
+          tests.test_mcp_search_index_live_contract.ProtectedMcpSearchIndexLifecycleCanaryTests
+
+      - name: Always retry guarded cleanup
+        id: cleanup
+        if: always() && steps.preflight.outcome == 'success' && steps.azure_login.outcome == 'success'
+        continue-on-error: true
+        run: |
+          mkdir -p .deployment
+          set +e
+          timeout --signal=INT --kill-after=30s 480s \
+            ./liveks down \
+              --config ".liveks/${LIVEKS_CANARY_ENVIRONMENT}.yaml" \
+              --env "$LIVEKS_CANARY_ENVIRONMENT" \
+              --yes \
+              --format json \
+            > .deployment/canary-cleanup.json
+          exit_code=$?
+          echo "exit-code=${exit_code}" >> "$GITHUB_OUTPUT"
+          exit "$exit_code"
+
+      - name: Always build sanitized canary evidence
+        id: evidence
+        if: always()
+        run: >-
+          python scripts/protected_canary.py evidence
+          --environment "$LIVEKS_CANARY_ENVIRONMENT"
+          --preflight-outcome "${{ steps.preflight.outcome || 'skipped' }}"
+          --login-outcome "${{ steps.azure_login.outcome || 'skipped' }}"
+          --lifecycle-outcome "${{ steps.lifecycle.outcome || 'skipped' }}"
+          --cleanup-outcome "${{ steps.cleanup.outcome || 'skipped' }}"
+          --output .deployment/canary-evidence.json
+          --detail .deployment/canary-detail.json
+          --summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload sanitized canary capsule
+        if: always() && hashFiles('.deployment/canary-evidence.json') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: protected-canary-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .deployment/canary-evidence.json
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 14
+
+      - name: Enforce canary result
+        if: always()
+        run: >-
+          python scripts/protected_canary.py final-status
+          --capsule .deployment/canary-evidence.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@ Rules:
 - Require the separate full-capacity acknowledgement even with `--yes`.
 - Use exactly one of `--cleanup` or `--keep-resources` for E2E.
 - Prefer `--cleanup`; if resources are retained, identify the cleanup owner.
+- Protected lifecycle canaries are manual `workflow_dispatch` runs on `main`, require the `mcp-search-index-live` GitHub Environment, and always use `--cleanup`.
+- Never run the protected canary from a fork, pull request, untrusted ref, or ordinary repository validation.
 
 ## Ownership Rules
 
@@ -109,6 +111,7 @@ Use the evidence that matches the claim:
 | Stable Search Index path is live | `liveks verify` reports `search-index-retrieve=pass`; use `--expect-term` for content acceptance |
 | Existing Search index survived cleanup | `liveks down` reports `search-index-preserved=pass` |
 | MCP + Search Index path is live | Independent `search-index-retrieve` and `mcp-retrieve` checks pass before `combined-retrieve`; the combined check reports only activity, references, or sourceData evidence |
+| Protected lifecycle canary is live | An approved manual run completes guarded E2E cleanup and uploads only `canary-evidence.json`; repository tests prove contract shape, not live execution |
 | Deployment is ready | Passing `liveks doctor` and `liveks plan` |
 | MCP path is live | MCP activity or references from `liveks verify` |
 | Fabric path is live | `fabricOntology` evidence in live mode with delegated authorization |
@@ -127,6 +130,7 @@ Do not publish or commit:
 - customer data or real tenant, subscription, workspace, or ontology IDs,
 - keys, bearer tokens, connection strings, or raw delegated tokens,
 - raw live retrieve responses or unsanitized screenshots,
+- protected canary detailed reports or step inputs; upload only the allowlist-sanitized capsule,
 - `.liveks/`, `.azure/`, `.deployment/`, `deployments/`, local dotenv files, or generated builds,
 - internal/private-preview Fabric setup, tenant allowlisting, or unpublished endpoints,
 - Fabric MCP through MCP Server KS as the recommended Fabric path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this accelerator are documented here.
 
 ### Added
 
+- A manual, GitHub Environment-gated `mcp-search-index` lifecycle canary with generated per-run environments, fixed concurrency, finite timeouts, explicit secret-name preflight, real `e2e --cleanup` execution, always-run guarded cleanup, and allowlist-only uploaded evidence.
+- Bounded retry classification for network timeouts and HTTP `408`, `429`, `500`, `502`, `503`, and `504`, including capped `Retry-After`, exponential backoff, deterministic failure boundaries, conditional-write idempotency checks, and sanitized retry telemetry. See the official [Azure AI Search HTTP status codes](https://learn.microsoft.com/rest/api/searchservice/http-status-codes).
 - A data-plane-only `mcp-search-index` profile that reuses an agentic-ready Search index and Azure OpenAI deployment, creates a GA Search Index KS plus preview MCP Server KS and combined KB, and proves each source independently before combined routing.
 - Version-aware collision protection, ETag-conditional three-object lock ownership, ambiguous PUT reconciliation, redacted plan payloads, sourceData-based index assertions, dependency-ordered cleanup, and an opt-in OIDC protected live contract for the combined profile.
 - The [MCP + Search Index execution manual](https://microsoft.github.io/azure-ai-search-foundry-iq-live-knowledge-sources/24-mcp-search-index-kb/) backed by official Microsoft Learn contracts for [Search Index KS](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-search-index), [MCP Server KS](https://learn.microsoft.com/azure/search/agentic-knowledge-source-how-to-mcp-server), [Knowledge Base creation](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-create-knowledge-base), and [retrieve](https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-retrieve).
@@ -35,6 +37,7 @@ All notable changes to this accelerator are documented here.
 
 ### Changed
 
+- The existing protected read-only retrieve test remains available, while the same test module now owns the opt-in full lifecycle canary contract. Normal CI runs neither credentialed path.
 - Profile selection, CLI/configuration documentation, generated environment catalogs, and API matrices now describe the guarded `search-index -> mcp-search-index` expansion without changing any existing profile.
 - Direct Search requests now accept an explicit API version so the combined lifecycle uses `2026-04-01` only for the Search Index KS and `2026-05-01-preview` only for MCP KS, combined KB, and retrieve.
 - Every profile now serializes environment `plan`, `up`, and `down`; E2E holds the same lock through optional cleanup. Direct Search profiles use ETag-conditional create and delete requests and reuse unchanged owned objects without another PUT.
@@ -65,6 +68,7 @@ All notable changes to this accelerator are documented here.
 
 ### Compatibility
 
+- Repository validation proves canary and resilience contract shape only. Protected live execution remains **NOT RUN** until an approved manual Environment run succeeds.
 - `mcp-search-index` requires both pinned versions, an existing Azure OpenAI chat deployment, and Search managed identity access to that model; it never falls back to the standalone stable or provisioned preview request shape.
 - Normal CI skips the protected live contract. Manual protected execution performs read/call verification only and does not create or delete cloud resources.
 - Search Index KS uses generally available `2026-04-01`, `intents`, and minimal extractive retrieval; MCP Server and Fabric Ontology profiles remain on `2026-05-01-preview` with `messages` and answer synthesis.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ This profile creates only a GA `2026-04-01` Search Index KS, a `2026-05-01-previ
 
 Cleanup deletes the lock-owned combined KB, MCP KS, and Search Index KS in dependency order, then requires `search-index-preserved=pass`. It never deletes the Search service, index, Azure OpenAI deployment, resource group, or Fabric. Read the [MCP + Search Index execution contract](docs/24-mcp-search-index-kb.md).
 
+### Protected Lifecycle Canary
+
+Maintainers can manually dispatch **Protected MCP and Search Index lifecycle canary** from `main` after approval in the `mcp-search-index-live` GitHub Environment. The job generates a unique environment name, validates required secret names before Azure login, runs the guarded `mcp-search-index` E2E path with `--cleanup --yes`, retries only bounded transient and semantically safe operations, and performs an additional always-run cleanup.
+
+The only uploaded artifact is `canary-evidence.json`, which contains revision, assertion statuses, source types/counts, retry categories/counts, ownership classes, cost-sensitive classes, cleanup status, and a detailed-report digest. It excludes questions, answers, raw payloads, endpoints, resource names, credentials, tenant/subscription IDs, GUIDs, and customer data.
+
+Repository tests validate this workflow and evidence shape without credentials or Azure calls. **Protected live canary: NOT RUN by normal CI.** An approved manual run is still required before making a live lifecycle or resilience claim.
+
 ## First Preview Live: MCP-Only
 
 Use the checked-in Codespaces environment to avoid installing Python, Node.js, Azure CLI, Bicep, and Azure Developer CLI yourself. Container creation runs only replay, dependency bootstrap, profile listing, and offline doctor; it never signs in or creates cloud resources.
@@ -319,6 +327,8 @@ For a controlled end-to-end rehearsal:
 ```bash
 ./liveks e2e --env liveks-mcp --cleanup --yes
 ```
+
+The protected canary never uses `--keep-resources`, `full`, or a Fabric profile.
 
 Use exactly one of `--cleanup` or `--keep-resources`. Prefer cleanup and record the owner whenever resources are retained.
 

--- a/docs/06-security-governance.md
+++ b/docs/06-security-governance.md
@@ -49,6 +49,18 @@ flowchart LR
 - Keep sample responses synthetic.
 - GitHub Pages runs canonical offline fixtures only. Live credentials and Search requests remain behind the Azure managed API.
 
+## Protected Canary Isolation
+
+- The lifecycle canary has only a manual `workflow_dispatch` trigger and a job condition restricted to the Microsoft repository `main` ref.
+- The credentialed job references the `mcp-search-index-live` GitHub Environment. Configure required reviewers and restrict deployment branches before adding secrets.
+- Missing environment configuration fails in preflight before Azure login. Messages contain variable names only.
+- One concurrency group prevents overlapping runs against the shared BYO target; each run still derives unique generated KS/KB names.
+- The canary uses `--cleanup` only and has bounded command and job timeouts plus an `always()` cleanup.
+- Only the allowlist-sanitized capsule is uploaded. Detailed reports, ledgers, locks, queries, answers, endpoints, identifiers, and raw payloads remain runner-local.
+- Ordinary pull-request and fork validation receives no canary secrets and runs no credentialed job.
+
+See GitHub's official guidance for [deployment environments](https://docs.github.com/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments) and [workflow concurrency](https://docs.github.com/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).
+
 ## Cleanup Governance
 
 - `byo-fabric` owns no Fabric capacity, workspace, or ontology and must never delete them.

--- a/docs/07-troubleshooting.md
+++ b/docs/07-troubleshooting.md
@@ -106,6 +106,18 @@ Start with machine-readable diagnostics:
 - Separate MCP and Fabric checks prove both live paths. A combined KB check passes with recognized live evidence from one or both because the Knowledge Base planner chooses which attached source to call for each query.
 - Cleanup must pass for release rehearsal runs. Use `--keep-resources` only while debugging.
 
+## Protected Canary Fails
+
+- A preflight failure lists missing environment configuration names only. Add them to the protected `mcp-search-index-live` GitHub Environment; do not move values into repository YAML.
+- The credentialed job is intentionally unavailable outside manual `workflow_dispatch` on `main` with `run-with-cleanup`.
+- HTTP `408`, `429`, `500`, `502`, `503`, and `504`, plus network timeouts, are transient categories only when the operation is a read or a lock/ETag-guarded conditional write.
+- A valid `Retry-After` is honored up to the hard cap. Otherwise bounded exponential backoff is used.
+- Deterministic `4xx` responses are not retried. Conditional conflicts remain ownership failures, not transient success.
+- `http-*-exhausted` or `network-timeout-exhausted` in the capsule is the terminal retry classification. Inspect the ignored detailed report locally; never upload it.
+- The lifecycle command has a shorter timeout than the job so `always()` cleanup and evidence still have time to run.
+- A failed or timed-out lifecycle is incomplete until the final cleanup result passes. The existing Search service, index, Azure OpenAI deployment, and remote MCP server must remain.
+- Repository tests prove the retry/workflow/capsule contract only. If the protected job was not approved and dispatched, report **Protected live canary: NOT RUN**.
+
 ## Cleanup Reports Partial
 
 - Read the ownership check in the `down` output and the redacted `.liveks/<env>.lock.json`.

--- a/docs/13-public-preview-limitations.md
+++ b/docs/13-public-preview-limitations.md
@@ -13,7 +13,7 @@ Return to [Overview](00-overview.md) to choose a repository path, or continue wi
 
 This sample uses Azure AI Search Knowledge Source APIs in `2026-05-01-preview`.
 
-LiveKS and the direct postprovision path reject other versions before cloud calls because the current MCP Server, Fabric Ontology, message-input, answer-synthesis, and reasoning payloads are a single preview contract. Azure AI Search `2026-04-01` stable remains valid for its generally available source kinds and minimal, extractive retrieval; this accelerator does not implement that separate lane. See [API Compatibility](14-api-compatibility.md).
+LiveKS and the direct postprovision path reject other versions before cloud calls because the current MCP Server, Fabric Ontology, message-input, answer-synthesis, and reasoning payloads are a single preview contract. The `search-index` profile implements Azure AI Search `2026-04-01` for generally available minimal extractive retrieval. The `mcp-search-index` profile keeps its Search Index KS on that stable contract while pinning MCP KS, combined KB, and retrieve to `2026-05-01-preview`. See [API Compatibility](14-api-compatibility.md).
 
 Treat these as preview-sensitive:
 
@@ -75,6 +75,8 @@ If the app has Fabric IDs but no delegated token, it should show offline replay 
 
 | Mode | Caveat | Safe interpretation |
 | --- | --- | --- |
+| `search-index` | Uses only the GA Search Index KS and extractive retrieve contract. | Lowest-risk existing-index proof without MCP. |
+| `mcp-search-index` | Reuses Search and Azure OpenAI assets but creates preview MCP/KB objects. | Protected canary target; no Fabric assets are created or deleted. |
 | `mcp-only` | Fabric is intentionally skipped. | This proves MCP Server KS, app hosting, Search/OpenAI deployment, and trace inspection. |
 | `byo-fabric` | Requires existing Fabric workspace and ontology IDs. | This is the safest customer-facing live Fabric path when semantic assets already exist. |
 | `full` | Requires Fabric capacity quota, Fabric API readiness, GraphModel readiness, and delegated auth for live retrieve. | This is the platform story and greenfield demo path, not the fastest first run. |
@@ -131,12 +133,14 @@ Avoid these claims in README, blogs, and presentations:
 - "Knowledge Source parameters are a strict source allow-list."
 - "Static screenshots prove the live path."
 - "A successful `azd up` proves KS/KB retrieve behavior."
+- "Repository tests prove the protected canary ran live."
 
 Prefer these claims:
 
 - "Reusable accelerator scaffold."
 - "Public preview sample."
 - "Validated deployment paths with explicit evidence."
+- "Credential-free tests validate the protected canary contract; an approved manual run supplies live evidence."
 - "MCP-only is the fastest first run."
 - "BYO Fabric is the safest live Fabric customer path."
 - "Full mode is the greenfield platform story and depends on quota, tenant settings, and delegated auth."

--- a/docs/20-liveks-cli.md
+++ b/docs/20-liveks-cli.md
@@ -126,6 +126,8 @@ The combined data-plane profile accepts `--query`, repeatable `--expect-term`, `
 
 Use `--keep-resources` only while debugging. Release evidence should include successful cleanup.
 
+The protected `mcp-search-index` canary is stricter: it is manual-only, accepts `--cleanup` only, derives a unique environment per run, serializes runs through workflow concurrency, and performs a second guarded cleanup with `always()`. Missing configuration fails before Azure login.
+
 Every E2E run writes four ignored artifacts under `deployments/<environment>/`:
 
 | Artifact | Purpose |
@@ -136,6 +138,8 @@ Every E2E run writes four ignored artifacts under `deployments/<environment>/`:
 | `evidence-capsule.md` | Human-readable view of the same sanitized assertion set. |
 
 The capsules omit the environment name, check messages, resource identifiers, endpoints, raw responses, and credentials. Review them before sharing because the detailed reports beside them remain local-only.
+
+The protected workflow uploads a separate `canary-evidence.json` allowlist capsule only. It adds retry categories/counts, source evidence counts, generated/BYO ownership classes, cost-sensitive classes, cleanup status, and a digest of the non-uploaded detailed report.
 
 ## Machine-Readable Output
 

--- a/docs/24-mcp-search-index-kb.md
+++ b/docs/24-mcp-search-index-kb.md
@@ -133,15 +133,38 @@ Native MCP output does not include the REST `activity` and `references` envelope
 
 ## Protected Live Contract
 
-`.github/workflows/protected-mcp-search-index.yml` is manual-only and uses the protected `mcp-search-index-live` GitHub environment. It signs in with OIDC, creates an ignored ledger from environment secrets, and runs the opt-in live test. The test performs no create or delete operation and uploads no raw response or report.
+`.github/workflows/protected-mcp-search-index.yml` is manual-only, accepts only an explicit `run-with-cleanup` confirmation on `main`, and uses the protected `mcp-search-index-live` GitHub Environment. Forks, pull requests, and untrusted refs cannot enter the credentialed job.
+
+The first protected step checks required configuration names without printing values. Only then does OIDC login run. One generated environment name is used per workflow run and attempt. The lifecycle test invokes the actual guarded E2E path:
+
+```text
+doctor -> plan -> conditional create -> Search Index verify -> MCP verify
+       -> combined verify -> dependency-ordered cleanup
+```
+
+The command is bounded by its own timeout and the job has a finite timeout. Workflow concurrency prevents two canaries from operating on the shared BYO target simultaneously. An `always()` step reruns lock/ETag-guarded cleanup after success, failure, or command timeout. The path never uses `--keep-resources`, `full`, or Fabric.
+
+Only `.deployment/canary-evidence.json` is uploaded. Detailed E2E, cleanup, lock, and retry inputs remain ignored on the runner. The capsule retains only:
+
+- revision, profile, assertion names/statuses,
+- source types and evidence counts,
+- retry categories/counts and terminal categories,
+- generated-versus-BYO ownership classes,
+- cost-sensitive resource classes,
+- cleanup result and detailed-report digest.
+
+It excludes questions, answers, raw payloads, tokens, endpoints, resource names, tenant/subscription IDs, GUID-shaped identifiers, and customer data.
 
 Normal unit discovery skips this test:
 
 ```text
 protected MCP + Search Index contract is opt-in
+protected MCP + Search Index lifecycle canary is opt-in
 ```
 
-Configure the protected environment only with approved non-customer acceptance questions and expected terms.
+Repository tests prove trigger, preflight, retry, cleanup, and capsule shape without Azure calls. They are not live evidence. Configure the protected environment only with approved non-customer acceptance questions and expected terms, then run the manual protected job to establish live evidence.
+
+Operational references: [Azure AI Search HTTP status codes](https://learn.microsoft.com/rest/api/searchservice/http-status-codes), [GitHub deployment environments](https://docs.github.com/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments), and [GitHub workflow concurrency](https://docs.github.com/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).
 
 ## Cleanup
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -260,6 +260,16 @@ For full:
 
 Never use `--keep-resources` for a release rehearsal without recording who owns the follow-up cleanup.
 
+### Protected MCP + Search Index Canary
+
+Maintainers can dispatch `.github/workflows/protected-mcp-search-index.yml` only from `main` with `run-with-cleanup`. The job is gated by the `mcp-search-index-live` GitHub Environment and one fixed concurrency group. Each run derives a unique LiveKS environment from the workflow run ID and attempt.
+
+Preflight names all missing configuration before OIDC login and never prints values. The lifecycle uses the existing `e2e --cleanup --yes` path, which already holds one operation lock across plan, create, ordered source verification, combined verification, and cleanup. The workflow adds command/job timeouts plus an `always()` cleanup and evidence step.
+
+Upload policy is strict: only the allowlist-sanitized `canary-evidence.json` capsule is retained. Never upload `e2e-report.json`, cleanup JSON, locks, ledgers, raw responses, or queries.
+
+Normal repository tests report both protected tests as skipped and prove only contract shape. Record the live canary as **NOT RUN** until an approved environment run succeeds.
+
 ## Evidence Boundary
 
 Keep `.liveks/`, `.deployment/`, `deployments/`, raw responses, tokens, and private screenshots out of git. Every `e2e` run writes allowlist-sanitized `evidence-capsule.json` and `evidence-capsule.md` files beside the detailed local reports. Review even sanitized capsules before sharing; public summaries should include only profile, revision, status, source types, assertion names, evidence counts, report digest, and cleanup result.

--- a/scripts/protected_canary.py
+++ b/scripts/protected_canary.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Prepare and summarize the manual protected lifecycle canary."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from liveks.canary import (  # noqa: E402
+    CanaryConfigurationError,
+    build_canary_evidence,
+    generated_canary_environment,
+    preflight_from_environment,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    preflight = subparsers.add_parser("preflight")
+    preflight.add_argument("--environment", required=True)
+
+    evidence = subparsers.add_parser("evidence")
+    evidence.add_argument("--environment", required=True)
+    evidence.add_argument("--preflight-outcome", default="unknown")
+    evidence.add_argument("--login-outcome", default="unknown")
+    evidence.add_argument("--lifecycle-outcome", default="unknown")
+    evidence.add_argument("--cleanup-outcome", default="unknown")
+    evidence.add_argument("--output", type=Path, required=True)
+    evidence.add_argument("--detail", type=Path, required=True)
+    evidence.add_argument("--summary", type=Path)
+
+    final_status = subparsers.add_parser("final-status")
+    final_status.add_argument("--capsule", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "preflight":
+        try:
+            if os.environ.get("GITHUB_RUN_ID") and os.environ.get("GITHUB_RUN_ATTEMPT"):
+                expected_environment = generated_canary_environment(
+                    os.environ["GITHUB_RUN_ID"],
+                    os.environ["GITHUB_RUN_ATTEMPT"],
+                )
+                if args.environment != expected_environment:
+                    raise CanaryConfigurationError(
+                        "Protected canary environment does not match the workflow run identity."
+                    )
+            path, _ = preflight_from_environment(
+                ROOT,
+                environment=args.environment,
+            )
+        except CanaryConfigurationError as error:
+            print(str(error), file=sys.stderr)
+            return 2
+        print(
+            "Protected canary preflight: PASS "
+            f"({path.name}; configuration values hidden)"
+        )
+        return 0
+    if args.command == "evidence":
+        capsule = build_canary_evidence(
+            ROOT,
+            environment=args.environment,
+            preflight_outcome=args.preflight_outcome,
+            login_outcome=args.login_outcome,
+            lifecycle_outcome=args.lifecycle_outcome,
+            cleanup_outcome=args.cleanup_outcome,
+            output_path=args.output,
+            detail_path=args.detail,
+            summary_path=args.summary,
+        )
+        print(f"Protected canary evidence: {str(capsule['status']).upper()}")
+        return 0
+    if args.command == "final-status":
+        import json
+
+        try:
+            capsule = json.loads(args.capsule.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            print(f"Protected canary evidence is unavailable: {error}", file=sys.stderr)
+            return 1
+        status = str(capsule.get("status") or "unknown")
+        print(f"Protected canary final status: {status.upper()}")
+        return 0 if status == "pass" else 1
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-local.sh
+++ b/scripts/validate-local.sh
@@ -167,6 +167,7 @@ run_required "Python compile" \
     scripts/azd_postprovision.py \
     scripts/deploy_static_webapp_api.py \
     scripts/generate_env_examples.py \
+    scripts/protected_canary.py \
     scripts/maintainers/summarize-e2e-evidence.py \
     scripts/maintainers/extract-review-evidence.py \
     tools/validate.py \
@@ -176,6 +177,7 @@ run_required "Python compile" \
     samples/python/inspect_retrieve_response.py \
     src/liveks/runtime.py \
     src/liveks/evidence.py \
+    src/liveks/canary.py \
     src/liveks/search_index.py \
     src/liveks/mcp_search_index.py \
     src/liveks/cli.py

--- a/src/liveks/canary.py
+++ b/src/liveks/canary.py
@@ -1,0 +1,497 @@
+"""Protected lifecycle canary configuration and sanitized evidence helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .config import ConfigError, ResolvedConfig, resolve_config
+from .evidence import generated_at, repository_revision, sha256_file, write_json
+
+
+REQUIRED_CANARY_CONFIGURATION = (
+    "AZURE_CLIENT_ID",
+    "AZURE_TENANT_ID",
+    "AZURE_SUBSCRIPTION_ID",
+    "SEARCH_ENDPOINT",
+    "SEARCH_INDEX_NAME",
+    "SEARCH_SEMANTIC_CONFIGURATION_NAME",
+    "AZURE_OPENAI_ENDPOINT",
+    "AZURE_OPENAI_DEPLOYMENT_ID",
+    "AZURE_OPENAI_MODEL_NAME",
+    "LIVEKS_INDEX_QUERY",
+    "LIVEKS_INDEX_EXPECT_TERM",
+    "LIVEKS_COMBINED_QUERY",
+)
+CANARY_ASSERTION_ALLOWLIST = frozenset(
+    {
+        "environment-lock",
+        "version-separated-payload-contract",
+        "search-index-retrieve",
+        "grounding-content",
+        "mcp-retrieve",
+        "combined-retrieve",
+        "ownership",
+        "delete-combinedKnowledgeBase",
+        "delete-mcpKnowledgeSource",
+        "delete-searchIndexKnowledgeSource",
+        "search-index-preserved",
+        "azure-openai-preserved",
+        "cleanup-authorization",
+    }
+)
+SOURCE_TYPES = frozenset({"searchIndex", "mcpServer"})
+ALLOWED_STATUSES = frozenset(
+    {
+        "pass",
+        "fail",
+        "warn",
+        "skip",
+        "skipped",
+        "unknown",
+        "cleanup-incomplete",
+        "not-run",
+    }
+)
+CAPSULE_KEYS = frozenset(
+    {
+        "schemaVersion",
+        "kind",
+        "status",
+        "generatedAt",
+        "repositoryRevision",
+        "profile",
+        "protectedLive",
+        "assertions",
+        "sourceEvidence",
+        "retries",
+        "ownership",
+        "costSensitiveResourceClasses",
+        "cleanup",
+        "detailedReport",
+        "privacy",
+    }
+)
+GUID_RE = re.compile(
+    r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
+)
+URL_RE = re.compile(r"https?://", re.IGNORECASE)
+SAFE_RETRY_CATEGORY_RE = re.compile(
+    r"^(?:http-(?:408|429|500|502|503|504)|network-timeout)"
+    r"(?:-(?:exhausted|unsafe-not-retried|non-retryable))?$"
+)
+
+
+class CanaryConfigurationError(ValueError):
+    """Raised when protected canary inputs are incomplete or unsafe."""
+
+
+def missing_canary_configuration(
+    environ: Mapping[str, str],
+    required: Sequence[str] = REQUIRED_CANARY_CONFIGURATION,
+) -> list[str]:
+    return sorted(name for name in required if not str(environ.get(name, "")).strip())
+
+
+def generated_canary_environment(run_id: str, run_attempt: str) -> str:
+    raw = f"canary-{run_id}-{run_attempt}".lower()
+    value = re.sub(r"[^a-z0-9-]", "-", raw)
+    value = re.sub(r"-+", "-", value).strip("-")[:63]
+    if len(value) < 3 or not value[0].isalpha():
+        raise CanaryConfigurationError("Generated canary environment is invalid.")
+    return value
+
+
+def write_canary_config(
+    root: Path,
+    *,
+    environment: str,
+    environ: Mapping[str, str],
+) -> tuple[Path, ResolvedConfig]:
+    missing = missing_canary_configuration(environ)
+    if missing:
+        raise CanaryConfigurationError(
+            "Missing required protected canary configuration: " + ", ".join(missing)
+        )
+
+    import yaml
+
+    data = {
+        "version": 2,
+        "profile": "mcp-search-index",
+        "environment": environment,
+        "azure": {
+            "tenant_id": environ["AZURE_TENANT_ID"],
+            "subscription_id": environ["AZURE_SUBSCRIPTION_ID"],
+        },
+        "search": {
+            "endpoint": environ["SEARCH_ENDPOINT"],
+            "index_name": environ["SEARCH_INDEX_NAME"],
+            "semantic_configuration_name": environ["SEARCH_SEMANTIC_CONFIGURATION_NAME"],
+            "search_fields": [],
+            "source_data_fields": [],
+        },
+        "openai": {
+            "endpoint": environ["AZURE_OPENAI_ENDPOINT"],
+            "deployment_name": environ["AZURE_OPENAI_DEPLOYMENT_ID"],
+            "model_name": environ["AZURE_OPENAI_MODEL_NAME"],
+        },
+    }
+    path = root / ".liveks" / f"{environment}.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    path.chmod(0o600)
+    try:
+        config = resolve_config(
+            profile=None,
+            environment=None,
+            config_path=path,
+        )
+    except ConfigError as error:
+        raise CanaryConfigurationError(
+            "Protected canary configuration is invalid: " + str(error)
+        ) from error
+    return path, config
+
+
+def protected_lifecycle_arguments(
+    *,
+    config_path: Path,
+    environment: str,
+    environ: Mapping[str, str],
+) -> list[str]:
+    missing = missing_canary_configuration(environ)
+    if missing:
+        raise CanaryConfigurationError(
+            "Missing required protected canary configuration: " + ", ".join(missing)
+        )
+    arguments = [
+        "e2e",
+        "--config",
+        str(config_path),
+        "--env",
+        environment,
+        "--cleanup",
+        "--yes",
+        "--format",
+        "json",
+        "--query",
+        environ["LIVEKS_INDEX_QUERY"],
+        "--expect-term",
+        environ["LIVEKS_INDEX_EXPECT_TERM"],
+        "--combined-query",
+        environ["LIVEKS_COMBINED_QUERY"],
+    ]
+    mcp_query = str(environ.get("LIVEKS_MCP_QUERY", "")).strip()
+    if mcp_query:
+        arguments.extend(["--mcp-query", mcp_query])
+    return arguments
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _safe_status(value: Any, default: str = "unknown") -> str:
+    normalized = str(value or default).lower()
+    return normalized if normalized in ALLOWED_STATUSES else default
+
+
+def _collect_assertions(report: dict[str, Any] | None) -> list[dict[str, str]]:
+    assertions: list[dict[str, str]] = []
+    if not report:
+        return assertions
+    phases = report.get("phases")
+    if not isinstance(phases, dict):
+        return assertions
+    for phase in ("up", "down"):
+        phase_report = phases.get(phase)
+        if not isinstance(phase_report, dict):
+            continue
+        for check in phase_report.get("checks", []):
+            if not isinstance(check, dict):
+                continue
+            name = str(check.get("name") or "")
+            if name not in CANARY_ASSERTION_ALLOWLIST:
+                continue
+            assertions.append(
+                {
+                    "phase": phase,
+                    "name": name,
+                    "status": _safe_status(check.get("status")),
+                }
+            )
+    return assertions
+
+
+def _source_counts(report: dict[str, Any] | None) -> dict[str, int]:
+    counts = {source_type: 0 for source_type in SOURCE_TYPES}
+    if not report:
+        return counts
+    phases = report.get("phases")
+    up = phases.get("up") if isinstance(phases, dict) else None
+    if not isinstance(up, dict):
+        return counts
+    for check in up.get("checks", []):
+        if not isinstance(check, dict):
+            continue
+        if check.get("name") == "search-index-retrieve":
+            count = check.get("evidenceCount")
+            if isinstance(count, int) and count >= 0:
+                counts["searchIndex"] += count
+        elif check.get("name") == "mcp-retrieve":
+            count = check.get("evidenceCount")
+            if isinstance(count, int) and count >= 0:
+                counts["mcpServer"] += count
+        elif check.get("name") == "combined-retrieve":
+            source_counts = check.get("sourceCounts")
+            if isinstance(source_counts, dict):
+                for source_type in SOURCE_TYPES:
+                    count = source_counts.get(source_type)
+                    if isinstance(count, int) and count >= 0:
+                        counts[source_type] += count
+    return dict(sorted(counts.items()))
+
+
+def _merge_retry_summaries(*reports: dict[str, Any] | None) -> dict[str, Any]:
+    retry_count = 0
+    recovered_count = 0
+    category_counts: dict[str, int] = {}
+    terminal_categories: dict[str, int] = {}
+    for report in reports:
+        summary = report.get("retrySummary") if isinstance(report, dict) else None
+        if not isinstance(summary, dict):
+            continue
+        count = summary.get("retryCount")
+        recovered = summary.get("recoveredCount")
+        if isinstance(count, int) and count >= 0:
+            retry_count += count
+        if isinstance(recovered, int) and recovered >= 0:
+            recovered_count += recovered
+        for target, key in (
+            (category_counts, "categoryCounts"),
+            (terminal_categories, "terminalCategories"),
+        ):
+            values = summary.get(key)
+            if not isinstance(values, dict):
+                continue
+            for category, value in values.items():
+                if (
+                    SAFE_RETRY_CATEGORY_RE.fullmatch(str(category))
+                    and isinstance(value, int)
+                    and value >= 0
+                ):
+                    target[str(category)] = target.get(str(category), 0) + value
+    return {
+        "retryCount": retry_count,
+        "recoveredCount": recovered_count,
+        "categoryCounts": dict(sorted(category_counts.items())),
+        "terminalCategories": dict(sorted(terminal_categories.items())),
+    }
+
+
+def _cleanup_status(
+    e2e_report: dict[str, Any] | None,
+    cleanup_report: dict[str, Any] | None,
+) -> str:
+    if cleanup_report:
+        return _safe_status(cleanup_report.get("status"))
+    phases = e2e_report.get("phases") if isinstance(e2e_report, dict) else None
+    down = phases.get("down") if isinstance(phases, dict) else None
+    return _safe_status(down.get("status"), "not-run") if isinstance(down, dict) else "not-run"
+
+
+def assert_canary_evidence_safe(capsule: dict[str, Any]) -> None:
+    unknown_keys = set(capsule) - CAPSULE_KEYS
+    if unknown_keys:
+        raise ValueError("Canary capsule has unsupported fields: " + ", ".join(sorted(unknown_keys)))
+    serialized = json.dumps(capsule, sort_keys=True)
+    if URL_RE.search(serialized):
+        raise ValueError("Canary capsule contains a URL.")
+    if GUID_RE.search(serialized):
+        raise ValueError("Canary capsule contains a GUID-shaped identifier.")
+    forbidden_keys = {
+        "answer",
+        "endpoint",
+        "environment",
+        "payload",
+        "query",
+        "resourceName",
+        "subscriptionId",
+        "tenantId",
+        "token",
+    }
+
+    def inspect(value: Any) -> None:
+        if isinstance(value, dict):
+            overlap = forbidden_keys.intersection(value)
+            if overlap:
+                raise ValueError(
+                    "Canary capsule contains forbidden fields: " + ", ".join(sorted(overlap))
+                )
+            for nested in value.values():
+                inspect(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                inspect(nested)
+
+    inspect(capsule)
+
+
+def build_canary_evidence(
+    root: Path,
+    *,
+    environment: str,
+    preflight_outcome: str,
+    login_outcome: str,
+    lifecycle_outcome: str,
+    cleanup_outcome: str,
+    output_path: Path,
+    detail_path: Path,
+    summary_path: Path | None = None,
+) -> dict[str, Any]:
+    e2e_report_path = root / "deployments" / environment / "e2e-report.json"
+    cleanup_report_path = root / ".deployment" / "canary-cleanup.json"
+    e2e_report = _load_json(e2e_report_path)
+    cleanup_report = _load_json(cleanup_report_path)
+    cleanup_status = _cleanup_status(e2e_report, cleanup_report)
+
+    ran = (
+        preflight_outcome == "success"
+        and login_outcome == "success"
+        and lifecycle_outcome not in {"", "skipped", "not-run"}
+    )
+    status = (
+        "not-run"
+        if not ran
+        else "pass"
+        if lifecycle_outcome == "success" and cleanup_status == "pass"
+        else "fail"
+    )
+    assertions = _collect_assertions(e2e_report)
+    counts = _source_counts(e2e_report)
+    retries = _merge_retry_summaries(e2e_report, cleanup_report)
+
+    detail = {
+        "schemaVersion": 1,
+        "kind": "protected-canary-detail",
+        "stepOutcomes": {
+            "preflight": preflight_outcome or "unknown",
+            "login": login_outcome or "unknown",
+            "lifecycle": lifecycle_outcome or "unknown",
+            "cleanup": cleanup_outcome or "unknown",
+        },
+        "e2eReportPresent": e2e_report is not None,
+        "e2eReportSha256": (
+            sha256_file(e2e_report_path)
+            if e2e_report is not None
+            else "unavailable"
+        ),
+        "cleanupReportPresent": cleanup_report is not None,
+        "assertionCount": len(assertions),
+        "retrySummary": retries,
+    }
+    write_json(detail_path, detail)
+    detailed_report_path = e2e_report_path if e2e_report is not None else detail_path
+
+    capsule = {
+        "schemaVersion": 1,
+        "kind": "liveks-protected-canary-evidence",
+        "status": status,
+        "generatedAt": generated_at(),
+        "repositoryRevision": repository_revision(root),
+        "profile": "mcp-search-index",
+        "protectedLive": {
+            "status": "run" if ran else "not-run",
+            "trigger": "workflow-dispatch",
+        },
+        "assertions": assertions,
+        "sourceEvidence": {
+            "types": sorted(source_type for source_type, count in counts.items() if count > 0),
+            "counts": counts,
+        },
+        "retries": retries,
+        "ownership": {
+            "generated": {
+                "knowledgeBases": 1,
+                "knowledgeSources": 2,
+            },
+            "byo": [
+                "azureOpenAIDeployment",
+                "remoteMcpServer",
+                "searchIndex",
+                "searchService",
+            ],
+            "fabric": "none",
+        },
+        "costSensitiveResourceClasses": [
+            "azureAISearchRetrieval",
+            "azureOpenAIModelUsage",
+            "remoteMcpService",
+        ],
+        "cleanup": {
+            "requested": True,
+            "status": cleanup_status,
+        },
+        "detailedReport": {
+            "kind": "e2e-report" if e2e_report is not None else "protected-canary-detail",
+            "sha256": sha256_file(detailed_report_path),
+        },
+        "privacy": {
+            "answersIncluded": False,
+            "credentialsIncluded": False,
+            "customerDataIncluded": False,
+            "identifiersIncluded": False,
+            "queriesIncluded": False,
+            "rawPayloadsIncluded": False,
+            "resourceNamesIncluded": False,
+            "serviceEndpointsIncluded": False,
+        },
+    }
+    assert_canary_evidence_safe(capsule)
+    write_json(output_path, capsule)
+
+    if summary_path is not None:
+        lines = [
+            "## Protected MCP + Search Index canary",
+            "",
+            f"- Status: `{status.upper()}`",
+            f"- Protected live execution: `{'RUN' if ran else 'NOT RUN'}`",
+            f"- Revision: `{capsule['repositoryRevision']}`",
+            f"- Profile: `{capsule['profile']}`",
+            f"- Assertions retained: `{len(assertions)}`",
+            f"- Source evidence: `searchIndex={counts['searchIndex']}, mcpServer={counts['mcpServer']}`",
+            f"- Retries: `{retries['retryCount']}`",
+            f"- Cleanup: `{cleanup_status.upper()}`",
+            f"- Detailed report digest: `{capsule['detailedReport']['sha256']}`",
+            "",
+            "Only the allowlist-sanitized capsule is uploaded.",
+            "",
+        ]
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        with summary_path.open("a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines))
+    return capsule
+
+
+def preflight_from_environment(
+    root: Path,
+    *,
+    environment: str,
+    environ: Mapping[str, str] | None = None,
+) -> tuple[Path, ResolvedConfig]:
+    return write_canary_config(
+        root,
+        environment=environment,
+        environ=environ or os.environ,
+    )

--- a/src/liveks/cli.py
+++ b/src/liveks/cli.py
@@ -41,6 +41,8 @@ from .runtime import (
     http_mcp_json,
     parse_azd_values,
     parse_version,
+    reset_retry_telemetry,
+    retry_telemetry_summary,
 )
 from .search_index import (
     acquire_bearer_token as acquire_search_bearer_token,
@@ -150,6 +152,18 @@ def _sanitized_e2e_checks(report: dict[str, Any]) -> list[dict[str, Any]]:
                 safe_check["sourceTypes"] = sorted(
                     {str(item) for item in source_types if item in {"fabricOntology", "mcpServer", "searchIndex"}}
                 )
+            evidence_count = check.get("evidenceCount")
+            if isinstance(evidence_count, int) and evidence_count >= 0:
+                safe_check["evidenceCount"] = evidence_count
+            source_counts = check.get("sourceCounts")
+            if isinstance(source_counts, dict):
+                safe_check["sourceCounts"] = {
+                    str(key): int(value)
+                    for key, value in source_counts.items()
+                    if key in {"fabricOntology", "mcpServer", "searchIndex"}
+                    and isinstance(value, int)
+                    and value >= 0
+                }
             checks.append(safe_check)
     return checks
 
@@ -1877,6 +1891,19 @@ def _evidence_types(payload: Any) -> list[str]:
     return sorted({str(item.get("type")) for item in evidence if isinstance(item, dict) and item.get("type")})
 
 
+def _evidence_count(payload: Any, source_type: str | None = None) -> int:
+    if not isinstance(payload, dict):
+        return 0
+    evidence = list(payload.get("activity", [])) + list(payload.get("references", []))
+    if source_type is None:
+        return sum(1 for item in evidence if isinstance(item, dict))
+    return sum(
+        1
+        for item in evidence
+        if isinstance(item, dict) and item.get("type") == source_type
+    )
+
+
 def _mcp_text_blocks(payload: Any) -> list[str]:
     if not isinstance(payload, dict):
         return []
@@ -2083,6 +2110,7 @@ def mcp_report(
             attempts=3,
             delay_seconds=3,
             timeout=30,
+            retry_mode="read",
         )
     except Exception:
         checks.append(_check("tools-list", "fail", "The MCP endpoint could not complete tool discovery."))
@@ -2119,6 +2147,7 @@ def mcp_report(
             attempts=3,
             delay_seconds=3,
             timeout=180,
+            retry_mode="read",
         )
     except Exception:
         checks.append(_check("tools-call", "fail", "The MCP endpoint could not complete the tool call."))
@@ -2271,7 +2300,8 @@ def _search_index_verify_report(
             method="POST",
             path=f"{search_object_path('knowledgebases', str(config.get('search.index_knowledge_base_name')))}/retrieve",
             body=payloads["retrieve"],
-            attempts=2,
+            attempts=3,
+            retry_mode="read",
         )
     except Exception:
         retrieve_code, retrieve_payload = 0, {}
@@ -2284,6 +2314,7 @@ def _search_index_verify_report(
             "Stable retrieve returned extracted content and searchIndex activity or reference evidence."
             if retrieve_ok
             else f"Stable retrieve did not return the required evidence (HTTP {retrieve_code or 'unavailable'}).",
+            evidenceCount=_evidence_count(retrieve_payload, "searchIndex"),
         )
     )
 
@@ -2508,7 +2539,8 @@ def _mcp_search_index_verify_report(
                 path=kb_path,
                 api_version=preview,
                 body=payloads["retrieve"][label],
-                attempts=2,
+                attempts=3,
+                retry_mode="read",
             )
         except Exception:
             retrieve_results[label] = (0, {})
@@ -2522,6 +2554,7 @@ def _mcp_search_index_verify_report(
             "Independent preview retrieve returned searchIndex activity, references, or sourceData evidence."
             if index_ok
             else _mcp_search_index_retrieve_failure(index_code, "Search Index"),
+            evidenceCount=_evidence_count(index_payload, "searchIndex"),
         )
     )
     terms = expected_terms or []
@@ -2549,6 +2582,7 @@ def _mcp_search_index_verify_report(
             "Independent preview retrieve returned mcpServer activity, references, or sourceData evidence."
             if mcp_ok
             else _mcp_search_index_retrieve_failure(mcp_code, "MCP Server"),
+            evidenceCount=_evidence_count(mcp_payload, "mcpServer"),
         )
     )
 
@@ -2564,7 +2598,8 @@ def _mcp_search_index_verify_report(
                 path=kb_path,
                 api_version=preview,
                 body=payloads["retrieve"]["combined"],
-                attempts=2,
+                attempts=3,
+                retry_mode="read",
             )
         except Exception:
             combined_code, combined_payload = 0, {}
@@ -2588,6 +2623,11 @@ def _mcp_search_index_verify_report(
             if not independent_sources_passed
             else _mcp_search_index_retrieve_failure(combined_code, "Combined"),
             sourceTypes=source_types,
+            evidenceCount=_evidence_count(combined_payload),
+            sourceCounts={
+                source_type: _evidence_count(combined_payload, source_type)
+                for source_type in source_types
+            },
         )
     )
 
@@ -2663,7 +2703,7 @@ def verify_report(
         try:
             status_code, status_payload = http_json(f"{app_url}/api/status", attempts=18, delay_seconds=10, timeout=20)
             checks.append(_check("app-status", "pass" if status_code == 200 else "fail", f"HTTP {status_code}"))
-            mcp_code, mcp_payload = http_json(f"{app_url}/api/retrieve/mcp", method="POST", body={"query": "What must be configured for an Azure AI Search MCP Server knowledge source?"}, attempts=3, delay_seconds=5, timeout=120)
+            mcp_code, mcp_payload = http_json(f"{app_url}/api/retrieve/mcp", method="POST", body={"query": "What must be configured for an Azure AI Search MCP Server knowledge source?"}, attempts=3, delay_seconds=5, timeout=120, retry_mode="read")
             mcp_ok = mcp_code == 200 and _response_has_live_evidence(mcp_payload, "mcpServer")
             checks.append(_check("mcp-retrieve", "pass" if mcp_ok else "fail", "Live MCP activity/reference evidence returned" if mcp_ok else f"HTTP {mcp_code}; live MCP evidence missing"))
             if config.profile in {"byo-fabric", "full"}:
@@ -2673,7 +2713,7 @@ def verify_report(
                     checks.append(_check("fabric-token", "fail", "Unable to acquire delegated Search token"))
                 else:
                     fabric_body = {"query": "Which airlines have the highest customer-care exposure this month?", "fabricUserSearchToken": token}
-                    fabric_code, fabric_payload = http_json(f"{app_url}/api/retrieve/fabric", method="POST", body=fabric_body, attempts=3, delay_seconds=5, timeout=120)
+                    fabric_code, fabric_payload = http_json(f"{app_url}/api/retrieve/fabric", method="POST", body=fabric_body, attempts=3, delay_seconds=5, timeout=120, retry_mode="read")
                     fabric_ok = fabric_code == 200 and _response_has_live_evidence(fabric_payload, "fabricOntology")
                     checks.append(_check("fabric-retrieve", "pass" if fabric_ok else "fail", "Live Fabric ontology evidence returned" if fabric_ok else f"HTTP {fabric_code}; live Fabric evidence missing"))
                     combined_body = {
@@ -2684,7 +2724,7 @@ def verify_report(
                         ),
                         "fabricUserSearchToken": token,
                     }
-                    combined_code, combined_payload = http_json(f"{app_url}/api/retrieve/combined", method="POST", body=combined_body, attempts=3, delay_seconds=5, timeout=120)
+                    combined_code, combined_payload = http_json(f"{app_url}/api/retrieve/combined", method="POST", body=combined_body, attempts=3, delay_seconds=5, timeout=120, retry_mode="read")
                     source_types = _evidence_types(combined_payload)
                     selected_types = [item for item in source_types if item in {"fabricOntology", "mcpServer"}]
                     combined_ok = combined_code == 200 and combined_payload.get("mode") == "live" and bool(selected_types)
@@ -2908,6 +2948,8 @@ def _search_index_down_report(config: ResolvedConfig, *, yes: bool, quiet: bool)
                 method="DELETE",
                 path=search_object_path(kind, name),
                 headers={"If-Match": etag},
+                attempts=3,
+                retry_mode="conditional-write",
                 timeout=60,
             )
         except Exception:
@@ -3088,6 +3130,8 @@ def _mcp_search_index_down_report(config: ResolvedConfig, *, yes: bool, quiet: b
                 path=search_object_path(kind, name),
                 api_version=api_version,
                 headers={"If-Match": etag},
+                attempts=3,
+                retry_mode="conditional-write",
                 timeout=60,
             )
         except Exception:
@@ -3560,6 +3604,7 @@ def _init_from_legacy(path: Path, profile: str, environment: str, destination: P
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    reset_retry_telemetry()
     if not args.command:
         parser.print_help()
         return 0
@@ -3702,13 +3747,16 @@ def main(argv: list[str] | None = None) -> int:
                 )
             status = "pass" if up["status"] == "pass" and (cleanup is None or cleanup["status"] == "pass") else "fail"
             report = envelope("e2e", status, profile=config.profile, environment=config.environment, phases={"up": up, "down": cleanup}, artifacts=list(dict.fromkeys(up.get("artifacts", []) + (cleanup or {}).get("artifacts", []))))
+            report["retrySummary"] = retry_telemetry_summary()
             write_e2e_reports(config, report, cleanup_requested=args.cleanup)
         else:
             raise ConfigError(f"Unsupported command: {args.command}")
+        report.setdefault("retrySummary", retry_telemetry_summary())
         emit(report, args.format)
         return _exit_code(report)
     except ConfigError as error:
         report = envelope(args.command, "fail", checks=[_check("configuration", "fail", str(error))])
+        report["retrySummary"] = retry_telemetry_summary()
         emit(report, getattr(args, "format", "text"))
         return 2
     except KeyboardInterrupt:

--- a/src/liveks/runtime.py
+++ b/src/liveks/runtime.py
@@ -5,13 +5,20 @@ from __future__ import annotations
 import json
 import os
 import re
+import socket
 import subprocess
 import time
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any, Iterable
+
+
+RETRYABLE_HTTP_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
+MAX_HTTP_ATTEMPTS = 20
 
 
 @dataclass
@@ -19,6 +26,141 @@ class CommandResult:
     command: list[str]
     returncode: int
     stdout: str
+
+
+@dataclass(frozen=True)
+class RetryClassification:
+    category: str
+    retryable: bool
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_attempts: int = 4
+    base_delay_seconds: float = 1.0
+    max_delay_seconds: float = 8.0
+    retry_after_cap_seconds: float = 30.0
+
+
+@dataclass
+class RetryTelemetry:
+    retry_count: int = 0
+    recovered_count: int = 0
+    category_counts: dict[str, int] = field(default_factory=dict)
+    terminal_categories: dict[str, int] = field(default_factory=dict)
+
+    def record_retry(self, category: str) -> None:
+        self.retry_count += 1
+        self.category_counts[category] = self.category_counts.get(category, 0) + 1
+
+    def record_recovered(self) -> None:
+        self.recovered_count += 1
+
+    def record_terminal(self, category: str) -> None:
+        self.terminal_categories[category] = self.terminal_categories.get(category, 0) + 1
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "retryCount": self.retry_count,
+            "recoveredCount": self.recovered_count,
+            "categoryCounts": dict(sorted(self.category_counts.items())),
+            "terminalCategories": dict(sorted(self.terminal_categories.items())),
+        }
+
+
+_RETRY_TELEMETRY = RetryTelemetry()
+
+
+def reset_retry_telemetry() -> None:
+    global _RETRY_TELEMETRY
+    _RETRY_TELEMETRY = RetryTelemetry()
+
+
+def retry_telemetry_summary() -> dict[str, Any]:
+    return _RETRY_TELEMETRY.summary()
+
+
+def classify_retry(
+    *,
+    status_code: int | None = None,
+    error: BaseException | None = None,
+) -> RetryClassification:
+    if status_code is not None:
+        return RetryClassification(
+            category=f"http-{status_code}",
+            retryable=status_code in RETRYABLE_HTTP_STATUSES,
+        )
+    reason = error.reason if isinstance(error, urllib.error.URLError) else error
+    if isinstance(reason, (TimeoutError, socket.timeout)):
+        return RetryClassification(category="network-timeout", retryable=True)
+    return RetryClassification(category="network-error", retryable=False)
+
+
+def retry_is_semantically_safe(
+    method: str,
+    retry_mode: str,
+    headers: dict[str, str] | None = None,
+) -> bool:
+    normalized_method = method.upper()
+    normalized_headers = {key.lower(): str(value) for key, value in (headers or {}).items()}
+    if retry_mode == "none":
+        return False
+    if retry_mode == "auto":
+        return normalized_method in {"GET", "HEAD", "OPTIONS"}
+    if retry_mode == "read":
+        return normalized_method in {"GET", "HEAD", "OPTIONS", "POST"}
+    if retry_mode == "conditional-write":
+        if normalized_method == "PUT":
+            return normalized_headers.get("if-none-match") == "*" or bool(normalized_headers.get("if-match"))
+        if normalized_method == "DELETE":
+            return bool(normalized_headers.get("if-match"))
+        return False
+    raise ValueError(f"Unsupported retry mode: {retry_mode}")
+
+
+def retry_after_seconds(
+    headers: Any,
+    *,
+    cap_seconds: float,
+    now: datetime | None = None,
+) -> float | None:
+    raw_value = headers.get("Retry-After") if headers is not None else None
+    if raw_value is None:
+        return None
+    value = str(raw_value).strip()
+    if not value:
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        try:
+            parsed = parsedate_to_datetime(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        current = now or datetime.now(timezone.utc)
+        seconds = max(0.0, (parsed - current).total_seconds())
+    if seconds < 0:
+        return None
+    return min(seconds, cap_seconds)
+
+
+def retry_delay_seconds(
+    retry_index: int,
+    headers: Any,
+    policy: RetryPolicy,
+) -> float:
+    retry_after = retry_after_seconds(
+        headers,
+        cap_seconds=policy.retry_after_cap_seconds,
+    )
+    if retry_after is not None:
+        return retry_after
+    return min(
+        policy.base_delay_seconds * (2**retry_index),
+        policy.max_delay_seconds,
+    )
 
 
 def close_http_error(error: urllib.error.HTTPError) -> None:
@@ -148,36 +290,69 @@ def http_json(
     attempts: int = 1,
     delay_seconds: float = 2,
     timeout: int = 30,
+    retry_mode: str = "auto",
+    retry_policy: RetryPolicy | None = None,
 ) -> tuple[int, Any]:
     payload = json.dumps(body).encode("utf-8") if body is not None else None
     request_headers = {"Accept": "application/json", **(headers or {})}
     if payload is not None:
         request_headers.setdefault("Content-Type", "application/json")
-    last_error: Exception | None = None
-    for attempt in range(attempts):
+    policy = retry_policy or RetryPolicy(
+        max_attempts=min(max(1, attempts), MAX_HTTP_ATTEMPTS),
+        base_delay_seconds=delay_seconds,
+    )
+    effective_attempts = min(max(1, attempts), max(1, policy.max_attempts), MAX_HTTP_ATTEMPTS)
+    retry_safe = retry_is_semantically_safe(method, retry_mode, request_headers)
+    retries_before = _RETRY_TELEMETRY.retry_count
+    for attempt in range(effective_attempts):
         request = urllib.request.Request(url, data=payload, headers=request_headers, method=method)
         try:
             with urllib.request.urlopen(request, timeout=timeout) as response:
                 raw = response.read().decode("utf-8")
+                if _RETRY_TELEMETRY.retry_count > retries_before:
+                    _RETRY_TELEMETRY.record_recovered()
                 return response.status, json.loads(raw) if raw else {}
         except urllib.error.HTTPError as error:
-            last_error = error
-            if error.code < 500 or attempt == attempts - 1:
-                try:
-                    raw = error.read().decode("utf-8", errors="replace")
-                finally:
-                    close_http_error(error)
-                try:
-                    return error.code, json.loads(raw) if raw else {}
-                except json.JSONDecodeError:
-                    return error.code, {"error": raw}
-            close_http_error(error)
-        except (urllib.error.URLError, TimeoutError) as error:
-            last_error = error
-            if attempt == attempts - 1:
-                break
-        time.sleep(delay_seconds)
-    raise RuntimeError(f"Request failed after {attempts} attempts: {url}: {last_error}")
+            classification = classify_retry(status_code=error.code)
+            can_retry = (
+                classification.retryable
+                and retry_safe
+                and attempt < effective_attempts - 1
+            )
+            if can_retry:
+                delay = retry_delay_seconds(attempt, error.headers, policy)
+                close_http_error(error)
+                _RETRY_TELEMETRY.record_retry(classification.category)
+                time.sleep(delay)
+                continue
+            if classification.retryable:
+                suffix = "exhausted" if retry_safe else "unsafe-not-retried"
+                _RETRY_TELEMETRY.record_terminal(f"{classification.category}-{suffix}")
+            try:
+                raw = error.read().decode("utf-8", errors="replace")
+            finally:
+                close_http_error(error)
+            try:
+                return error.code, json.loads(raw) if raw else {}
+            except json.JSONDecodeError:
+                return error.code, {"error": raw}
+        except (urllib.error.URLError, TimeoutError, socket.timeout) as error:
+            classification = classify_retry(error=error)
+            can_retry = (
+                classification.retryable
+                and retry_safe
+                and attempt < effective_attempts - 1
+            )
+            if can_retry:
+                _RETRY_TELEMETRY.record_retry(classification.category)
+                time.sleep(retry_delay_seconds(attempt, None, policy))
+                continue
+            suffix = "exhausted" if classification.retryable and retry_safe else "non-retryable"
+            _RETRY_TELEMETRY.record_terminal(f"{classification.category}-{suffix}")
+            raise RuntimeError(
+                f"Request failed with {classification.category} after {attempt + 1} attempt(s)."
+            ) from error
+    raise RuntimeError("Request failed without a terminal classification.")
 
 
 def parse_json_or_sse(raw: str, content_type: str) -> Any:
@@ -207,6 +382,8 @@ def http_mcp_json(
     attempts: int = 1,
     delay_seconds: float = 2,
     timeout: int = 120,
+    retry_mode: str = "none",
+    retry_policy: RetryPolicy | None = None,
 ) -> tuple[int, Any]:
     """POST one stateless MCP JSON-RPC request and accept JSON or SSE."""
     payload = json.dumps(body).encode("utf-8")
@@ -215,30 +392,61 @@ def http_mcp_json(
         "Content-Type": "application/json",
         **(headers or {}),
     }
-    last_error: Exception | None = None
-    for attempt in range(attempts):
+    policy = retry_policy or RetryPolicy(
+        max_attempts=min(max(1, attempts), MAX_HTTP_ATTEMPTS),
+        base_delay_seconds=delay_seconds,
+    )
+    effective_attempts = min(max(1, attempts), max(1, policy.max_attempts), MAX_HTTP_ATTEMPTS)
+    retry_safe = retry_is_semantically_safe("POST", retry_mode, request_headers)
+    retries_before = _RETRY_TELEMETRY.retry_count
+    for attempt in range(effective_attempts):
         request = urllib.request.Request(url, data=payload, headers=request_headers, method="POST")
         try:
             with urllib.request.urlopen(request, timeout=timeout) as response:
                 raw = response.read().decode("utf-8", errors="replace")
                 content_type = response.headers.get("Content-Type", "application/json")
+                if _RETRY_TELEMETRY.retry_count > retries_before:
+                    _RETRY_TELEMETRY.record_recovered()
                 return response.status, parse_json_or_sse(raw, content_type)
         except urllib.error.HTTPError as error:
-            last_error = error
-            if error.code < 500 or attempt == attempts - 1:
-                try:
-                    raw = error.read().decode("utf-8", errors="replace")
-                    content_type = error.headers.get("Content-Type", "application/json") if error.headers else "application/json"
-                finally:
-                    close_http_error(error)
-                try:
-                    return error.code, parse_json_or_sse(raw, content_type)
-                except (json.JSONDecodeError, ValueError):
-                    return error.code, {"error": "non-JSON MCP error response"}
-            close_http_error(error)
-        except (urllib.error.URLError, TimeoutError) as error:
-            last_error = error
-            if attempt == attempts - 1:
-                break
-        time.sleep(delay_seconds)
-    raise RuntimeError(f"MCP request failed after {attempts} attempts: {last_error}")
+            classification = classify_retry(status_code=error.code)
+            can_retry = (
+                classification.retryable
+                and retry_safe
+                and attempt < effective_attempts - 1
+            )
+            if can_retry:
+                delay = retry_delay_seconds(attempt, error.headers, policy)
+                close_http_error(error)
+                _RETRY_TELEMETRY.record_retry(classification.category)
+                time.sleep(delay)
+                continue
+            if classification.retryable:
+                suffix = "exhausted" if retry_safe else "unsafe-not-retried"
+                _RETRY_TELEMETRY.record_terminal(f"{classification.category}-{suffix}")
+            try:
+                raw = error.read().decode("utf-8", errors="replace")
+                content_type = error.headers.get("Content-Type", "application/json") if error.headers else "application/json"
+            finally:
+                close_http_error(error)
+            try:
+                return error.code, parse_json_or_sse(raw, content_type)
+            except (json.JSONDecodeError, ValueError):
+                return error.code, {"error": "non-JSON MCP error response"}
+        except (urllib.error.URLError, TimeoutError, socket.timeout) as error:
+            classification = classify_retry(error=error)
+            can_retry = (
+                classification.retryable
+                and retry_safe
+                and attempt < effective_attempts - 1
+            )
+            if can_retry:
+                _RETRY_TELEMETRY.record_retry(classification.category)
+                time.sleep(retry_delay_seconds(attempt, None, policy))
+                continue
+            suffix = "exhausted" if classification.retryable and retry_safe else "non-retryable"
+            _RETRY_TELEMETRY.record_terminal(f"{classification.category}-{suffix}")
+            raise RuntimeError(
+                f"MCP request failed with {classification.category} after {attempt + 1} attempt(s)."
+            ) from error
+    raise RuntimeError("MCP request failed without a terminal classification.")

--- a/src/liveks/search_index.py
+++ b/src/liveks/search_index.py
@@ -8,7 +8,7 @@ from urllib.parse import quote
 from ks_factory import create_extracting_knowledge_base, create_search_index_knowledge_source
 
 from .config import ResolvedConfig
-from .runtime import CommandRunner, http_json
+from .runtime import CommandRunner, RetryPolicy, http_json
 
 
 def acquire_bearer_token(runner: CommandRunner) -> str:
@@ -42,8 +42,10 @@ def request(
     body: dict[str, Any] | None = None,
     api_version: str | None = None,
     headers: dict[str, str] | None = None,
-    attempts: int = 1,
+    attempts: int = 3,
     timeout: int = 120,
+    retry_mode: str = "auto",
+    retry_policy: RetryPolicy | None = None,
 ) -> tuple[int, Any]:
     endpoint = str(config.get("search.endpoint")).rstrip("/")
     resolved_api_version = str(api_version or config.get("search.api_version"))
@@ -61,6 +63,8 @@ def request(
             attempts=attempts,
             delay_seconds=2,
             timeout=timeout,
+            retry_mode=retry_mode,
+            retry_policy=retry_policy,
         )
     except Exception as error:
         raise RuntimeError("Azure AI Search request could not be completed.") from error

--- a/tests/test_mcp_search_index_live_contract.py
+++ b/tests/test_mcp_search_index_live_contract.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import os
 import sys
 import unittest
@@ -8,6 +10,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
 from liveks import cli  # noqa: E402
+from liveks.canary import protected_lifecycle_arguments  # noqa: E402
 from liveks.config import resolve_config  # noqa: E402
 
 
@@ -46,6 +49,25 @@ class ProtectedMcpSearchIndexContractTests(unittest.TestCase):
         self.assertLess(names.index("search-index-retrieve"), names.index("mcp-retrieve"))
         self.assertLess(names.index("mcp-retrieve"), names.index("combined-retrieve"))
         self.assertTrue(checks["combined-retrieve"]["sourceTypes"])
+
+
+@unittest.skipUnless(
+    os.environ.get("LIVEKS_RUN_PROTECTED_MCP_SEARCH_INDEX_LIFECYCLE") == "1",
+    "protected MCP + Search Index lifecycle canary is opt-in",
+)
+class ProtectedMcpSearchIndexLifecycleCanaryTests(unittest.TestCase):
+    def test_guarded_e2e_always_requests_cleanup(self):
+        config_path = Path(os.environ["LIVEKS_PROTECTED_CONFIG"])
+        arguments = protected_lifecycle_arguments(
+            config_path=config_path,
+            environment=os.environ["LIVEKS_CANARY_ENVIRONMENT"],
+            environ=os.environ,
+        )
+        self.assertIn("--cleanup", arguments)
+        self.assertNotIn("--keep-resources", arguments)
+        with contextlib.redirect_stdout(io.StringIO()):
+            result = cli.main(arguments)
+        self.assertEqual(result, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_protected_canary.py
+++ b/tests/test_protected_canary.py
@@ -1,0 +1,334 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from liveks.canary import (  # noqa: E402
+    CAPSULE_KEYS,
+    CanaryConfigurationError,
+    assert_canary_evidence_safe,
+    build_canary_evidence,
+    generated_canary_environment,
+    missing_canary_configuration,
+    protected_lifecycle_arguments,
+    write_canary_config,
+)
+
+
+def complete_environment():
+    return {
+        "AZURE_CLIENT_ID": "11111111-1111-1111-1111-111111111111",
+        "AZURE_TENANT_ID": "22222222-2222-2222-2222-222222222222",
+        "AZURE_SUBSCRIPTION_ID": "33333333-3333-3333-3333-333333333333",
+        "SEARCH_ENDPOINT": "https://example.search.windows.net",
+        "SEARCH_INDEX_NAME": "existing-index",
+        "SEARCH_SEMANTIC_CONFIGURATION_NAME": "semantic-default",
+        "AZURE_OPENAI_ENDPOINT": "https://example.openai.azure.com",
+        "AZURE_OPENAI_DEPLOYMENT_ID": "existing-model",
+        "AZURE_OPENAI_MODEL_NAME": "gpt-5-mini",
+        "LIVEKS_INDEX_QUERY": "private index question",
+        "LIVEKS_INDEX_EXPECT_TERM": "private known term",
+        "LIVEKS_MCP_QUERY": "private MCP question",
+        "LIVEKS_COMBINED_QUERY": "private combined question",
+    }
+
+
+class ProtectedCanaryPreflightTests(unittest.TestCase):
+    def test_missing_configuration_names_are_reported_without_values(self):
+        environ = complete_environment()
+        environ["SEARCH_ENDPOINT"] = ""
+        environ["LIVEKS_INDEX_QUERY"] = ""
+        missing = missing_canary_configuration(environ)
+
+        self.assertEqual(missing, ["LIVEKS_INDEX_QUERY", "SEARCH_ENDPOINT"])
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with self.assertRaisesRegex(
+                CanaryConfigurationError,
+                "LIVEKS_INDEX_QUERY, SEARCH_ENDPOINT",
+            ) as error:
+                write_canary_config(
+                    Path(temp_dir),
+                    environment="canary-123-1",
+                    environ=environ,
+                )
+        self.assertNotIn("private known term", str(error.exception))
+
+    def test_preflight_writes_valid_ignored_profile_with_run_unique_names(self):
+        environ = complete_environment()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path, config = write_canary_config(
+                Path(temp_dir),
+                environment="canary-12345-2",
+                environ=environ,
+            )
+
+            text = path.read_text(encoding="utf-8")
+
+        self.assertEqual(config.profile, "mcp-search-index")
+        self.assertEqual(config.environment, "canary-12345-2")
+        self.assertEqual(
+            config.get("search.index_knowledge_source_name"),
+            "canary-12345-2-search-index-ks",
+        )
+        self.assertNotIn("AZURE_CLIENT_ID", text)
+        self.assertNotIn(environ["LIVEKS_INDEX_QUERY"], text)
+        self.assertNotIn(environ["LIVEKS_INDEX_EXPECT_TERM"], text)
+
+    def test_generated_environment_is_bounded_and_valid(self):
+        value = generated_canary_environment("1234567890" * 10, "4")
+        self.assertLessEqual(len(value), 63)
+        self.assertRegex(value, r"^[a-z][a-z0-9-]{2,62}$")
+
+    def test_lifecycle_arguments_require_cleanup_and_never_keep_resources(self):
+        arguments = protected_lifecycle_arguments(
+            config_path=Path(".liveks/canary.yaml"),
+            environment="canary-123-1",
+            environ=complete_environment(),
+        )
+        self.assertEqual(arguments[0], "e2e")
+        self.assertIn("--cleanup", arguments)
+        self.assertIn("--yes", arguments)
+        self.assertNotIn("--keep-resources", arguments)
+        self.assertNotIn("full", arguments)
+        self.assertNotIn("fabric", " ".join(arguments).lower())
+
+
+class ProtectedCanaryEvidenceTests(unittest.TestCase):
+    def test_capsule_is_allowlist_only_and_redacts_detailed_content(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            environment = "canary-123-1"
+            report_dir = root / "deployments" / environment
+            report_dir.mkdir(parents=True)
+            e2e_report = {
+                "status": "pass",
+                "environment": environment,
+                "retrySummary": {
+                    "retryCount": 2,
+                    "recoveredCount": 1,
+                    "categoryCounts": {"http-429": 1, "network-timeout": 1},
+                    "terminalCategories": {"http-503-exhausted": 1},
+                },
+                "phases": {
+                    "up": {
+                        "checks": [
+                            {
+                                "name": "search-index-retrieve",
+                                "status": "pass",
+                                "message": "private query and https://private.example",
+                                "evidenceCount": 2,
+                            },
+                            {
+                                "name": "mcp-retrieve",
+                                "status": "pass",
+                                "message": "raw answer secret-token",
+                                "evidenceCount": 3,
+                            },
+                            {
+                                "name": "combined-retrieve",
+                                "status": "pass",
+                                "sourceTypes": ["searchIndex", "mcpServer"],
+                                "sourceCounts": {"searchIndex": 1, "mcpServer": 2},
+                            },
+                            {
+                                "name": "unapproved-diagnostic",
+                                "status": "pass",
+                                "message": "33333333-3333-3333-3333-333333333333",
+                            },
+                        ]
+                    },
+                    "down": {
+                        "status": "pass",
+                        "checks": [
+                            {"name": "delete-combinedKnowledgeBase", "status": "pass"},
+                            {"name": "search-index-preserved", "status": "pass"},
+                        ],
+                    },
+                },
+            }
+            (report_dir / "e2e-report.json").write_text(
+                json.dumps(e2e_report),
+                encoding="utf-8",
+            )
+            cleanup_path = root / ".deployment" / "canary-cleanup.json"
+            cleanup_path.parent.mkdir(parents=True)
+            cleanup_path.write_text(
+                json.dumps(
+                    {
+                        "status": "pass",
+                        "retrySummary": {
+                            "retryCount": 1,
+                            "recoveredCount": 1,
+                            "categoryCounts": {"http-500": 1},
+                            "terminalCategories": {},
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            output = root / ".deployment" / "canary-evidence.json"
+            detail = root / ".deployment" / "canary-detail.json"
+            summary = root / ".deployment" / "step-summary.md"
+            with mock.patch.dict(os.environ, {"GITHUB_SHA": "a" * 40}):
+                capsule = build_canary_evidence(
+                    root,
+                    environment=environment,
+                    preflight_outcome="success",
+                    login_outcome="success",
+                    lifecycle_outcome="success",
+                    cleanup_outcome="success",
+                    output_path=output,
+                    detail_path=detail,
+                    summary_path=summary,
+                )
+
+            serialized = output.read_text(encoding="utf-8")
+            summary_text = summary.read_text(encoding="utf-8")
+
+        self.assertEqual(set(capsule), set(CAPSULE_KEYS))
+        self.assertEqual(capsule["status"], "pass")
+        self.assertEqual(capsule["protectedLive"]["status"], "run")
+        self.assertEqual(
+            capsule["sourceEvidence"]["counts"],
+            {"mcpServer": 5, "searchIndex": 3},
+        )
+        self.assertEqual(capsule["retries"]["retryCount"], 3)
+        self.assertEqual(capsule["cleanup"]["status"], "pass")
+        self.assertEqual(len(capsule["detailedReport"]["sha256"]), 64)
+        self.assertNotIn("unapproved-diagnostic", serialized)
+        for forbidden in (
+            "private query",
+            "private.example",
+            "secret-token",
+            "33333333-3333-3333-3333-333333333333",
+            environment,
+        ):
+            self.assertNotIn(forbidden, serialized)
+        self.assertIn("Only the allowlist-sanitized capsule is uploaded.", summary_text)
+
+    def test_missing_preflight_is_explicitly_not_run(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            capsule = build_canary_evidence(
+                root,
+                environment="canary-123-1",
+                preflight_outcome="failure",
+                login_outcome="skipped",
+                lifecycle_outcome="skipped",
+                cleanup_outcome="skipped",
+                output_path=root / "capsule.json",
+                detail_path=root / "detail.json",
+            )
+
+        self.assertEqual(capsule["status"], "not-run")
+        self.assertEqual(capsule["protectedLive"]["status"], "not-run")
+        self.assertEqual(capsule["cleanup"]["status"], "not-run")
+
+    def test_capsule_validator_rejects_urls_guids_and_unknown_fields(self):
+        with self.assertRaisesRegex(ValueError, "unsupported fields"):
+            assert_canary_evidence_safe({"unexpected": "value"})
+        with self.assertRaisesRegex(ValueError, "URL"):
+            assert_canary_evidence_safe(
+                {key: [] if key == "assertions" else {} for key in CAPSULE_KEYS}
+                | {"kind": "https://private.example"}
+            )
+
+
+class ProtectedCanaryWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.path = ROOT / ".github" / "workflows" / "protected-mcp-search-index.yml"
+        cls.text = cls.path.read_text(encoding="utf-8")
+        cls.workflow = yaml.load(cls.text, Loader=yaml.BaseLoader)
+        cls.job = cls.workflow["jobs"]["live-canary"]
+        cls.steps = {step["name"]: step for step in cls.job["steps"]}
+
+    def test_trigger_permissions_environment_concurrency_and_timeout(self):
+        self.assertEqual(set(self.workflow["on"]), {"workflow_dispatch"})
+        self.assertNotIn("schedule:", self.text)
+        self.assertEqual(
+            self.workflow["permissions"],
+            {"contents": "read", "id-token": "write"},
+        )
+        self.assertEqual(
+            self.workflow["concurrency"],
+            {
+                "group": "protected-mcp-search-index-live",
+                "cancel-in-progress": "false",
+            },
+        )
+        self.assertEqual(self.job["environment"], "mcp-search-index-live")
+        self.assertEqual(self.job["timeout-minutes"], "35")
+
+    def test_untrusted_contexts_cannot_enter_credentialed_job(self):
+        condition = self.job["if"]
+        self.assertIn("github.event_name == 'workflow_dispatch'", condition)
+        self.assertIn("github.repository_owner == 'microsoft'", condition)
+        self.assertIn("github.ref == 'refs/heads/main'", condition)
+        self.assertIn("inputs.confirmation == 'run-with-cleanup'", condition)
+        self.assertNotIn("pull_request", set(self.workflow["on"]))
+        self.assertNotIn("pull_request_target", set(self.workflow["on"]))
+
+    def test_preflight_precedes_login_and_names_required_configuration(self):
+        names = [step["name"] for step in self.job["steps"]]
+        self.assertLess(
+            names.index("Preflight protected configuration"),
+            names.index("Sign in to Azure with OIDC"),
+        )
+        preflight = self.steps["Preflight protected configuration"]
+        for name in (
+            "AZURE_CLIENT_ID",
+            "AZURE_TENANT_ID",
+            "AZURE_SUBSCRIPTION_ID",
+            "SEARCH_ENDPOINT",
+            "SEARCH_INDEX_NAME",
+            "SEARCH_SEMANTIC_CONFIGURATION_NAME",
+            "AZURE_OPENAI_ENDPOINT",
+            "AZURE_OPENAI_DEPLOYMENT_ID",
+            "AZURE_OPENAI_MODEL_NAME",
+            "LIVEKS_INDEX_QUERY",
+            "LIVEKS_INDEX_EXPECT_TERM",
+            "LIVEKS_COMBINED_QUERY",
+        ):
+            self.assertIn(name, preflight["env"])
+
+    def test_run_unique_environment_and_guarded_cleanup_only_lifecycle(self):
+        generated = self.job["env"]["LIVEKS_CANARY_ENVIRONMENT"]
+        self.assertIn("github.run_id", generated)
+        self.assertIn("github.run_attempt", generated)
+        lifecycle = self.steps["Run guarded lifecycle with cleanup"]
+        self.assertEqual(lifecycle["continue-on-error"], "true")
+        self.assertIn("ProtectedMcpSearchIndexLifecycleCanaryTests", lifecycle["run"])
+        self.assertNotIn("--keep-resources", self.text)
+        self.assertNotIn("profile: full", self.text)
+        self.assertNotIn("byo-fabric", self.text)
+
+    def test_cleanup_and_evidence_always_run_with_bounded_commands(self):
+        cleanup = self.steps["Always retry guarded cleanup"]
+        evidence = self.steps["Always build sanitized canary evidence"]
+        self.assertIn("always()", cleanup["if"])
+        self.assertIn("always()", evidence["if"])
+        self.assertIn("timeout --signal=INT", cleanup["run"])
+        self.assertIn("--yes", cleanup["run"])
+        self.assertIn("canary-cleanup.json", cleanup["run"])
+        self.assertIn("--kill-after=30s 1200s", self.steps["Run guarded lifecycle with cleanup"]["run"])
+
+    def test_only_sanitized_capsule_is_uploaded(self):
+        upload = self.steps["Upload sanitized canary capsule"]
+        self.assertEqual(upload["with"]["path"], ".deployment/canary-evidence.json")
+        self.assertNotIn("canary-detail.json", upload["with"]["path"])
+        self.assertNotIn("deployments/", upload["with"]["path"])
+        self.assertNotIn("e2e-report", upload["with"]["path"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retry_runtime.py
+++ b/tests/test_retry_runtime.py
@@ -1,0 +1,252 @@
+import io
+import json
+import socket
+import sys
+import unittest
+import urllib.error
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from liveks import runtime  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, payload=None, *, status=200, content_type="application/json"):
+        self.status = status
+        self.headers = {"Content-Type": content_type}
+        self.payload = payload if payload is not None else {"ok": True}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def http_error(status, *, retry_after=None):
+    headers = {}
+    if retry_after is not None:
+        headers["Retry-After"] = str(retry_after)
+    return urllib.error.HTTPError(
+        "https://private-search.example/secret",
+        status,
+        "error",
+        headers,
+        io.BytesIO(b'{"error":"private response"}'),
+    )
+
+
+class RetryClassificationTests(unittest.TestCase):
+    def test_required_http_statuses_are_retryable(self):
+        for status in (408, 429, 500, 502, 503, 504):
+            with self.subTest(status=status):
+                classification = runtime.classify_retry(status_code=status)
+                self.assertTrue(classification.retryable)
+                self.assertEqual(classification.category, f"http-{status}")
+
+    def test_deterministic_http_failures_are_not_retryable(self):
+        for status in (400, 401, 403, 404, 409, 412, 422):
+            with self.subTest(status=status):
+                self.assertFalse(runtime.classify_retry(status_code=status).retryable)
+
+    def test_only_explicit_read_or_conditional_write_modes_retry(self):
+        self.assertTrue(runtime.retry_is_semantically_safe("GET", "auto"))
+        self.assertFalse(runtime.retry_is_semantically_safe("POST", "auto"))
+        self.assertTrue(runtime.retry_is_semantically_safe("POST", "read"))
+        self.assertFalse(runtime.retry_is_semantically_safe("PUT", "conditional-write"))
+        self.assertTrue(
+            runtime.retry_is_semantically_safe(
+                "PUT",
+                "conditional-write",
+                {"If-None-Match": "*"},
+            )
+        )
+        self.assertTrue(
+            runtime.retry_is_semantically_safe(
+                "DELETE",
+                "conditional-write",
+                {"If-Match": "etag"},
+            )
+        )
+
+    def test_retry_after_seconds_and_http_date_are_capped(self):
+        self.assertEqual(
+            runtime.retry_after_seconds(
+                {"Retry-After": "120"},
+                cap_seconds=30,
+            ),
+            30,
+        )
+        now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        retry_at = format_datetime(now + timedelta(seconds=9), usegmt=True)
+        self.assertEqual(
+            runtime.retry_after_seconds(
+                {"Retry-After": retry_at},
+                cap_seconds=30,
+                now=now,
+            ),
+            9,
+        )
+        self.assertIsNone(
+            runtime.retry_after_seconds(
+                {"Retry-After": "not-valid"},
+                cap_seconds=30,
+            )
+        )
+
+    def test_exponential_backoff_has_a_hard_cap(self):
+        policy = runtime.RetryPolicy(
+            max_attempts=6,
+            base_delay_seconds=2,
+            max_delay_seconds=5,
+            retry_after_cap_seconds=30,
+        )
+        self.assertEqual(
+            [runtime.retry_delay_seconds(index, None, policy) for index in range(4)],
+            [2, 4, 5, 5],
+        )
+
+
+class RetryExecutionTests(unittest.TestCase):
+    def setUp(self):
+        runtime.reset_retry_telemetry()
+
+    def test_get_respects_retry_after_then_records_recovery(self):
+        first = http_error(429, retry_after=3)
+        with (
+            mock.patch.object(runtime.urllib.request, "urlopen", side_effect=[first, FakeResponse()]) as urlopen,
+            mock.patch.object(runtime.time, "sleep") as sleep,
+        ):
+            status, payload = runtime.http_json(
+                "https://private-search.example",
+                attempts=3,
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload, {"ok": True})
+        self.assertEqual(urlopen.call_count, 2)
+        sleep.assert_called_once_with(3)
+        self.assertEqual(
+            runtime.retry_telemetry_summary(),
+            {
+                "retryCount": 1,
+                "recoveredCount": 1,
+                "categoryCounts": {"http-429": 1},
+                "terminalCategories": {},
+            },
+        )
+
+    def test_deterministic_4xx_is_returned_without_retry(self):
+        failure = http_error(403)
+        with (
+            mock.patch.object(runtime.urllib.request, "urlopen", side_effect=failure) as urlopen,
+            mock.patch.object(runtime.time, "sleep") as sleep,
+        ):
+            status, payload = runtime.http_json(
+                "https://private-search.example",
+                attempts=4,
+            )
+
+        self.assertEqual(status, 403)
+        self.assertEqual(payload, {"error": "private response"})
+        self.assertEqual(urlopen.call_count, 1)
+        sleep.assert_not_called()
+        self.assertEqual(runtime.retry_telemetry_summary()["retryCount"], 0)
+
+    def test_unsafe_post_is_not_retried(self):
+        failure = http_error(503)
+        with (
+            mock.patch.object(runtime.urllib.request, "urlopen", side_effect=failure) as urlopen,
+            mock.patch.object(runtime.time, "sleep") as sleep,
+        ):
+            status, _ = runtime.http_json(
+                "https://private-search.example",
+                method="POST",
+                body={"private": "payload"},
+                attempts=4,
+            )
+
+        self.assertEqual(status, 503)
+        self.assertEqual(urlopen.call_count, 1)
+        sleep.assert_not_called()
+        self.assertEqual(
+            runtime.retry_telemetry_summary()["terminalCategories"],
+            {"http-503-unsafe-not-retried": 1},
+        )
+
+    def test_conditional_delete_can_retry(self):
+        first = http_error(500)
+        with (
+            mock.patch.object(runtime.urllib.request, "urlopen", side_effect=[first, FakeResponse()]) as urlopen,
+            mock.patch.object(runtime.time, "sleep"),
+        ):
+            status, _ = runtime.http_json(
+                "https://private-search.example",
+                method="DELETE",
+                headers={"If-Match": "etag"},
+                attempts=3,
+                retry_mode="conditional-write",
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(urlopen.call_count, 2)
+
+    def test_timeout_retries_are_bounded_and_terminal_message_is_redacted(self):
+        timeout = urllib.error.URLError(socket.timeout("private timeout"))
+        policy = runtime.RetryPolicy(
+            max_attempts=3,
+            base_delay_seconds=0,
+            max_delay_seconds=0,
+        )
+        with (
+            mock.patch.object(runtime.urllib.request, "urlopen", side_effect=timeout) as urlopen,
+            mock.patch.object(runtime.time, "sleep") as sleep,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "network-timeout after 3 attempt"):
+                runtime.http_json(
+                    "https://private-search.example/secret",
+                    attempts=25,
+                    retry_policy=policy,
+                )
+
+        self.assertEqual(urlopen.call_count, 3)
+        self.assertEqual(sleep.call_count, 2)
+        summary = runtime.retry_telemetry_summary()
+        self.assertEqual(summary["retryCount"], 2)
+        self.assertEqual(
+            summary["terminalCategories"],
+            {"network-timeout-exhausted": 1},
+        )
+
+    def test_native_mcp_retry_requires_explicit_read_mode(self):
+        first = http_error(502)
+        response = FakeResponse(
+            {"jsonrpc": "2.0", "id": 1, "result": {"tools": []}},
+        )
+        with (
+            mock.patch.object(runtime.urllib.request, "urlopen", side_effect=[first, response]) as urlopen,
+            mock.patch.object(runtime.time, "sleep"),
+        ):
+            status, payload = runtime.http_mcp_json(
+                "https://private-search.example/mcp",
+                body={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+                attempts=3,
+                retry_mode="read",
+            )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["result"]["tools"], [])
+        self.assertEqual(urlopen.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Extends the existing protected MCP + Search Index retrieve contract into a manually dispatched lifecycle canary. The protected job is restricted to the Microsoft repository `main` ref and the `mcp-search-index-live` GitHub Environment, validates required configuration before OIDC login, derives one environment per run, runs the guarded `e2e --cleanup --yes` path, and performs always-run lock/ETag cleanup and sanitized evidence generation.

Adds bounded retry classification for network timeouts and HTTP 408/429/500/502/503/504. Retry-After is capped, backoff is bounded, deterministic failures are not retried, and writes require explicit conditional idempotency. Only an allowlist capsule is uploaded; detailed reports remain runner-local.

## Change Type

- [x] Documentation
- [ ] REST sample / payload shape
- [ ] Notebook
- [x] Script or deployment automation
- [ ] Demo app
- [x] Test or validation evidence
- [x] Other

## Deployment Mode Impact

- [ ] `search-index` (stable existing-index path)
- [x] `mcp-search-index` (GA Search Index KS + preview MCP/KB path)
- [ ] `mcp-only`
- [ ] `byo-fabric`
- [ ] `full`
- [ ] No deployment-mode impact

## Validation

- [x] `bash scripts/validate-local.sh`
- [x] `git diff --check`
- [ ] GitHub Actions `Validate` workflow passes
- [ ] E2E report reviewed when deployment behavior changed
- [x] Generated reports remain local and ignored
- [ ] Not applicable; docs-only or metadata-only change

Executed without credentials or cloud mutation:

- Full unit suite: 147 passed, 2 protected live tests skipped.
- Focused retry/canary/workflow/profile suite: 68 passed, 2 protected live tests skipped.
- Offline replay JSON and offline doctor JSON: passed.
- Generated environment example check: passed.
- Strict MkDocs build: passed.
- Complete local validation, including Bicep and static app builds: passed.

```text
Protected read-only live contract: NOT RUN
Protected lifecycle canary: NOT RUN
Reason: this implementation task did not use an approved credentialed environment.
```

## API And Security Checklist

- [x] API version remains explicit and matches the stable or preview contract used by this change.
- [x] No secrets, bearer tokens, API keys, tenant-specific IDs, customer data, or private endpoint details were added.
- [x] Generated files remain under ignored paths such as `.deployment/`, `deployments/`, or `scratch/`.
- [x] Fabric live claims are backed by live Fabric activity or clearly described as offline replay.
- [x] MCP examples use remote HTTPS MCP servers, not local stdio servers.
- [x] Public-facing claims follow `docs/13-public-preview-limitations.md`.

## Reviewer Notes

Please review:

- manual-only trigger, `main`/owner condition, Environment gate, concurrency, and finite timeouts;
- preflight ordering before Azure login and missing-name-only diagnostics;
- actual `mcp-search-index` E2E cleanup path plus the second always-run cleanup;
- retry status classification, capped Retry-After, bounded backoff, and idempotency boundaries;
- evidence field allowlist, source/retry counts, ownership/cost classes, digest, and artifact upload path.

Official references:

- https://learn.microsoft.com/rest/api/searchservice/http-status-codes
- https://learn.microsoft.com/azure/search/agentic-retrieval-how-to-retrieve
- https://docs.github.com/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
- https://docs.github.com/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency

Residual live risk: repository validation proves contract shape only. An approved manual protected run is still required to prove real lifecycle, transient recovery, source evidence, and cleanup against the configured BYO Search and Azure OpenAI assets.
